### PR TITLE
Needs GHC >= 7.4

### DIFF
--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -21,7 +21,7 @@ library
   default-language:     Haskell2010
 
   build-depends:
-      base >= 4.3 && < 4.9
+      base >= 4.5 && < 4.9
     , bytestring
     , transformers
     , deepseq


### PR DESCRIPTION
`Data.Monoid.<>` was added in base-4.5/GHC-7.4

I revised existing versions: http://hackage.haskell.org/package/haddock-library/revisions/

Build matrix: http://matrix.hackage.haskell.org/package/haddock-library#GHC-7.2/haddock-library-1.2.0