### PR TITLE
Line anchors for hyperlinked source

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -280,8 +280,13 @@ render dflags flags qual ifaces installedIfaces extSrcMap = do
       | otherwise = pkgSrcMap
 
     -- TODO: Get these from the interface files as with srcMap
-    srcLMap' = maybe Map.empty (\path -> Map.singleton pkgKey path) srcLEntity
-    sourceUrls' = (srcBase, srcModule', pkgSrcMap', srcLMap')
+    pkgSrcLMap'
+      | Flag_HyperlinkedSource `elem` flags =
+          Map.singleton pkgKey hypSrcModuleLineUrlFormat
+      | Just path <- srcLEntity = Map.singleton pkgKey path
+      | otherwise = Map.empty
+
+    sourceUrls' = (srcBase, srcModule', pkgSrcMap', pkgSrcLMap')
 
   libDir   <- getHaddockLibDir flags
   prologue <- getPrologue dflags flags

--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Utils.hs
@@ -1,7 +1,11 @@
 module Haddock.Backends.Hyperlinker.Utils
     ( hypSrcDir, hypSrcModuleFile, hypSrcModuleFile'
-    , hypSrcModuleUrl, hypSrcModuleUrl', hypSrcNameUrl, hypSrcModuleNameUrl
-    , hypSrcModuleUrlFormat, hypSrcModuleNameUrlFormat,
+    , hypSrcModuleUrl, hypSrcModuleUrl'
+    , hypSrcNameUrl
+    , hypSrcLineUrl
+    , hypSrcModuleNameUrl, hypSrcModuleLineUrl
+    , hypSrcModuleUrlFormat
+    , hypSrcModuleNameUrlFormat, hypSrcModuleLineUrlFormat
     ) where
 
 
@@ -31,8 +35,15 @@ hypSrcNameUrl :: Name -> String
 hypSrcNameUrl name = spliceURL
     Nothing Nothing (Just name) Nothing nameFormat
 
+hypSrcLineUrl :: SrcSpan -> String
+hypSrcLineUrl spn = spliceURL
+    Nothing Nothing Nothing (Just spn) lineFormat
+
 hypSrcModuleNameUrl :: Module -> Name -> String
 hypSrcModuleNameUrl mdl name = hypSrcModuleUrl mdl ++ "#" ++ hypSrcNameUrl name
+
+hypSrcModuleLineUrl :: Module -> SrcSpan -> String
+hypSrcModuleLineUrl mdl spn = hypSrcModuleUrl mdl ++ "#" ++ hypSrcLineUrl spn
 
 hypSrcModuleUrlFormat :: String
 hypSrcModuleUrlFormat = hypSrcDir </> moduleFormat
@@ -40,8 +51,14 @@ hypSrcModuleUrlFormat = hypSrcDir </> moduleFormat
 hypSrcModuleNameUrlFormat :: String
 hypSrcModuleNameUrlFormat = hypSrcModuleUrlFormat ++ "#" ++ nameFormat
 
+hypSrcModuleLineUrlFormat :: String
+hypSrcModuleLineUrlFormat = hypSrcModuleUrlFormat ++ "#" ++ lineFormat
+
 moduleFormat :: String
 moduleFormat = "%{MODULE}.html"
 
 nameFormat :: String
 nameFormat = "%{NAME}"
+
+lineFormat :: String
+lineFormat = "%{LINE}"

--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Utils.hs
@@ -12,6 +12,7 @@ module Haddock.Backends.Hyperlinker.Utils
 import Haddock.Backends.Xhtml.Utils
 
 import GHC
+import FastString
 import System.FilePath.Posix ((</>))
 
 
@@ -35,15 +36,18 @@ hypSrcNameUrl :: Name -> String
 hypSrcNameUrl name = spliceURL
     Nothing Nothing (Just name) Nothing nameFormat
 
-hypSrcLineUrl :: SrcSpan -> String
-hypSrcLineUrl spn = spliceURL
+hypSrcLineUrl :: Int -> String
+hypSrcLineUrl line = spliceURL
     Nothing Nothing Nothing (Just spn) lineFormat
+  where
+    loc = mkSrcLoc nilFS line 1
+    spn = mkSrcSpan loc loc
 
 hypSrcModuleNameUrl :: Module -> Name -> String
 hypSrcModuleNameUrl mdl name = hypSrcModuleUrl mdl ++ "#" ++ hypSrcNameUrl name
 
-hypSrcModuleLineUrl :: Module -> SrcSpan -> String
-hypSrcModuleLineUrl mdl spn = hypSrcModuleUrl mdl ++ "#" ++ hypSrcLineUrl spn
+hypSrcModuleLineUrl :: Module -> Int -> String
+hypSrcModuleLineUrl mdl line = hypSrcModuleUrl mdl ++ "#" ++ hypSrcLineUrl line
 
 hypSrcModuleUrlFormat :: String
 hypSrcModuleUrlFormat = hypSrcDir </> moduleFormat
@@ -61,4 +65,4 @@ nameFormat :: String
 nameFormat = "%{NAME}"
 
 lineFormat :: String
-lineFormat = "%{LINE}"
+lineFormat = "line-%{LINE}"

