### PR TITLE
haddock-library - small changes to allow building on ghc 7.4

### DIFF
--- a/haddock-library/src/Documentation/Haddock/Parser.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser.hs
@@ -342,11 +342,9 @@ takeNonEmptyLine = do
 
 -- | Blocks of text of the form:
 --
--- @
--- > foo
--- > bar
--- > baz
--- @
+-- >> foo
+-- >> bar
+-- >> baz
 --
 birdtracks :: Parser (DocH mod a)
 birdtracks = DocCodeBlock . DocString . intercalate "\n" . stripSpace <$> many1 line
@@ -409,7 +407,7 @@ property :: Parser (DocH mod a)
 property = DocProperty . strip . decodeUtf8 <$> ("prop>" *> takeWhile1 (/= '\n'))
 
 -- |
--- Paragraph level codeblock. Anything between the two delimiting @ is parsed
+-- Paragraph level codeblock. Anything between the two delimiting \@ is parsed
 -- for markup.
 codeblock :: Parser (DocH mod Identifier)
 codeblock =


### PR DESCRIPTION
The one-line use of LambdaCase was preventing the library from building on ghc 7.4. I try to support ghc 7.4 with pandoc, so I'd like haddock-library to build there too.  This pull request replaces the use of LambdaCase with a regular case statement, and fixes a couple of comments that were generating haddock warnings.
