### PR TITLE
List nesting improvements (fixes #278)

### DIFF
--- a/haddock-library/src/Documentation/Haddock/Parser.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser.hs
@@ -382,6 +382,15 @@ takeNonEmptyLine :: Parser String
 takeNonEmptyLine = do
     (++ "\n") . decodeUtf8 <$> (takeWhile1 (/= '\n') >>= nonSpace) <* "\n"
 
+-- | Takes indentation of first non-empty line.
+--
+-- More precisely: skips all whitespace-only lines and returns indentation
+-- (horizontal space, might be empty) of that non-empty line.
+takeIndent :: Parser BS.ByteString
+takeIndent = do
+  indent <- takeHorizontalSpace
+  "\n" *> takeIndent <|> return indent
+
 -- | Blocks of text of the form:
 --
 -- >> foo

--- a/haddock-library/test/Documentation/Haddock/ParserSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/ParserSpec.hs
@@ -696,6 +696,23 @@ spec = do
                            ]
           <> DocOrderedList [ DocParagraph "baz" ]
 
+      it "allows arbitrary initial indent of a list" $ do
+        unlines
+          [ "     * foo"
+          , "     * bar"
+          , ""
+          , "         * quux"
+          , ""
+          , "     * baz"
+          ]
+        `shouldParseTo`
+        DocUnorderedList
+          [ DocParagraph "foo"
+          , DocParagraph "bar"
+            <> DocUnorderedList [ DocParagraph "quux" ]
+          , DocParagraph "baz"
+          ]
+
       it "definition lists can come back to top level with a different list" $ do
         "[foo]: foov\n\n    [bar]: barv\n\n1. baz" `shouldParseTo`
           DocDefList [ ("foo", "foov"

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -73,6 +73,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Nesting.html");};
 	  ><a href=""
 	    >j</a
 	    > :: t</li
+	  ><li class="src short"
+	  ><a href=""
+	    >k</a
+	    > :: t</li
 	  ></ul
 	></div
       ><div id="interface"
@@ -285,16 +289,16 @@ with more of the indented list content.</p
 			  ><dd
 			  >No newline separation even in indented lists.
         We can have any paragraph level element that we normally
-        can, like headers<h3
-			    >Level 3 header</h3
-			    ><p
-			    >with some content&#8230;</p
-			    ><ul
-			    ><li
-			      >and even more lists inside</li
-			      ></ul
-			    ></dd
+        can, like headers</dd
 			  ></dl
+			><h3
+			>Level 3 header</h3
+			><p
+			>with some content&#8230;</p
+			><ul
+			><li
+			  >and even more lists inside</li
+			  ></ul
 			></li
 		      ></ol
 		    ></li
@@ -303,13 +307,38 @@ with more of the indented list content.</p
 	      ></dl
 	    ></div
 	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a name="v:k" class="def"
+	    >k</a
+	    > :: t</p
+	  ><div class="doc"
+	  ><ul
+	    ><li
+	      >list may start at arbitrary depth</li
+	      ><li
+	      >and consecutive items at that depth
+      belong to the same list</li
+	      ><li
+	      ><p
+		>of course we can still</p
+		><ul
+		><li
+		  >nest items like we are used to</li
+		  ></ul
+		></li
+	      ><li
+	      >and then get back to initial list</li
+	      ></ul
+	    ></div
+	  ></div
 	></div
       ></div
     ><div id="footer"
     ><p
       >Produced by <a href=""
 	>Haddock</a
-	> version 2.15.0</p
+	> version 2.16.1</p
       ></div
     ></body
   ></html

--- a/html-test/src/Nesting.hs
+++ b/html-test/src/Nesting.hs
@@ -119,3 +119,18 @@ definition lists too.
 -}
 j :: t
 j = undefined
+
+{-|
+      - list may start at arbitrary depth
+
+      - and consecutive items at that depth
+      belong to the same list
+
+      - of course we can still
+
+          * nest items like we are used to
+
+      - and then get back to initial list
+-}
+k :: t
+k = undefined


### PR DESCRIPTION
It hopefully fixes #278, although there may be some corner cases I haven't thought about. It also slightly changed (fixed?) behaviour in case `k` of `Nesting.hs` test module. Before, *level 3 header* was parsed as a child of the *[c]* item. But they are separated by an empty line so the header should be just the element of paragraph, not a child of a list. I might be wrong of course, but then it would be erratic with the way the example item is treated couple lines above.