### PR TITLE
Break the response file by line termination

### DIFF
--- a/driver/Main.hs
+++ b/driver/Main.hs
@@ -20,7 +20,7 @@ expandResponse :: [String] -> IO [String]
 expandResponse = fmap concat . mapM expand
   where
     expand :: String -> IO [String]
-    expand ('@':f) = readFileExc f >>= return . filter (not . null) . words
+    expand ('@':f) = readFileExc f >>= return . filter (not . null) . lines
     expand x = return [x]
 
     readFileExc f =


### PR DESCRIPTION
Break the response file by line termination rather than
spaces, since spaces may be within the parameters.  This
simple approach avoids having the need for any quoting
and/or escaping (although a newline char will not be
possible in a parameter and has no escape mechanism to allow
it).

This is what was used to build HP 7.10.2 for Windows,
but it does need a corresponding change in cabal-install
to utilize it.  Hopefully, this and its corresponding cabal-install
change can make it into the next ghc release and eliminate
much gnashing of teeth, error prone, and time consuming
manual steps in the HP build process.