### PR TITLE
Do not insert anchor for section headings in contents box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 /doc/configure
 tags
 TAGS
+
+.cabal-sandbox
+cabal.sandbox.config

--- a/haddock-api/src/Haddock/Backends/Xhtml/DocMarkup.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/DocMarkup.hs
@@ -62,7 +62,10 @@ parHtmlMarkup qual insertAnchors ppId = Markup {
                                   then anchor ! [href url]
                                        << fromMaybe url mLabel
                                   else toHtml $ fromMaybe url mLabel,
-  markupAName                = \aname -> namedAnchor aname << "",
+  markupAName                = \aname
+                               -> if insertAnchors
+                                  then namedAnchor aname << ""
+                                  else noHtml,
   markupPic                  = \(Picture uri t) -> image ! ([src uri] ++ fromMaybe [] (return . title <$> t)),
   markupProperty             = pre . toHtml,
   markupExample              = examplesToHtml,

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >Bug387</title
+    ><link href="ocean.css" rel="stylesheet" type="text/css" title="Ocean"
+     /><script src="haddock-util.js" type="text/javascript"
+    ></script
+    ><script type="text/javascript"
+    >//<![CDATA[
+window.onload = function () {pageLoad();setSynopsis("mini_Bug387.html");};
+//]]>
+</script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href=""
+	  >Contents</a
+	  ></li
+	><li
+	><a href=""
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      >&nbsp;</p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug387</p
+	></div
+      ><div id="table-of-contents"
+      ><p class="caption"
+	>Contents</p
+	><ul
+	><li
+	  ><a href=""
+	    >Section1</a
+	    ></li
+	  ><li
+	  ><a href=""
+	    >Section2</a
+	    ></li
+	  ></ul
+	></div
+      ><div id="synopsis"
+      ><p id="control.syn" class="caption expander" onclick="toggleSection('syn')"
+	>Synopsis</p
+	><ul id="section.syn" class="hide" onclick="toggleSection('syn')"
+	><li class="src short"
+	  ><a href=""
+	    >test1</a
+	    > :: <a href=""
+	    >Int</a
+	    ></li
+	  ><li class="src short"
+	  ><a href=""
+	    >test2</a
+	    > :: <a href=""
+	    >Int</a
+	    ></li
+	  ></ul
+	></div
+      ><div id="interface"
+      ><h1 id="g:1"
+	>Section1<a name="a:section1"
+	  ></a
+	  ></h1
+	><div class="top"
+	><p class="src"
+	  ><a name="v:test1" class="def"
+	    >test1</a
+	    > :: <a href=""
+	    >Int</a
+	    ></p
+	  ></div
+	><h1 id="g:2"
+	>Section2<a name="a:section2"
+	  ></a
+	  ></h1
+	><div class="top"
+	><p class="src"
+	  ><a name="v:test2" class="def"
+	    >test2</a
+	    > :: <a href=""
+	    >Int</a
+	    ></p
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ><p
+      >Produced by <a href=""
+	>Haddock</a
+	> version 2.16.1</p
+      ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug387.hs
+++ b/html-test/src/Bug387.hs
@@ -1,0 +1,12 @@
+module Bug387
+  ( -- * Section1#a:section1#
+    test1
+    -- * Section2#a:section2#
+  , test2
+  ) where
+
+test1 :: Int
+test1 = 223
+
+test2 :: Int
+test2 = 42


### PR DESCRIPTION
Haddock used to insert anchor for section headings both in contexts box and the actual headings. This makes a link `#section1` jump to the element in contexts box instead of the actual heading, because they have duplicate anchor name. See test for more details. The diff of `Bug387.html` is:
```diff
45c45,47
< 	  >Section1</li
---
> 	  >Section1<a name="a:section1"
> 	      ></a
> 	    ></li
47c49,51
< 	  >Section2</li
---
> 	  >Section2<a name="a:section2"
> 	      ></a
> 	    ></li
```