### PR TITLE
Fix improper lazy IO use

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -456,7 +456,7 @@ getPrologue dflags flags =
     [filename] -> withFile filename ReadMode $ \h -> do
       hSetEncoding h utf8
       str <- hGetContents h
-      return . Just $ parseParas dflags str
+      return . Just $! parseParas dflags str
     _ -> throwE "multiple -p/--prologue options"
 
 


### PR DESCRIPTION
Make `getPrologue` force `parseParas dflags str` before returning. Without this, it will attempt to read from the file after it is closed, with unspecified and generally bad results.
