### PR TITLE
Fix alignment of Source links in instance table in Firefox

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -416,6 +416,14 @@ div#style-menu-holder {
   margin-top: 0.8em;
 }
 
+.clearfix:after {
+  clear: both;
+  content: " ";
+  display: block;
+  height: 0;
+  visibility: hidden;
+}
+
 .subs dl {
   margin: 0;
 }
@@ -453,6 +461,11 @@ div#style-menu-holder {
 .inst, .inst li {
   list-style: none;
   margin-left: 1em;
+}
+
+/* Workaround for bug in Firefox (issue #384) */
+.inst-left {
+  float: left;
 }
 
 .top p.src {

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -154,8 +154,9 @@ subTableSrc _ _  _ [] = Nothing
 subTableSrc qual lnks splice decls = Just $ table << aboves (concatMap subRow decls)
   where
     subRow ((decl, mdoc, subs),L loc dn) =
-      (td ! [theclass "src"] << decl
-      <+> linkHtml loc dn
+      (td ! [theclass "src clearfix"] <<
+        (thespan ! [theclass "inst-left"] << decl)
+        <+> linkHtml loc dn
       <->
       docElement td << fmap (docToHtml Nothing qual) mdoc
       )


### PR DESCRIPTION
Due to a [Firefox bug][1], a combination of 'whitespace: nowrap' on the parent element with 'float: right' on the inner element can cause the floated element to be displaced downwards for no apparent reason.

To work around this, the left side is wrapped in its own <span> and set to 'float: left'.  As a precautionary measure to prevent the parent element from collapsing entirely, we also add the classic "clearfix"
hack.  The latter is not strictly needed but it helps prevent bugs if the layout is altered again in the future.

Fixes #384.

*Remark:* line 159 of `src/Haddock/Backends/Xhtml/Layout.hs` was indented to prevent confusion over the operator precedence of `(<+>)` vs `(<<)`.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=488725