### PR TITLE
Change ModuleTree to fix #385

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -288,7 +288,7 @@ mkNodeList qual ss p ts = case ts of
 
 
 mkNode :: Qualification -> [String] -> String -> ModuleTree -> Html
-mkNode qual ss p (Node s leaf pkg short ts) =
+mkNode qual ss p (Node s leaf pkg srcPkg short ts) =
   htmlModule <+> shortDescr +++ htmlPkg +++ subtree
   where
     modAttrs = case (ts, leaf) of
@@ -312,7 +312,7 @@ mkNode qual ss p (Node s leaf pkg short ts) =
     mdl = intercalate "." (reverse (s:ss))
 
     shortDescr = maybe noHtml (origDocToHtml qual) short
-    htmlPkg = maybe noHtml (thespan ! [theclass "package"] <<) pkg
+    htmlPkg = maybe noHtml (thespan ! [theclass "package"] <<) srcPkg
 
     subtree = mkNodeList qual (s:ss) p ts ! collapseSection p True ""
 


### PR DESCRIPTION
This is a pretty mechanical addition of an extra parameter to `ModuleTree.Node` so that it carries both the `PackageKey` (required so that the call to `ppModule` in `mkNode` can find the entry in `html_xrefs`) and the `SourcePackageId` (required so that `htmlPkg` in `mkNode` refers to a nice package name). 