--- a/hypsrc-test/ref/src/Classes.html
+++ b/hypsrc-test/ref/src/Classes.html
@@ -9,22 +9,32 @@
   ><pre
     ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Classes</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-2"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
       ><span class="hs-keyword"
       >class</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Foo"
       ><a href="Classes.html#Foo"
@@ -32,7 +42,7 @@
 	  >Foo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -40,59 +50,67 @@
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-5"
+      ></a
+      ><span
+      >    </span
       ><a name="bar"
       ><a href="Classes.html#bar"
 	><span class="hs-identifier"
 	  >bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-6"
+      ></a
+      ><span
+      >    </span
       ><a name="baz"
       ><a href="Classes.html#baz"
 	><span class="hs-identifier"
 	  >baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -102,7 +120,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
@@ -110,53 +128,67 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-7"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-8"
+      ></a
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-9"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#bar"
 	><span class="hs-identifier"
 	  >bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >id</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-10"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#baz"
 	><span class="hs-identifier"
 	  >baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -164,11 +196,11 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -178,7 +210,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -186,19 +218,25 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-11"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-12"
+      ></a
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -208,45 +246,53 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-13"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#bar"
 	><span class="hs-identifier"
 	  >bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >length</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-14"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#baz"
 	><span class="hs-identifier"
 	  >baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >_</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -256,7 +302,7 @@
       >]</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -264,30 +310,40 @@
       >]</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-15"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-16"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-17"
+      ></a
       ><span class="hs-keyword"
       >class</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Foo%27"
       ><a href="Classes.html#Foo%27"
@@ -295,7 +351,7 @@
 	  >Foo'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -303,24 +359,28 @@
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-18"
+      ></a
+      ><span
+      >    </span
       ><a name="quux"
       ><a href="Classes.html#quux"
 	><span class="hs-identifier"
 	  >quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -330,7 +390,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
@@ -338,26 +398,30 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-19"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#quux"
 	><span class="hs-identifier"
 	  >quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -369,7 +433,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -379,17 +443,17 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#norf"
       ><span class="hs-identifier hs-var"
 	>norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -399,7 +463,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -407,21 +471,29 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
-
-    </span
+</span
+      ><a name="line-20"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-21"
+      ></a
+      ><span
+      >    </span
       ><a name="norf"
       ><a href="Classes.html#norf"
 	><span class="hs-identifier"
 	  >norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -431,117 +503,137 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-22"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#norf"
 	><span class="hs-identifier"
 	  >norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#quux"
       ><span class="hs-identifier hs-var"
 	>quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#baz"
       ><span class="hs-identifier hs-var"
 	>baz</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >sum</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >map</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#bar"
       ><span class="hs-identifier hs-var"
 	>bar</span
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-23"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-24"
+      ></a
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#Foo%27"
       ><span class="hs-identifier hs-type"
 	>Foo'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-25"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#norf"
 	><span class="hs-identifier"
 	  >norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >sum</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-26"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-27"
+      ></a
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#Foo%27"
       ><span class="hs-identifier hs-type"
 	>Foo'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -551,28 +643,32 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-28"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#quux"
 	><span class="hs-identifier"
 	  >quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >uncurry</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -580,14 +676,24 @@
       >++</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-29"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-30"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-31"
+      ></a
       ><span class="hs-keyword"
       >class</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Plugh"
       ><a href="Classes.html#Plugh"
@@ -595,7 +701,7 @@
 	  >Plugh</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -603,74 +709,78 @@
 	  >p</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-32"
+      ></a
+      ><span
+      >    </span
       ><a name="plugh"
       ><a href="Classes.html#plugh"
 	><span class="hs-identifier"
 	  >plugh</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>b</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>b</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -678,11 +788,11 @@
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
@@ -690,7 +800,7 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -698,11 +808,11 @@
       ><span class="hs-identifier hs-type"
 	>b</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
@@ -710,42 +820,52 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-33"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-34"
+      ></a
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Classes.html#Plugh"
       ><span class="hs-identifier hs-type"
 	>Plugh</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Either</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-35"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="Classes.html#plugh"
 	><span class="hs-identifier"
 	  >plugh</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
       ><span class="hs-identifier hs-var"
       >Left</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -755,176 +875,190 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >_</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >Right</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >$</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >const</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
