### PR TITLE
Avoid JavaScript error during page load in non-frame mode

### DIFF
--- a/haddock-api/resources/html/haddock-util.js
+++ b/haddock-api/resources/html/haddock-util.js
@@ -229,7 +229,7 @@ function perform_search(full)
 }
 
 function setSynopsis(filename) {
-    if (parent.window.synopsis) {
+    if (parent.window.synopsis && parent.window.synopsis.location) {
         if (parent.window.synopsis.location.replace) {
             // In Firefox this avoids adding the change to the history.
             parent.window.synopsis.location.replace(filename);


### PR DESCRIPTION
In non-frame mode, `parent.window.synopsis` refers to the `synopsis` div rather than the nonexistent frame.  Unfortunately, the script wrongly assumes that if it exists it must be a frame, leading to an error where it tries to access the nonexistent attribute `replace` of an undefined value (`synopsis.location`).

This might be related to #374.