### PR TITLE
Prevent Synopsis from using up too much horizontal space

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -318,6 +318,7 @@ div#style-menu-holder {
   height: 80%;
   top: 10%;
   padding: 0;
+  max-width: 75%;
 }
 
 #synopsis .caption {


### PR DESCRIPTION
When long type signatures occur in the Synopsis, the element is stretched beyond the width of the window.  Scrollbars don't appear, so it's impossible to read anything when this happens.