-      >
-    </span
-      ><span class="hs-identifier"
-      >plugh</span
-      ><span class=""
-      > </span
-      ><span class="hs-special"
-      >(</span
-      ><span class="hs-identifier hs-var"
-      >Right</span
-      ><span class=""
-      > </span
-      ><a name="local-0"
-      ><a href="#local-0"
-	><span class="hs-identifier"
-	  >a</span
-	  ></a
-	></a
-      ><span class="hs-special"
-      >)</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier"
-      >_</span
-      ><span class=""
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier hs-var"
-      >Right</span
-      ><span class=""
-      > </span
-      ><span class="hs-operator hs-var"
-      >$</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier hs-var"
-      >const</span
-      ><span class=""
-      > </span
-      ><a href="#local-0"
-      ><span class="hs-identifier hs-var"
-	>a</span
-	></a
-      ><span class=""
-      >
-    </span
-      ><span class="hs-identifier"
-      >plugh</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier"
-      >_</span
-      ><span class=""
-      > </span
-      ><span class="hs-special"
-      >(</span
-      ><span class="hs-identifier hs-var"
-      >Left</span
-      ><span class=""
-      > </span
-      ><a name="local-0"
-      ><a href="#local-0"
-	><span class="hs-identifier"
-	  >b</span
-	  ></a
-	></a
-      ><span class="hs-special"
-      >)</span
-      ><span class=""
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier hs-var"
-      >Left</span
-      ><span class=""
-      > </span
-      ><span class="hs-operator hs-var"
-      >$</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier hs-var"
-      >const</span
-      ><span class=""
-      > </span
-      ><a href="#local-0"
-      ><span class="hs-identifier hs-var"
-	>b</span
-	></a
-      ><span class=""
-      >
-    </span
-      ><span class="hs-identifier"
-      >plugh</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier"
-      >_</span
-      ><span class=""
-      > </span
-      ><span class="hs-special"
-      >(</span
-      ><span class="hs-identifier hs-var"
-      >Right</span
-      ><span class=""
-      > </span
-      ><a name="local-0"
-      ><a href="#local-0"
-	><span class="hs-identifier"
-	  >b</span
-	  ></a
-	></a
-      ><span class="hs-special"
-      >)</span
-      ><span class=""
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier hs-var"
-      >Left</span
-      ><span class=""
-      > </span
-      ><span class="hs-operator hs-var"
-      >$</span
-      ><span class=""
-      > </span
-      ><span class="hs-identifier hs-var"
-      >const</span
-      ><span class=""
-      > </span
-      ><a href="#local-0"
-      ><span class="hs-identifier hs-var"
-	>b</span
-	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-36"
+      ></a
+      ><span
+      >    </span
+      ><span class="hs-identifier"
+      >plugh</span
+      ><span
+      > </span
+      ><span class="hs-special"
+      >(</span
+      ><span class="hs-identifier hs-var"
+      >Right</span
+      ><span
+      > </span
+      ><a name="local-0"
+      ><a href="#local-0"
+	><span class="hs-identifier"
+	  >a</span
+	  ></a
+	></a
+      ><span class="hs-special"
+      >)</span
+      ><span
+      > </span
+      ><span class="hs-identifier"
+      >_</span
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >=</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-var"
+      >Right</span
+      ><span
+      > </span
+      ><span class="hs-operator hs-var"
+      >$</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-var"
+      >const</span
+      ><span
+      > </span
+      ><a href="#local-0"
+      ><span class="hs-identifier hs-var"
+	>a</span
+	></a
+      ><span
+      >
+</span
+      ><a name="line-37"
+      ></a
+      ><span
+      >    </span
+      ><span class="hs-identifier"
+      >plugh</span
+      ><span
+      > </span
+      ><span class="hs-identifier"
+      >_</span
+      ><span
+      > </span
+      ><span class="hs-special"
+      >(</span
+      ><span class="hs-identifier hs-var"
+      >Left</span
+      ><span
+      > </span
+      ><a name="local-0"
+      ><a href="#local-0"
+	><span class="hs-identifier"
+	  >b</span
+	  ></a
+	></a
+      ><span class="hs-special"
+      >)</span
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >=</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-var"
+      >Left</span
+      ><span
+      > </span
+      ><span class="hs-operator hs-var"
+      >$</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-var"
+      >const</span
+      ><span
+      > </span
+      ><a href="#local-0"
+      ><span class="hs-identifier hs-var"
+	>b</span
+	></a
+      ><span
+      >
+</span
+      ><a name="line-38"
+      ></a
+      ><span
+      >    </span
+      ><span class="hs-identifier"
+      >plugh</span
+      ><span
+      > </span
+      ><span class="hs-identifier"
+      >_</span
+      ><span
+      > </span
+      ><span class="hs-special"
+      >(</span
+      ><span class="hs-identifier hs-var"
+      >Right</span
+      ><span
+      > </span
+      ><a name="local-0"
+      ><a href="#local-0"
+	><span class="hs-identifier"
+	  >b</span
+	  ></a
+	></a
+      ><span class="hs-special"
+      >)</span
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >=</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-var"
+      >Left</span
+      ><span
+      > </span
+      ><span class="hs-operator hs-var"
+      >$</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-var"
+      >const</span
+      ><span
+      > </span
+      ><a href="#local-0"
+      ><span class="hs-identifier hs-var"
+	>b</span
+	></a
+      ><span
+      >
+</span
+      ><a name="line-39"
+      ></a
       ></pre
     ></body
   ></html

--- a/hypsrc-test/ref/src/Constructors.html
+++ b/hypsrc-test/ref/src/Constructors.html
@@ -9,22 +9,32 @@
   ><pre
     ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Constructors</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-2"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
       ><span class="hs-keyword"
       >data</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Foo"
       ><a href="Constructors.html#Foo"
@@ -32,12 +42,16 @@
 	  >Foo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-5"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Bar"
       ><a href="Constructors.html#Bar"
@@ -45,12 +59,16 @@
 	  >Bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-6"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Baz"
       ><a href="Constructors.html#Baz"
@@ -58,12 +76,16 @@
 	  >Baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-7"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Quux"
       ><a href="Constructors.html#Quux"
@@ -71,23 +93,29 @@
 	  >Quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-8"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-9"
