### PR TITLE
Ignore doc/haddock.{ps,pdf}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /latex-test/out/
 
 /doc/haddock
+/doc/haddock.ps
+/doc/haddock.pdf
 /doc/autom4te.cache/
 /doc/config.log
 /doc/config.mk


### PR DESCRIPTION
These have frequently clogged up my workflow as arcanist insists that there be no unstaged changes (including untracked files) before creating a differential.