### PR TITLE
header could contain several lines

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -218,7 +218,7 @@ docWith :: Outputable o => DynFlags -> String -> Maybe (Doc o) -> [String]
 docWith _ [] Nothing = []
 docWith dflags header d
   = ("":) $ zipWith (++) ("-- | " : repeat "--   ") $
-    [header | header /= ""] ++ ["" | header /= "" && isJust d] ++
+    lines header ++ ["" | header /= "" && isJust d] ++
     maybe [] (showTags . markup (markupTag dflags)) d
 
 


### PR DESCRIPTION
If I have a project with a synopsis field in the cabal field that has more than one line (not recommended, but not an error from cabal check's point of view), then the generated hoogle file is incorrect, as the lines of the synopsis after the first one are not preceded by the comment symbol. This fix addresses that.