+      ></a
       ><span class="hs-keyword"
       >newtype</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Norf"
       ><a href="Constructors.html#Norf"
@@ -95,11 +123,11 @@
 	  >Norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Norf"
       ><a href="Constructors.html#Norf"
@@ -107,7 +135,7 @@
 	  >Norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -117,7 +145,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -129,7 +157,7 @@
       >]</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Foo"
       ><span class="hs-identifier hs-type"
@@ -137,175 +165,207 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-10"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-11"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-12"
+      ></a
       ><span class="hs-identifier"
       >bar</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >baz</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >quux</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-13"
+      ></a
       ><a name="bar"
       ><a href="Constructors.html#bar"
 	><span class="hs-identifier"
 	  >bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Bar"
       ><span class="hs-identifier hs-var"
 	>Bar</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-14"
+      ></a
       ><a name="baz"
       ><a href="Constructors.html#baz"
 	><span class="hs-identifier"
 	  >baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Baz"
       ><span class="hs-identifier hs-var"
 	>Baz</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-15"
+      ></a
       ><a name="quux"
       ><a href="Constructors.html#quux"
 	><span class="hs-identifier"
 	  >quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Quux"
       ><span class="hs-identifier hs-var"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#quux"
       ><span class="hs-identifier hs-var"
 	>quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-16"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-17"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-18"
+      ></a
       ><span class="hs-identifier"
       >unfoo</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-19"
+      ></a
       ><a name="unfoo"
       ><a href="Constructors.html#unfoo"
 	><span class="hs-identifier"
 	  >unfoo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Bar"
       ><span class="hs-identifier hs-var"
 	>Bar</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-20"
+      ></a
       ><span class="hs-identifier"
       >unfoo</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Baz"
       ><span class="hs-identifier hs-var"
 	>Baz</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-21"
+      ></a
       ><span class="hs-identifier"
       >unfoo</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -313,7 +373,7 @@
       ><span class="hs-identifier hs-var"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -321,7 +381,7 @@
 	  >foo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -331,62 +391,72 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >42</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>n</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unfoo"
       ><span class="hs-identifier hs-var"
 	>unfoo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>foo</span
 	></a
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-22"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-23"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-24"
+      ></a
       ><span class="hs-identifier"
       >unnorf</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Norf"
       ><span class="hs-identifier hs-type"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -396,16 +466,18 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-25"
+      ></a
       ><a name="unnorf"
       ><a href="Constructors.html#unnorf"
 	><span class="hs-identifier"
 	  >unnorf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -413,7 +485,7 @@
       ><span class="hs-identifier hs-var"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -423,7 +495,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -433,7 +505,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Bar"
       ><span class="hs-identifier hs-var"
@@ -443,22 +515,24 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>xs</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-26"
+      ></a
       ><span class="hs-identifier"
       >unnorf</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -466,7 +540,7 @@
       ><span class="hs-identifier hs-var"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -476,7 +550,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -486,7 +560,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Baz"
       ><span class="hs-identifier hs-var"
@@ -496,72 +570,86 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >reverse</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>xs</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-27"
+      ></a
       ><span class="hs-identifier"
       >unnorf</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >_</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >undefined</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-28"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-29"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-30"
+      ></a
       ><span class="hs-identifier"
       >unnorf'</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#Norf"
       ><span class="hs-identifier hs-type"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-31"
+      ></a
       ><a name="unnorf%27"
       ><a href="Constructors.html#unnorf%27"
 	><span class="hs-identifier"
 	  >unnorf'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -577,7 +665,7 @@
       ><span class="hs-identifier hs-var"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -595,11 +683,11 @@
       ><span class="hs-identifier hs-var"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >_</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -611,13 +699,13 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >_</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -633,7 +721,7 @@
       ><span class="hs-identifier hs-var"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -641,7 +729,7 @@
 	  >f3</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >_</span
@@ -651,74 +739,86 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-32"
+      ></a
+      ><span
+      >    </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>n</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unfoo"
       ><span class="hs-identifier hs-var"
 	>unfoo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>f1</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>aux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>f3</span
 	></a
-      ><span class=""
+      ><span
       >
-  </span
+</span
+      ><a name="line-33"
+      ></a
+      ><span
+      >  </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-34"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >aux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -726,108 +826,114 @@
 	  >fx</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unfoo"
       ><span class="hs-identifier hs-var"
 	>unfoo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>f2</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unfoo"
       ><span class="hs-identifier hs-var"
 	>unfoo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>fx</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unfoo"
       ><span class="hs-identifier hs-var"
 	>unfoo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>f3</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-35"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >x'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >sum</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >map</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unfoo"
       ><span class="hs-identifier hs-var"
 	>unfoo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Constructors.html#unnorf"
       ><span class="hs-identifier hs-var"
 	>unnorf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >$</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-36"
+      ></a
       ></pre
     ></body
   ></html

--- a/hypsrc-test/ref/src/Identifiers.html
+++ b/hypsrc-test/ref/src/Identifiers.html
@@ -9,67 +9,79 @@
   ><pre
     ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Identifiers</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-2"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
       ><span class="hs-identifier"
       >foo</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >bar</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >baz</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-5"
+      ></a
       ><a name="foo"
       ><a href="Identifiers.html#foo"
 	><span class="hs-identifier"
 	  >foo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -77,7 +89,7 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -85,78 +97,80 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#bar"
       ><span class="hs-identifier hs-var"
 	>bar</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-6"
