### PR TITLE
Build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,18 @@ before_install:
  - sudo apt-get update
  - sudo apt-get install ghc-$GHCVER
  - export PATH=/opt/ghc/$GHCVER/bin:$PATH
+ - sudo apt-get install cabal-install-1.22
+ - export PATH=/opt/cabal/1.22/bin:$PATH
+ - cabal --version
  - cd haddock-library
  - cabal install --only-dependencies --enable-tests
  - cabal install doctest
- - cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test
+ # --ghc-options=-Werror
+ - cabal configure --enable-tests && cabal build && cabal test
  - doctest -isrc -i$(echo vendor/attoparsec-*) -optP-include -optPdist/build/autogen/cabal_macros.h src/Documentation/Haddock/Parser.hs
  - cabal install
  - cd ..
- - (cd haddock-api/ && cabal install --only-dependencies --enable-tests && cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test && cabal install)
+ - (cd haddock-api/ && cabal install --only-dependencies --enable-tests && cabal configure --enable-tests && cabal build && cabal test && cabal install)
 
 script:
- - cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test
+ - cabal configure --enable-tests && cabal build && cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,11 @@ before_install:
  - cd haddock-library
  - cabal install --only-dependencies --enable-tests
  - cabal install doctest
- # --ghc-options=-Werror
- - cabal configure --enable-tests && cabal build && cabal test
+ - cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test
  - doctest -isrc -i$(echo vendor/attoparsec-*) -optP-include -optPdist/build/autogen/cabal_macros.h src/Documentation/Haddock/Parser.hs
  - cabal install
  - cd ..
- - (cd haddock-api/ && cabal install --only-dependencies --enable-tests && cabal configure --enable-tests && cabal build && cabal test && cabal install)
+ - (cd haddock-api/ && cabal install --only-dependencies --enable-tests && cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test && cabal install)
 
 script:
- - cabal configure --enable-tests && cabal build && cabal test
+ - cabal configure --enable-tests --ghc-options=-Werror && cabal build && cabal test

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/AdvanceTypes.html
+++ b/html-test/ref/AdvanceTypes.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_AdvanceTypes.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/B.html
+++ b/html-test/ref/B.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_B.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bold.html
+++ b/html-test/ref/Bold.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bold.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug1.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug195.html
+++ b/html-test/ref/Bug195.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"
@@ -172,7 +172,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
     ><p
       >Produced by <a href=""
 	>Haddock</a
-	> version 2.15.0</p
+	> version 2.16.0</p
       ></div
     ></body
   ></html

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug2.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug201.html
+++ b/html-test/ref/Bug201.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug201.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug294.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug298.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug3.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug308.html
+++ b/html-test/ref/Bug308.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug308.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug308CrossModule.html
+++ b/html-test/ref/Bug308CrossModule.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug308CrossModule.html
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug313.html
+++ b/html-test/ref/Bug313.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug313.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug335.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug4.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"
@@ -98,7 +98,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	><p class="src"
 	  ><a name="v:-45--45--45--62-" class="def"
 	    >(---&gt;)</a
-	    > :: [a] -&gt; <a href=""
+	    > :: <a href=""
+	    >Foldable</a
+	    > t0 =&gt; t0 t -&gt; <a href=""
 	    >Typ</a
 	    > -&gt; <a href=""
 	    >Typ</a
@@ -132,7 +134,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
     ><p
       >Produced by <a href=""
 	>Haddock</a
-	> version 2.15.0</p
+	> version 2.16.0</p
       ></div
     ></body
   ></html

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"
@@ -128,7 +128,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
     ><p
       >Produced by <a href=""
 	>Haddock</a
-	> version 2.15.0</p
+	> version 2.16.0</p
       ></div
     ></body
   ></html

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugExportHeadings.html
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bugs.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/CrossPackageDocs.html
+++ b/html-test/ref/CrossPackageDocs.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_CrossPackageDocs.html"
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedClass.html")
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedData.html
+++ b/html-test/ref/DeprecatedData.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction.htm
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction2.ht
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction3.ht
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedModule.html"
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedModule2.html
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedNewtype.html
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedReExport.htm
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedRecord.html"
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeFamily.h
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"
@@ -98,7 +98,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeFamily.h
     ><p
       >Produced by <a href=""
 	>Haddock</a
-	> version 2.15.0</p
+	> version 2.16.0</p
       ></div
     ></body
   ></html

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeSynonym.
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Examples.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Extensions.html
+++ b/html-test/ref/Extensions.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Extensions.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ><tr
 	  ><th

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_FunArgs.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hyperlinks.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/IgnoreExports.html
+++ b/html-test/ref/IgnoreExports.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_IgnoreExports.html");}
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_ImplicitParams.html");
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_ModuleWithWarning.html
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/NamedDoc.html
+++ b/html-test/ref/NamedDoc.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_NamedDoc.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Nesting.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_NoLayout.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/NonGreedy.html
+++ b/html-test/ref/NonGreedy.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_NonGreedy.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Properties.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/PruneWithWarning.html
+++ b/html-test/ref/PruneWithWarning.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PruneWithWarning.html"
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_SpuriousSuperclassCons
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -65,7 +65,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Ticket253_1.html
+++ b/html-test/ref/Ticket253_1.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket253_1.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Ticket253_2.html
+++ b/html-test/ref/Ticket253_2.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket253_2.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket61.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket75.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TitledPicture.html");}
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeOperators.html");}
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Unicode.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -35,7 +35,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Visible.html");};
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >Safe-Inferred</td
+	    >Safe</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/src/Bug8.hs
+++ b/html-test/src/Bug8.hs
@@ -7,6 +7,7 @@ data Typ = Type (Typ,[Typ])
          | TFree (Typ, [Typ])
 
 x --> y = Type(s,[s,t])
+(--->) :: (Foldable t0) => t0 t -> Typ -> Typ
 (--->) = flip $ foldr (-->)
 
 s = undefined

--- a/latex-test/run.lhs
+++ b/latex-test/run.lhs
@@ -6,7 +6,7 @@ import Control.Monad
 import Control.Applicative
 import Data.List
 import Data.Maybe
-import Distribution.InstalledPackageInfo
+import Distribution.InstalledPackageInfo hiding (dataDir)
 import Distribution.Package (PackageName (..))
 import Distribution.Simple.Compiler
 import Distribution.Simple.GHC


### PR DESCRIPTION
The travis file now installs Cabal 1.22 and ignore the warnings. Also an ambiguity on dataDir has been solved. Note that the build still doesn't pass because the tests fail, but at least it compiles. The test seem to generate "Safe" instead of "Safe-inferred". I have no idea if this is normal in GHC 7.10. Please advise, and I can proceed fixing the tests.