### PR TITLE
StrictData: add support for lazyness marks

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -823,8 +823,11 @@ pp_hs_context cxt unicode = parenList (map (ppType unicode) cxt)
 
 
 ppBang :: HsBang -> LaTeX
-ppBang HsNoBang = empty
-ppBang _        = char '!' -- Unpacked args is an implementation detail,
+ppBang HsStrict                     = char '!'
+ppBang (HsUnpack {})                = char '!'
+ppBang (HsSrcBang _ _ (Just True))  = char '!'
+ppBang (HsSrcBang _ _ (Just False)) = char '~'
+ppBang _                            = empty
 
 
 tupleParens :: HsTupleSort -> [LaTeX] -> LaTeX

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -769,9 +769,11 @@ ppDataHeader _ _ _ _ = error "ppDataHeader: illegal argument"
 
 
 ppBang :: HsBang -> Html
-ppBang HsNoBang = noHtml
-ppBang _        = toHtml "!" -- Unpacked args is an implementation detail,
-                             -- so we just show the strictness annotation
+ppBang HsStrict                     = toHtml "!"
+ppBang (HsUnpack {})                = toHtml "!"
+ppBang (HsSrcBang _ _ (Just True))  = toHtml "!"
+ppBang (HsSrcBang _ _ (Just False)) = toHtml "~"
+ppBang _                            = noHtml
 
 
 tupleParens :: HsTupleSort -> [Html] -> Html

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -269,13 +269,13 @@ synifyDataCon use_gadt_syntax dc =
   linear_tys = zipWith (\ty bang ->
             let tySyn = synifyType WithinType ty
                 src_bang = case bang of
-                             HsUnpack {} -> HsSrcBang Nothing (Just True) True
-                             HsStrict    -> HsSrcBang Nothing (Just False) True
+                             HsUnpack {} -> HsSrcBang Nothing (Just True) (Just True)
+                             HsStrict    -> HsSrcBang Nothing (Just False) (Just True)
+                             HsLazy      -> HsSrcBang Nothing Nothing Nothing
                              _           -> bang
             in case src_bang of
-                 HsNoBang -> tySyn
+                 (HsSrcBang _ Nothing Nothing) -> tySyn
                  _        -> noLoc $ HsBangTy bang tySyn
-            -- HsNoBang never appears, it's implied instead.
           )
           arg_tys (dataConSrcBangs dc)
   field_tys = zipWith (\field synTy -> noLoc $ ConDeclField


### PR DESCRIPTION
This ones needs to be merged in order for https://phabricator.haskell.org/D1033 to be merged into GHC.