+      ></a
       ><a name="bar"
       ><a href="Identifiers.html#bar"
 	><span class="hs-identifier"
 	  >bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -164,7 +178,7 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -172,78 +186,80 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#baz"
       ><span class="hs-identifier hs-var"
 	>baz</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-7"
+      ></a
       ><a name="baz"
       ><a href="Identifiers.html#baz"
 	><span class="hs-identifier"
 	  >baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -251,7 +267,7 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -259,88 +275,96 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-8"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-9"
+      ></a
       ><span class="hs-identifier"
       >quux</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-10"
+      ></a
       ><a name="quux"
       ><a href="Identifiers.html#quux"
 	><span class="hs-identifier"
 	  >quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -348,17 +372,17 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#foo"
       ><span class="hs-identifier hs-var"
 	>foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -366,13 +390,13 @@
       ><span class="hs-identifier hs-var"
 	>bar</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -380,7 +404,7 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -388,13 +412,13 @@
       ><span class="hs-identifier hs-var"
 	>bar</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -402,54 +426,62 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-11"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-12"
+      ></a
       ><span class="hs-identifier"
       >norf</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-13"
+      ></a
       ><a name="norf"
       ><a href="Identifiers.html#norf"
 	><span class="hs-identifier"
 	  >norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -457,7 +489,7 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -465,7 +497,7 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -473,131 +505,147 @@
 	  >z</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-14"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >&lt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#quux"
       ><span class="hs-identifier hs-var"
 	>quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-15"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >&lt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#quux"
       ><span class="hs-identifier hs-var"
 	>quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-16"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>z</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >&lt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#quux"
       ><span class="hs-identifier hs-var"
 	>quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>z</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-17"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >otherwise</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#norf"
       ><span class="hs-identifier hs-var"
 	>norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -609,7 +657,7 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -621,7 +669,7 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -633,126 +681,150 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-18"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-19"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-20"
+      ></a
       ><span class="hs-identifier"
       >main</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >IO</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-21"
+      ></a
       ><a name="main"
       ><a href="Identifiers.html#main"
 	><span class="hs-identifier"
 	  >main</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >do</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-22"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-identifier hs-var"
       >putStrLn</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >show</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >$</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#foo"
       ><span class="hs-identifier hs-var"
 	>foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-23"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-identifier hs-var"
       >putStrLn</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >show</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >$</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#quux"
       ><span class="hs-identifier hs-var"
 	>quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>z</span
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-24"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-identifier hs-var"
       >putStrLn</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >.</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >show</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >$</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Identifiers.html#norf"
       ><span class="hs-identifier hs-var"
@@ -762,83 +834,101 @@
 	><span class="hs-identifier hs-var"
 	>norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>z</span
 	></a
-      ><span class=""
+      ><span
       >
-  </span
+</span
+      ><a name="line-25"
+      ></a
+      ><span
+      >  </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-26"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >10</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-27"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >20</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-28"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >z</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >30</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-29"
+      ></a
       ></pre
     ></body
   ></html

--- a/hypsrc-test/ref/src/Literals.html
+++ b/hypsrc-test/ref/src/Literals.html
@@ -9,183 +9,217 @@
   ><pre
     ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Literals</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-2"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
       ><span class="hs-identifier"
       >str</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >String</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-5"
+      ></a
       ><a name="str"
       ><a href="Literals.html#str"
 	><span class="hs-identifier"
 	  >str</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-string"
       >&quot;str literal&quot;</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-6"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-7"
+      ></a
       ><span class="hs-identifier"
       >num</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Num</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-8"
+      ></a
       ><a name="num"
       ><a href="Literals.html#num"
 	><span class="hs-identifier"
 	  >num</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >1</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >1010011</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >41231</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >12131</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-9"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-10"
+      ></a
       ><span class="hs-identifier"
       >frac</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Fractional</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-11"
+      ></a
       ><a name="frac"
       ><a href="Literals.html#frac"
 	><span class="hs-identifier"
 	  >frac</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >42.0000001</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-12"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-13"
+      ></a
       ><span class="hs-identifier"
       >list</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -207,20 +241,22 @@
       >]</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-14"
+      ></a
       ><a name="list"
       ><a href="Literals.html#list"
 	><span class="hs-identifier"
 	  >list</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -230,7 +266,7 @@
       >]</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -242,7 +278,7 @@
       >]</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -258,17 +294,23 @@
       >]</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-15"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-16"
+      ></a
       ><span class="hs-identifier"
       >pair</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -278,7 +320,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -288,7 +330,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -296,7 +338,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -306,7 +348,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -314,20 +356,22 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-17"
+      ></a
       ><a name="pair"
       ><a href="Literals.html#pair"
 	><span class="hs-identifier"
 	  >pair</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -337,7 +381,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -347,7 +391,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -355,7 +399,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -365,7 +409,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -373,9 +417,11 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-18"
+      ></a
       ></pre
     ></body
   ></html

--- a/hypsrc-test/ref/src/Operators.html
+++ b/hypsrc-test/ref/src/Operators.html
@@ -9,30 +9,40 @@
   ><pre
     ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Operators</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-2"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >+++</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -42,11 +52,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -56,11 +66,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -70,16 +80,18 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-5"
+      ></a
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="%2B%2B%2B"
       ><a href="Operators.html#%2B%2B%2B"
@@ -87,7 +99,7 @@
 	  >+++</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -95,51 +107,57 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >++</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>b</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >++</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-6"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-7"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >$$$</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -149,11 +167,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -163,11 +181,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -177,16 +195,18 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-8"
+      ></a
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="%24%24%24"
       ><a href="Operators.html#%24%24%24"
@@ -194,7 +214,7 @@
 	  >$$$</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -202,43 +222,49 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>b</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Operators.html#%2B%2B%2B"
       ><span class="hs-operator hs-var"
 	>+++</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-9"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-10"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >***</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -248,11 +274,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -262,11 +288,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -276,9 +302,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-11"
+      ></a
       ><span class="hs-special"
       >(</span
       ><a name="%2A%2A%2A"
@@ -289,7 +317,7 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -297,32 +325,34 @@
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-12"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >***</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -330,7 +360,7 @@
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -346,23 +376,23 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Operators.html#%2B%2B%2B"
       ><span class="hs-operator hs-var"
 	>+++</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -370,13 +400,13 @@
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Operators.html#%2A%2A%2A"
       ><span class="hs-operator hs-var"
 	>***</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -384,21 +414,27 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-13"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-14"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >*/\*</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -412,11 +448,11 @@
       >]</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -426,11 +462,11 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -440,16 +476,18 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-15"
+      ></a
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="%2A%2F%5C%2A"
       ><a href="Operators.html#%2A%2F%5C%2A"
@@ -457,7 +495,7 @@
 	  >*/\*</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -465,15 +503,15 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >concatMap</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -481,7 +519,7 @@
       ><span class="hs-operator hs-var"
 	>***</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -489,27 +527,33 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-16"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-17"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >**/\**</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -523,11 +567,11 @@
       >]</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -541,11 +585,11 @@
       >]</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -559,16 +603,18 @@
       >]</span
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-18"
+      ></a
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="%2A%2A%2F%5C%2A%2A"
       ><a href="Operators.html#%2A%2A%2F%5C%2A%2A"
@@ -576,7 +622,7 @@
 	  >**/\**</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -584,15 +630,15 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >zipWith</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -602,7 +648,7 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >[</span
@@ -610,13 +656,13 @@
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Operators.html#%2B%2B%2B"
       ><span class="hs-operator hs-var"
 	>+++</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -624,7 +670,7 @@
 	></a
       ><span class="hs-special"
       >]</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -632,13 +678,13 @@
       ><span class="hs-identifier hs-var"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Operators.html#%24%24%24"
       ><span class="hs-operator hs-var"
 	>$$$</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -646,42 +692,52 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-19"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-20"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-21"
+      ></a
       ><span class="hs-special"
       >(</span
       ><span class="hs-operator"
       >#.#</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>a</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
 	>b</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -689,11 +745,11 @@
       ><span class="hs-identifier hs-type"
 	>c</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -703,7 +759,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-type"
@@ -713,16 +769,18 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-22"
+      ></a
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="%23.%23"
       ><a href="Operators.html#%23.%23"
@@ -730,7 +788,7 @@
 	  >#.#</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -738,19 +796,19 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-var"
       >const</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >$</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -760,7 +818,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -768,9 +826,11 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-23"
+      ></a
       ></pre
     ></body
   ></html

--- a/hypsrc-test/ref/src/Records.html
+++ b/hypsrc-test/ref/src/Records.html
@@ -9,34 +9,56 @@
   ><pre
     ><span class="hs-pragma"
       >{-# LANGUAGE NamedFieldPuns #-}</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-2"
+      ></a
       ><span class="hs-pragma"
       >{-# LANGUAGE RecordWildCards #-}</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-5"
+      ></a
       ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Records</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-6"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-7"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-8"
+      ></a
       ><span class="hs-keyword"
       >data</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Point"
       ><a href="Records.html#Point"
@@ -44,11 +66,11 @@
 	  >Point</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Point"
       ><a href="Records.html#Point"
@@ -56,12 +78,16 @@
 	  >Point</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-9"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a name="x"
       ><a href="Records.html#x"
@@ -69,22 +95,26 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >!</span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-10"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a name="y"
       ><a href="Records.html#y"
@@ -92,64 +122,80 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >!</span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-11"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-special"
       >}</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-12"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-13"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-14"
+      ></a
       ><span class="hs-identifier"
       >point</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-15"
+      ></a
       ><a name="point"
       ><a href="Records.html#point"
 	><span class="hs-identifier"
 	  >point</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -157,7 +203,7 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -165,31 +211,31 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-var"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#x"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -197,61 +243,73 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#y"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >}</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-16"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-17"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-18"
+      ></a
       ><span class="hs-identifier"
       >lengthSqr</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-19"
+      ></a
       ><a name="lengthSqr"
       ><a href="Records.html#lengthSqr"
 	><span class="hs-identifier"
 	  >lengthSqr</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -259,21 +317,21 @@
       ><span class="hs-identifier hs-var"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#x"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -283,17 +341,17 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#y"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -301,86 +359,94 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >}</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-20"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-21"
+      ></a
       ><span class="hs-identifier"
       >lengthSqr'</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-22"
+      ></a
       ><a name="lengthSqr%27"
       ><a href="Records.html#lengthSqr%27"
 	><span class="hs-identifier"
 	  >lengthSqr'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -388,11 +454,11 @@
       ><span class="hs-identifier hs-var"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#x"
       ><span class="hs-identifier hs-var"
@@ -400,109 +466,121 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#y"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >}</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >*</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-23"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-24"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-25"
+      ></a
       ><span class="hs-identifier"
       >translateX</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >translateY</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-26"
+      ></a
       ><a name="translateX"
       ><a href="Records.html#translateX"
 	><span class="hs-identifier"
 	  >translateX</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -510,7 +588,7 @@
 	  >p</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -518,66 +596,68 @@
 	  >d</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#x"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#x"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>d</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >}</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-27"
+      ></a
       ><a name="translateY"
       ><a href="Records.html#translateY"
 	><span class="hs-identifier"
 	  >translateY</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -585,7 +665,7 @@
 	  >p</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -593,108 +673,116 @@
 	  >d</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#y"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#y"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>d</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >}</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-28"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-29"
+      ></a
       ><span class="hs-identifier"
       >translate</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-type"
 	>Point</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-30"
+      ></a
       ><a name="translate"
       ><a href="Records.html#translate"
 	><span class="hs-identifier"
 	  >translate</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -702,7 +790,7 @@
 	  >x</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -710,7 +798,7 @@
 	  >y</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -718,31 +806,43 @@
 	  >p</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-31"
+      ></a
+      ><span
+      >    </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>aux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       >
-  </span
+</span
+      ><a name="line-32"
+      ></a
+      ><span
+      >  </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-33"
+      ></a
+      ><span
+      >    </span
       ><span class="hs-special"
       >(</span
       ><a name="local-0"
@@ -753,7 +853,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -763,11 +863,11 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -777,7 +877,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -785,16 +885,20 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-    </span
+</span
+      ><a name="line-34"
+      ></a
+      ><span
+      >    </span
       ><a name="local-0"
       ><a href="#local-0"
 	><span class="hs-identifier"
 	  >aux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#Point"
       ><span class="hs-identifier hs-var"
@@ -806,41 +910,41 @@
       >..</span
       ><span class="hs-special"
       >}</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>p</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >{</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#x"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>x</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
@@ -848,39 +952,41 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Records.html#y"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>y</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-operator hs-var"
       >+</span
-      ><span class=""
+      ><span
       > </span
       ><a href="#local-0"
       ><span class="hs-identifier hs-var"
 	>dy</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >}</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-35"
+      ></a
       ></pre
     ></body
   ></html

--- a/hypsrc-test/ref/src/Types.html
+++ b/hypsrc-test/ref/src/Types.html
@@ -9,29 +9,49 @@
   ><pre
     ><span class="hs-pragma"
       >{-# LANGUAGE TypeFamilies #-}</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-2"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
       ><span class="hs-keyword"
       >module</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier"
       >Types</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >where</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-5"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-6"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-7"
+      ></a
       ><span class="hs-keyword"
       >data</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Quux"
       ><a href="Types.html#Quux"
@@ -39,11 +59,11 @@
 	  >Quux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Bar"
       ><a href="Types.html#Bar"
@@ -51,11 +71,11 @@
 	  >Bar</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >|</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Baz"
       ><a href="Types.html#Baz"
@@ -63,13 +83,19 @@
 	  >Baz</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-8"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-9"
+      ></a
       ><span class="hs-keyword"
       >newtype</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Foo"
       ><a href="Types.html#Foo"
@@ -77,11 +103,11 @@
 	  >Foo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Foo"
       ><a href="Types.html#Foo"
@@ -89,19 +115,25 @@
 	  >Foo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-10"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-11"
+      ></a
       ><span class="hs-keyword"
       >type</span
-      ><span class=""
+      ><span
       > </span
       ><a name="FooQuux"
       ><a href="Types.html#FooQuux"
@@ -109,11 +141,11 @@
 	  >FooQuux</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -123,7 +155,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
@@ -131,12 +163,14 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-12"
+      ></a
       ><span class="hs-keyword"
       >type</span
-      ><span class=""
+      ><span
       > </span
       ><a name="QuuxFoo"
       ><a href="Types.html#QuuxFoo"
@@ -144,11 +178,11 @@
 	  >QuuxFoo</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -158,7 +192,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
@@ -166,18 +200,28 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-13"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-14"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-15"
+      ></a
       ><span class="hs-keyword"
       >data</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >family</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Norf"
       ><a href="Types.html#Norf"
@@ -185,7 +229,7 @@
 	  >Norf</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -193,7 +237,7 @@
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -201,39 +245,45 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-16"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-17"
+      ></a
       ><span class="hs-keyword"
       >data</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf"
       ><span class="hs-identifier hs-type"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="NFQ"
       ><a href="Types.html#NFQ"
@@ -241,50 +291,52 @@
 	  >NFQ</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-18"
+      ></a
       ><span class="hs-keyword"
       >data</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf"
       ><span class="hs-identifier hs-type"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><a name="NQF"
       ><a href="Types.html#NQF"
@@ -292,30 +344,40 @@
 	  >NQF</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-19"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-20"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-21"
+      ></a
       ><span class="hs-keyword"
       >type</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >family</span
-      ><span class=""
+      ><span
       > </span
       ><a name="Norf%27"
       ><a href="Types.html#Norf%27"
@@ -323,7 +385,7 @@
 	  >Norf'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -331,7 +393,7 @@
 	  >a</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a name="local-0"
       ><a href="#local-0"
@@ -339,39 +401,45 @@
 	  >b</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-22"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-23"
+      ></a
       ><span class="hs-keyword"
       >type</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf%27"
       ><span class="hs-identifier hs-type"
 	>Norf'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -381,7 +449,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
@@ -389,38 +457,40 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-24"
+      ></a
       ><span class="hs-keyword"
       >type</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-keyword"
       >instance</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf%27"
       ><span class="hs-identifier hs-type"
 	>Norf'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -430,7 +500,7 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
@@ -438,53 +508,65 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-25"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-26"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-27"
+      ></a
       ><span class="hs-identifier"
       >norf1</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf"
       ><span class="hs-identifier hs-type"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-28"
+      ></a
       ><a name="norf1"
       ><a href="Types.html#norf1"
 	><span class="hs-identifier"
 	  >norf1</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -492,7 +574,7 @@
       ><span class="hs-identifier hs-var"
 	>NFQ</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -500,7 +582,7 @@
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -508,7 +590,7 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Bar"
       ><span class="hs-identifier hs-var"
@@ -516,20 +598,22 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-29"
+      ></a
       ><span class="hs-identifier"
       >norf1</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -537,7 +621,7 @@
       ><span class="hs-identifier hs-var"
 	>NFQ</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -545,7 +629,7 @@
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -553,7 +637,7 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Baz"
       ><span class="hs-identifier hs-var"
@@ -561,60 +645,68 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >1</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-30"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-31"
+      ></a
       ><span class="hs-identifier"
       >norf2</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf"
       ><span class="hs-identifier hs-type"
 	>Norf</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-32"
+      ></a
       ><a name="norf2"
       ><a href="Types.html#norf2"
 	><span class="hs-identifier"
 	  >norf2</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -622,13 +714,13 @@
       ><span class="hs-identifier hs-var"
 	>NQF</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Bar"
       ><span class="hs-identifier hs-var"
 	>Bar</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -636,7 +728,7 @@
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -646,20 +738,22 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-33"
+      ></a
       ><span class="hs-identifier"
       >norf2</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -667,13 +761,13 @@
       ><span class="hs-identifier hs-var"
 	>NQF</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Baz"
       ><span class="hs-identifier hs-var"
 	>Baz</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -681,7 +775,7 @@
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -691,61 +785,73 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >1</span
-      ><span class=""
+      ><span
       >
-
-
 </span
+      ><a name="line-34"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-35"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-36"
+      ></a
       ><span class="hs-identifier"
       >norf1'</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf%27"
       ><span class="hs-identifier hs-type"
 	>Norf'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-37"
+      ></a
       ><a name="norf1%27"
       ><a href="Types.html#norf1%27"
 	><span class="hs-identifier"
 	  >norf1'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -753,7 +859,7 @@
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -761,7 +867,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Bar"
       ><span class="hs-identifier hs-var"
@@ -769,20 +875,22 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-38"
+      ></a
       ><span class="hs-identifier"
       >norf1'</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -790,7 +898,7 @@
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -798,7 +906,7 @@
       >)</span
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Baz"
       ><span class="hs-identifier hs-var"
@@ -806,60 +914,68 @@
 	></a
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >1</span
-      ><span class=""
+      ><span
       >
-
 </span
+      ><a name="line-39"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-40"
+      ></a
       ><span class="hs-identifier"
       >norf2'</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >::</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Norf%27"
       ><span class="hs-identifier hs-type"
 	>Norf'</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Quux"
       ><span class="hs-identifier hs-type"
 	>Quux</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-type"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >-&gt;</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-identifier hs-type"
       >Int</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-41"
+      ></a
       ><a name="norf2%27"
       ><a href="Types.html#norf2%27"
 	><span class="hs-identifier"
 	  >norf2'</span
 	  ></a
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -869,13 +985,13 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -883,20 +999,22 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >0</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-42"
+      ></a
       ><span class="hs-identifier"
       >norf2'</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -906,13 +1024,13 @@
 	></a
       ><span class="hs-special"
       >,</span
-      ><span class=""
+      ><span
       > </span
       ><a href="Types.html#Foo"
       ><span class="hs-identifier hs-var"
 	>Foo</span
 	></a
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-special"
       >(</span
@@ -920,17 +1038,19 @@
       >)</span
       ><span class="hs-special"
       >)</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-glyph"
       >=</span
-      ><span class=""
+      ><span
       > </span
       ><span class="hs-number"
       >1</span
-      ><span class=""
+      ><span
       >
 </span
+      ><a name="line-43"
+      ></a
       ></pre
     ></body
   ></html


### PR DESCRIPTION
As @mpickering mentioned in #419, it would be nice to have line anchors in hyperlinked source. So, here they are.

Note that it does *not* solve #419 - documentation for instances still sometimes refers to the wrong line number. It is not bug in hyperlinker itself so this should be a subject for another PR (once I figure out what's wrong).