### PR TITLE
Support for typeclass specialization

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -69,6 +69,7 @@ library
     Haddock.Interface.AttachInstances
     Haddock.Interface.LexParseRn
     Haddock.Interface.ParseModuleHeader
+    Haddock.Interface.Specialize
     Haddock.Parser
     Haddock.Utils
     Haddock.Backends.Xhtml
@@ -76,7 +77,6 @@ library
     Haddock.Backends.Xhtml.DocMarkup
     Haddock.Backends.Xhtml.Layout
     Haddock.Backends.Xhtml.Names
-    Haddock.Backends.Xhtml.Specialize
     Haddock.Backends.Xhtml.Themes
     Haddock.Backends.Xhtml.Types
     Haddock.Backends.Xhtml.Utils

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -43,6 +43,7 @@ library
     , filepath
     , directory
     , containers
+    , transformers
     , deepseq
     , array
     , xhtml >= 3000.2 && < 3000.3

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -159,6 +159,8 @@ p.caption.expander {
 .instance.collapser, .instance.expander {
   margin-left: 0px;
   background-position: left center;
+  min-width: 9px;
+  min-height: 9px;
 }
 
 

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -146,15 +146,21 @@ ul.links li a {
   background-image: url(plus.gif);
   background-repeat: no-repeat;
 }
-p.caption.collapser,
-p.caption.expander {
-  background-position: 0 0.4em;
-}
 .collapser, .expander {
   padding-left: 14px;
   margin-left: -14px;
   cursor: pointer;
 }
+p.caption.collapser,
+p.caption.expander {
+  background-position: 0 0.4em;
+}
+
+.instance.collapser, .instance.expander {
+  margin-left: 0px;
+  background-position: left center;
+}
+
 
 pre {
   padding: 0.25em;

--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -562,7 +562,7 @@ ppInstDecl unicode instHead = keyword "instance" <+> ppInstHead unicode instHead
 
 ppInstHead :: Bool -> InstHead DocName -> LaTeX
 ppInstHead unicode (InstHead {..}) = case ihdInstType of
-    ClassInst ctx _ _ -> ppContextNoLocs ctx unicode <+> typ
+    ClassInst ctx _ _ _ -> ppContextNoLocs ctx unicode <+> typ
     TypeInst rhs -> keyword "type" <+> typ <+> tibody rhs
     DataInst _ -> error "data instances not supported by --latex yet"
   where

--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -562,7 +562,7 @@ ppInstDecl unicode instHead = keyword "instance" <+> ppInstHead unicode instHead
 
 ppInstHead :: Bool -> InstHead DocName -> LaTeX
 ppInstHead unicode (InstHead {..}) = case ihdInstType of
-    ClassInst ctx -> ppContextNoLocs ctx unicode <+> typ
+    ClassInst ctx _ _ -> ppContextNoLocs ctx unicode <+> typ
     TypeInst rhs -> keyword "type" <+> typ <+> tibody rhs
     DataInst _ -> error "data instances not supported by --latex yet"
   where

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -239,28 +239,31 @@ ppSimpleSig links splice unicode qual loc names typ =
 --------------------------------------------------------------------------------
 
 
+ppFamilyInfo :: Bool -> FamilyInfo DocName -> Html
+ppFamilyInfo assoc OpenTypeFamily
+    | assoc = keyword "type"
+    | otherwise = keyword "type family"
+ppFamilyInfo assoc DataFamily
+    | assoc = keyword "data"
+    | otherwise = keyword "data family"
+ppFamilyInfo _ (ClosedTypeFamily _) = keyword "type family"
+
+
+ppFamilyKind :: Unicode -> Qualification -> Maybe (LHsKind DocName) -> Html
+ppFamilyKind unicode qual (Just kind) =
+    dcolon unicode <+> ppLKind unicode qual kind
+ppFamilyKind _ _ Nothing = noHtml
+
+
 ppTyFamHeader :: Bool -> Bool -> FamilyDecl DocName
               -> Unicode -> Qualification -> Html
 ppTyFamHeader summary associated d@(FamilyDecl { fdInfo = info
                                                , fdKindSig = mkind })
               unicode qual =
-  (case info of
-     OpenTypeFamily
-       | associated -> keyword "type"
-       | otherwise  -> keyword "type family"
-     DataFamily
-       | associated -> keyword "data"
-       | otherwise  -> keyword "data family"
-     ClosedTypeFamily _
-                    -> keyword "type family"
-  ) <+>
+    ppFamilyInfo associated info <+>
+    ppFamDeclBinderWithVars summary d <+>
+    ppFamilyKind unicode qual mkind
 
-  ppFamDeclBinderWithVars summary d <+>
-
-  (case mkind of
-    Just kind -> dcolon unicode  <+> ppLKind unicode qual kind
-    Nothing   -> noHtml
-  )
 
 ppTyFam :: Bool -> Bool -> LinksInfo -> [DocInstance DocName] ->
            [(DocName, Fixity)] -> SrcSpan -> Documentation DocName ->

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -534,19 +534,6 @@ ppClassDecl summary links instances fixities loc d subdocs
 ppClassDecl _ _ _ _ _ _ _ _ _ _ _ = error "declaration type not supported by ppShortClassDecl"
 
 
-data InstOrigin name
-    = OriginClass name
-    | OriginData name
-    | OriginFamily name
-
-
-instance NamedThing name => NamedThing (InstOrigin name) where
-
-    getName (OriginClass name) = getName name
-    getName (OriginData name) = getName name
-    getName (OriginFamily name) = getName name
-
-
 ppInstances :: LinksInfo
             -> InstOrigin DocName -> [DocInstance DocName]
             -> Splice -> Unicode -> Qualification

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -31,6 +31,7 @@ import Haddock.Doc (combineDocumentation)
 
 import           Data.List             ( intersperse, sort )
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import           Data.Maybe
 import           Text.XHtml hiding     ( name, title, p, quote )
 
@@ -540,9 +541,12 @@ ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification
 ppInstanceSigs links splice unicode qual (InstSpec {..}) (InstHead {..}) = do
     TypeSig lnames (L sspan typ) _ <- ispecSigs
     let names = map unLoc lnames
-    let typ' = sugar $ specializeTyVarBndrs ispecTyVars ihdTypes typ
+    let typ' = rename' . sugar $ specializeTyVarBndrs ispecTyVars ihdTypes typ
     return $ ppFunSig False links sspan noDocForDecl names typ' []
         splice unicode qual
+  where
+    fv = foldr Set.union Set.empty . map freeVariables $ ihdTypes
+    rename' = rename fv
 
 
 lookupAnySubdoc :: Eq id1 => id1 -> [(id1, DocForDecl id2)] -> DocForDecl id2

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -223,14 +223,13 @@ ppTyName :: Name -> Html
 ppTyName = ppName Prefix
 
 
-ppSimpleSig :: LinksInfo -> Splice -> Unicode -> Qualification
+ppSimpleSig :: LinksInfo -> Splice -> Unicode -> Qualification -> SrcSpan
             -> [DocName] -> HsType DocName
             -> Html
-ppSimpleSig links splice unicode qual names typ =
+ppSimpleSig links splice unicode qual loc names typ =
     topDeclElem' names $ ppTypeSig True occNames ppTyp unicode
   where
-    -- TODO: Use *helpful* source span.
-    topDeclElem' = topDeclElem links (UnhelpfulSpan undefined) splice
+    topDeclElem' = topDeclElem links loc splice
     ppTyp = ppType unicode qual typ
     occNames = map getOccName names
 
@@ -551,10 +550,10 @@ ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification
               -> InstSpec DocName -> InstHead DocName
               -> [Html]
 ppInstanceSigs links splice unicode qual (InstSpec {..}) (InstHead {..}) = do
-    TypeSig lnames (L sspan typ) _ <- ispecSigs
+    TypeSig lnames (L loc typ) _ <- ispecSigs
     let names = map unLoc lnames
     let typ' = rename' . sugar $ specializeTyVarBndrs ispecTyVars ihdTypes typ
-    return $ ppSimpleSig links splice unicode qual names typ'
+    return $ ppSimpleSig links splice unicode qual loc names typ'
   where
     fv = foldr Set.union Set.empty . map freeVariables $ ihdTypes
     rename' = rename fv

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -302,6 +302,15 @@ ppAssocType summ links doc (L loc decl) fixities splice unicode qual =
    ppTyFam summ True links [] fixities loc (fst doc) decl splice unicode qual
 
 
+ppSimpleAssocTy :: LinksInfo -> Splice -> Unicode -> Qualification
+              -> FamilyDecl DocName
+              -> Html
+ppSimpleAssocTy links splice unicode qual decl =
+    ppAssocType False links noDocForDecl ldecl [] splice unicode qual
+  where
+    ldecl = L (getLoc $ fdLName decl) decl
+
+
 --------------------------------------------------------------------------------
 -- * TyClDecl helpers
 --------------------------------------------------------------------------------
@@ -568,9 +577,9 @@ ppInstanceAssocTys :: LinksInfo -> Splice -> Unicode -> Qualification
                    -> [FamilyDecl DocName]
                    -> [Html]
 ppInstanceAssocTys links splice unicode qual =
-    map ppTyFam'
+    map ppSimpleAssocTy'
   where
-    ppTyFam' fam = ppTyFamHeader False True fam unicode qual
+    ppSimpleAssocTy' = ppSimpleAssocTy links splice unicode qual
 
 
 ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -537,12 +537,14 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
         ClassInst { .. } ->
             ( subInstHead iid $ ppContextNoLocs clsiCtx unicode qual <+> typ
             , mdoc
-            , [subInstMethods iid sigs]
+            , [subInstDetails iid ats sigs]
             )
           where
             iid = instanceId origin no ihdClsName
             sigs = ppInstanceSigs links splice unicode qual
                 clsiTyVars ihdTypes clsiSigs
+            ats = ppInstanceAssocTys links splice unicode qual
+                clsiAssocTys
         TypeInst rhs ->
             (ptype, mdoc, [])
           where
@@ -560,6 +562,15 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
                 ]
   where
     typ = ppAppNameTypes ihdClsName ihdKinds ihdTypes unicode qual
+
+
+ppInstanceAssocTys :: LinksInfo -> Splice -> Unicode -> Qualification
+                   -> [FamilyDecl DocName]
+                   -> [Html]
+ppInstanceAssocTys links splice unicode qual =
+    map ppTyFam'
+  where
+    ppTyFam' fam = ppTyFamHeader False True fam unicode qual
 
 
 ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -567,18 +567,13 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
         TypeInst rhs ->
             (ptype, mdoc, [])
           where
-            ptype = mconcat
-                [ keyword "type"
-                , typ
-                , maybe noHtml (\t -> equals <+> ppType unicode qual t) rhs
-                ]
+            ptype = keyword "type" <+> typ <+> prhs
+            prhs = maybe noHtml (\t -> equals <+> ppType unicode qual t) rhs
         DataInst dd ->
             (pdata, mdoc, [])
           where
-            pdata = mconcat
-                [ keyword "data" <+> typ
-                , ppShortDataDecl False True dd unicode qual
-                ]
+            pdata = keyword "data" <+> typ <+> pdecl
+            pdecl = ppShortDataDecl False True dd unicode qual
   where
     typ = ppAppNameTypes ihdClsName ihdKinds ihdTypes unicode qual
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -265,6 +265,14 @@ ppTyFamHeader summary associated d@(FamilyDecl { fdInfo = info
     ppFamilyKind unicode qual mkind
 
 
+ppPseudoFamilyHeader :: Unicode -> Qualification -> PseudoFamilyDecl DocName
+                     -> Html
+ppPseudoFamilyHeader unicode qual (PseudoFamilyDecl { .. }) =
+    ppFamilyInfo True pfdInfo <+>
+    ppAppNameTypes (unLoc pfdLName) [] (map unLoc pfdTyVars) unicode qual <+>
+    ppFamilyKind unicode qual pfdKindSig
+
+
 ppTyFam :: Bool -> Bool -> LinksInfo -> [DocInstance DocName] ->
            [(DocName, Fixity)] -> SrcSpan -> Documentation DocName ->
            FamilyDecl DocName -> Splice -> Unicode -> Qualification -> Html
@@ -299,7 +307,11 @@ ppTyFam summary associated links instances fixities loc doc decl splice unicode 
 ppPseudoFamilyDecl :: LinksInfo -> Splice -> Unicode -> Qualification
                    -> PseudoFamilyDecl DocName
                    -> Html
-ppPseudoFamilyDecl = undefined
+ppPseudoFamilyDecl links splice unicode qual
+                   decl@(PseudoFamilyDecl { pfdLName = L loc name, .. }) =
+    wrapper $ ppPseudoFamilyHeader unicode qual decl
+  where
+    wrapper = topDeclElem links loc splice [name]
 
 
 --------------------------------------------------------------------------------

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -22,7 +22,6 @@ module Haddock.Backends.Xhtml.Decl (
 import Haddock.Backends.Xhtml.DocMarkup
 import Haddock.Backends.Xhtml.Layout
 import Haddock.Backends.Xhtml.Names
-import Haddock.Backends.Xhtml.Specialize
 import Haddock.Backends.Xhtml.Types
 import Haddock.Backends.Xhtml.Utils
 import Haddock.GhcUtils
@@ -563,10 +562,8 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
             )
           where
             iid = instanceId origin no ihdClsName
-            sigs = ppInstanceSigs links splice unicode qual
-                clsiTyVars ihdTypes clsiSigs
-            ats = ppInstanceAssocTys links splice unicode qual
-                clsiTyVars ihdTypes clsiAssocTys
+            sigs = ppInstanceSigs links splice unicode qual clsiSigs
+            ats = ppInstanceAssocTys links splice unicode qual clsiAssocTys
         TypeInst rhs ->
             (ptype, mdoc, [])
           where
@@ -587,20 +584,19 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
 
 
 ppInstanceAssocTys :: LinksInfo -> Splice -> Unicode -> Qualification
-                   -> LHsTyVarBndrs DocName -> [HsType DocName]
                    -> [PseudoFamilyDecl DocName]
                    -> [Html]
-ppInstanceAssocTys links splice unicode qual bndrs tys =
-    map ppFamilyDecl' . map (specializePseudoFamilyDecl bndrs tys)
+ppInstanceAssocTys links splice unicode qual =
+    map ppFamilyDecl'
   where
     ppFamilyDecl' = ppPseudoFamilyDecl links splice unicode qual
 
 
 ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification
-              -> LHsTyVarBndrs DocName -> [HsType DocName] -> [Sig DocName]
+              -> [Sig DocName]
               -> [Html]
-ppInstanceSigs links splice unicode qual bndrs tys sigs = do
-    TypeSig lnames (L loc typ) _ <- map (specializeSig bndrs tys) sigs
+ppInstanceSigs links splice unicode qual sigs = do
+    TypeSig lnames (L loc typ) _ <- sigs
     let names = map unLoc lnames
     return $ ppSimpleSig links splice unicode qual loc names typ
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -567,7 +567,7 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
             sigs = ppInstanceSigs links splice unicode qual
                 clsiTyVars ihdTypes clsiSigs
             ats = ppInstanceAssocTys links splice unicode qual
-                clsiAssocTys
+                clsiTyVars ihdTypes clsiAssocTys
         TypeInst rhs ->
             (ptype, mdoc, [])
           where
@@ -588,10 +588,11 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
 
 
 ppInstanceAssocTys :: LinksInfo -> Splice -> Unicode -> Qualification
+                   -> LHsTyVarBndrs DocName -> [HsType DocName]
                    -> [PseudoFamilyDecl DocName]
                    -> [Html]
-ppInstanceAssocTys links splice unicode qual =
-    map ppFamilyDecl'
+ppInstanceAssocTys links splice unicode qual bndrs tys =
+    map ppFamilyDecl' . map (specializePseudoFamilyDecl bndrs tys)
   where
     ppFamilyDecl' = ppPseudoFamilyDecl links splice unicode qual
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -291,6 +291,14 @@ ppTyFam summary associated links instances fixities loc doc decl splice unicode 
           <+> equals <+> ppType unicode qual (unLoc rhs)
         , Nothing, [] )
 
+
+
+ppPseudoFamilyDecl :: LinksInfo -> Splice -> Unicode -> Qualification
+                   -> PseudoFamilyDecl DocName
+                   -> Html
+ppPseudoFamilyDecl = undefined
+
+
 --------------------------------------------------------------------------------
 -- * Associated Types
 --------------------------------------------------------------------------------
@@ -300,15 +308,6 @@ ppAssocType :: Bool -> LinksInfo -> DocForDecl DocName -> LFamilyDecl DocName
             -> [(DocName, Fixity)] -> Splice -> Unicode -> Qualification -> Html
 ppAssocType summ links doc (L loc decl) fixities splice unicode qual =
    ppTyFam summ True links [] fixities loc (fst doc) decl splice unicode qual
-
-
-ppSimpleAssocTy :: LinksInfo -> Splice -> Unicode -> Qualification
-              -> FamilyDecl DocName
-              -> Html
-ppSimpleAssocTy links splice unicode qual decl =
-    ppAssocType False links noDocForDecl ldecl [] splice unicode qual
-  where
-    ldecl = L (getLoc $ fdLName decl) decl
 
 
 --------------------------------------------------------------------------------
@@ -574,12 +573,12 @@ ppInstHead links splice unicode qual mdoc origin no (InstHead {..}) =
 
 
 ppInstanceAssocTys :: LinksInfo -> Splice -> Unicode -> Qualification
-                   -> [FamilyDecl DocName]
+                   -> [PseudoFamilyDecl DocName]
                    -> [Html]
 ppInstanceAssocTys links splice unicode qual =
-    map ppSimpleAssocTy'
+    map ppFamilyDecl'
   where
-    ppSimpleAssocTy' = ppSimpleAssocTy links splice unicode qual
+    ppFamilyDecl' = ppPseudoFamilyDecl links splice unicode qual
 
 
 ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -223,6 +223,14 @@ ppTyName :: Name -> Html
 ppTyName = ppName Prefix
 
 
+ppSimpleSig :: Unicode -> Qualification -> [DocName] -> HsType DocName -> Html
+ppSimpleSig unicode qual names typ =
+    ppTypeSig True occNames ppTyp unicode
+  where
+    ppTyp = ppType unicode qual typ
+    occNames = map getOccName names
+
+
 --------------------------------------------------------------------------------
 -- * Type families
 --------------------------------------------------------------------------------
@@ -542,8 +550,7 @@ ppInstanceSigs links splice unicode qual (InstSpec {..}) (InstHead {..}) = do
     TypeSig lnames (L sspan typ) _ <- ispecSigs
     let names = map unLoc lnames
     let typ' = rename' . sugar $ specializeTyVarBndrs ispecTyVars ihdTypes typ
-    return $ ppFunSig False links sspan noDocForDecl names typ' []
-        splice unicode qual
+    return $ ppSimpleSig unicode qual names typ'
   where
     fv = foldr Set.union Set.empty . map freeVariables $ ihdTypes
     rename' = rename fv

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -223,10 +223,14 @@ ppTyName :: Name -> Html
 ppTyName = ppName Prefix
 
 
-ppSimpleSig :: Unicode -> Qualification -> [DocName] -> HsType DocName -> Html
-ppSimpleSig unicode qual names typ =
-    ppTypeSig True occNames ppTyp unicode
+ppSimpleSig :: LinksInfo -> Splice -> Unicode -> Qualification
+            -> [DocName] -> HsType DocName
+            -> Html
+ppSimpleSig links splice unicode qual names typ =
+    topDeclElem' names $ ppTypeSig True occNames ppTyp unicode
   where
+    -- TODO: Use *helpful* source span.
+    topDeclElem' = topDeclElem links (UnhelpfulSpan undefined) splice
     ppTyp = ppType unicode qual typ
     occNames = map getOccName names
 
@@ -550,7 +554,7 @@ ppInstanceSigs links splice unicode qual (InstSpec {..}) (InstHead {..}) = do
     TypeSig lnames (L sspan typ) _ <- ispecSigs
     let names = map unLoc lnames
     let typ' = rename' . sugar $ specializeTyVarBndrs ispecTyVars ihdTypes typ
-    return $ ppSimpleSig unicode qual names typ'
+    return $ ppSimpleSig links splice unicode qual names typ'
   where
     fv = foldr Set.union Set.empty . map freeVariables $ ihdTypes
     rename' = rename fv

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -31,10 +31,12 @@ import Haddock.Syb
 import Haddock.Doc (combineDocumentation)
 
 import           Data.Bits
+import           Data.Char
 import           Data.Data (Data, cast)
 import           Data.List             ( intersperse, sort )
 import qualified Data.Map as Map
 import           Data.Maybe
+import           Data.Word
 import           Text.XHtml hiding     ( name, title, p, quote )
 
 import GHC
@@ -636,16 +638,16 @@ instanceId orgin no ihd = concat
 -- section anchors in testing framework and that is not only inconvenient but
 -- also makes testing less viable. And it is only temporary solution so we can
 -- live with it.
-instHeadId :: InstHead DocName -> Int
+instHeadId :: InstHead DocName -> Word64
 instHeadId (InstHead { .. }) =
-    djb2 . map key $ [ihdClsName] ++ names ihdTypes ++ names ihdKinds
+    djb2 id . map key $ [ihdClsName] ++ names ihdTypes ++ names ihdKinds
   where
     names = everything (++) $
         maybeToList . (cast :: forall a. Data a => a -> Maybe DocName)
-    key = djb2 . occNameString . nameOccName . getName
+    key = djb2 (fromIntegral . ord) . occNameString . nameOccName . getName
 
-    djb2 :: Enum a => [a] -> Int
-    djb2 = foldl (\h c -> h * 33 `xor` fromEnum c) 5381
+    djb2 :: (a -> Word64) -> [a] -> Word64
+    djb2 conv = foldl (\h c -> h * 33 `xor` conv c) 5381
 
 
 -------------------------------------------------------------------------------

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -31,7 +31,6 @@ import Haddock.Doc (combineDocumentation)
 
 import           Data.List             ( intersperse, sort )
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import           Data.Maybe
 import           Text.XHtml hiding     ( name, title, p, quote )
 
@@ -601,13 +600,9 @@ ppInstanceSigs :: LinksInfo -> Splice -> Unicode -> Qualification
               -> LHsTyVarBndrs DocName -> [HsType DocName] -> [Sig DocName]
               -> [Html]
 ppInstanceSigs links splice unicode qual bndrs tys sigs = do
-    TypeSig lnames (L loc typ) _ <- sigs
+    TypeSig lnames (L loc typ) _ <- map (specializeSig bndrs tys) sigs
     let names = map unLoc lnames
-    let typ' = rename' . sugar $ specializeTyVarBndrs bndrs tys typ
-    return $ ppSimpleSig links splice unicode qual loc names typ'
-  where
-    fv = foldr Set.union Set.empty . map freeVariables $ tys
-    rename' = rename fv
+    return $ ppSimpleSig links splice unicode qual loc names typ
 
 
 lookupAnySubdoc :: Eq id1 => id1 -> [(id1, DocForDecl id2)] -> DocForDecl id2

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -531,13 +531,13 @@ ppInstHead :: LinksInfo -> Splice -> Unicode -> Qualification
            -> Html
 ppInstHead links splice unicode qual iid mspec ihead@(InstHead {..}) =
     case ihdInstType of
-        ClassInst cs | Just spec <- mspec ->
+        ClassInst cs _ _ | Just spec <- mspec ->
             subClsInstance (nameStr ++ "-" ++ show iid) hdr (mets spec ihead)
           where
             hdr = ppContextNoLocs cs unicode qual <+> typ
             mets = ppInstanceSigs links splice unicode qual
             nameStr = occNameString . nameOccName $ getName ihdClsName
-        ClassInst cs -> ppContextNoLocs cs unicode qual <+> typ
+        ClassInst cs _ _ -> ppContextNoLocs cs unicode qual <+> typ
         TypeInst rhs -> keyword "type" <+> typ
             <+> maybe noHtml (\t -> equals <+> ppType unicode qual t) rhs
         DataInst dd -> keyword "data" <+> typ

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -214,7 +214,7 @@ subInstMethods :: String -- ^ Instance unique id (for anchor generation)
                -> [Html] -- ^ Method contents (pretty-printed signatures)
                -> Html
 subInstMethods iid mets =
-    section << subBlock mets
+    section << subMethods mets
   where
     section = thediv ! collapseSection (instAnchorId iid) False "methods"
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -31,7 +31,7 @@ module Haddock.Backends.Xhtml.Layout (
   subConstructors,
   subEquations,
   subFields,
-  subInstances, subClsInstance, subInstHead, subInstMethods,
+  subInstances, subInstHead, subInstMethods,
   subMethods,
   subMinimal,
 
@@ -200,15 +200,7 @@ subInstances qual nm lnks splice = maybe noHtml wrap . instTable
     subCaption = paragraph ! collapseControl id_ True "caption" << "Instances"
     id_ = makeAnchorId $ "i:" ++ nm
 
-
--- | Generate class instance div with specialized methods.
-subClsInstance :: String -- ^ Section unique id
-               -> Html -- ^ Header contents (instance name and type)
-               -> [Html] -- ^ Method contents (pretty-printed signatures)
-               -> Html
-subClsInstance iid hdr mets = subInstHead iid hdr <+> subInstMethods iid mets
-
-
+ 
 subInstHead :: String -- ^ Instance unique id (for anchor generation)
             -> Html -- ^ Header content (instance name and type)
             -> Html

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -211,7 +211,7 @@ subClsInstance sid hdr mets =
   where
     anchorId = makeAnchorId $ "i:" ++ sid
     hdrDiv = thediv ! collapseControl anchorId False "instance" << hdr
-    methodDiv = thediv ! collapseSection anchorId False [] << subMethods mets
+    methodDiv = thediv ! collapseSection anchorId False [] << subBlock mets
 
 
 subMethods :: [Html] -> Html

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -31,7 +31,7 @@ module Haddock.Backends.Xhtml.Layout (
   subConstructors,
   subEquations,
   subFields,
-  subInstances, subInstHead, subInstMethods,
+  subInstances, subInstHead, subInstDetails,
   subMethods,
   subMinimal,
 
@@ -210,13 +210,14 @@ subInstHead iid hdr =
     expander = thediv ! collapseControl (instAnchorId iid) False "instance"
 
 
-subInstMethods :: String -- ^ Instance unique id (for anchor generation)
+subInstDetails :: String -- ^ Instance unique id (for anchor generation)
+               -> [Html] -- ^ Associated type contents
                -> [Html] -- ^ Method contents (pretty-printed signatures)
                -> Html
-subInstMethods iid mets =
-    section << subMethods mets
+subInstDetails iid ats mets =
+    section << (subAssociatedTypes ats <+> subMethods mets)
   where
-    section = thediv ! collapseSection (instAnchorId iid) False "methods"
+    section = thediv ! collapseSection (instAnchorId iid) False "inst-details"
 
 
 instAnchorId :: String -> String

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -207,11 +207,11 @@ subClsInstance :: String -- ^ Section unique id
                -> [Html] -- ^ Method contents (pretty-printed signatures)
                -> Html
 subClsInstance sid hdr mets =
-    hdrDiv <+> methodDiv
+    (hdrDiv << hdr) <+> (methodDiv << subBlock mets)
   where
     anchorId = makeAnchorId $ "i:" ++ sid
-    hdrDiv = thediv ! collapseControl anchorId False "instance" << hdr
-    methodDiv = thediv ! collapseSection anchorId False [] << subBlock mets
+    hdrDiv = thediv ! collapseControl anchorId False "instance"
+    methodDiv = thediv ! collapseSection anchorId False "methods"
 
 
 subMethods :: [Html] -> Html

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -205,9 +205,9 @@ subInstHead :: String -- ^ Instance unique id (for anchor generation)
             -> Html -- ^ Header content (instance name and type)
             -> Html
 subInstHead iid hdr =
-    expander << hdr
+    expander noHtml <+> hdr
   where
-    expander = thediv ! collapseControl (instAnchorId iid) False "instance"
+    expander = thespan ! collapseControl (instAnchorId iid) False "instance"
 
 
 subInstDetails :: String -- ^ Instance unique id (for anchor generation)

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -206,12 +206,29 @@ subClsInstance :: String -- ^ Section unique id
                -> Html -- ^ Header contents (instance name and type)
                -> [Html] -- ^ Method contents (pretty-printed signatures)
                -> Html
-subClsInstance sid hdr mets =
-    (hdrDiv << hdr) <+> (methodDiv << subBlock mets)
+subClsInstance iid hdr mets = subInstHead iid hdr <+> subInstMethods iid mets
+
+
+subInstHead :: String -- ^ Instance unique id (for anchor generation)
+            -> Html -- ^ Header content (instance name and type)
+            -> Html
+subInstHead iid hdr =
+    expander << hdr
   where
-    anchorId = makeAnchorId $ "i:" ++ sid
-    hdrDiv = thediv ! collapseControl anchorId False "instance"
-    methodDiv = thediv ! collapseSection anchorId False "methods"
+    expander = thediv ! collapseControl (instAnchorId iid) False "instance"
+
+
+subInstMethods :: String -- ^ Instance unique id (for anchor generation)
+               -> [Html] -- ^ Method contents (pretty-printed signatures)
+               -> Html
+subInstMethods iid mets =
+    section << subBlock mets
+  where
+    section = thediv ! collapseSection (instAnchorId iid) False "methods"
+
+
+instAnchorId :: String -> String
+instAnchorId iid = makeAnchorId $ "i:" ++ iid
 
 
 subMethods :: [Html] -> Html

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -31,7 +31,7 @@ module Haddock.Backends.Xhtml.Layout (
   subConstructors,
   subEquations,
   subFields,
-  subInstances, subClsInstance,
+  subInstances, subClsInstance, subInstHead, subInstMethods,
   subMethods,
   subMinimal,
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -5,11 +5,7 @@
 
 
 module Haddock.Backends.Xhtml.Specialize
-    ( specialize, specialize'
-    , specializeTyVarBndrs
-    , specializePseudoFamilyDecl
-    , sugar, rename
-    , freeVariables
+    ( specializePseudoFamilyDecl, specializeSig
     ) where
 
 
@@ -78,6 +74,18 @@ specializePseudoFamilyDecl bndrs typs decl =
     decl { pfdTyVars = map specializeTyVars (pfdTyVars decl) }
   where
     specializeTyVars = specializeTyVarBndrs bndrs typs
+
+
+specializeSig :: (Eq name, Typeable name, DataId name, SetName name)
+              => LHsTyVarBndrs name -> [HsType name]
+              -> Sig name
+              -> Sig name
+specializeSig bndrs typs (TypeSig lnames (L loc typ) prn) =
+    TypeSig lnames (L loc typ') prn
+  where
+    typ' = rename fv . sugar $ specializeTyVarBndrs bndrs typs typ
+    fv = foldr Set.union Set.empty . map freeVariables $ typs
+specializeSig _ _ sig = sig
 
 
 -- | Make given type use tuple and list literals where appropriate.

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -320,7 +320,7 @@ findFreshName :: Set NameRep -> NameRep -> NameRep
 findFreshName taken =
     fromJust . List.find isFresh . alternativeNames
   where
-    isFresh = not . Set.member taken
+    isFresh = not . flip Set.member taken
 
 
 alternativeNames :: NameRep -> [NameRep]

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -135,9 +135,9 @@ renameType (HsBangTy bang lt) = HsBangTy bang <$> renameLType lt
 renameType t@(HsRecTy _) = pure t
 renameType t@(HsCoreTy _) = pure t
 renameType (HsExplicitListTy ph ltys) =
-    HsExplicitListTy ph <$> mapM renameLType ltys
+    HsExplicitListTy ph <$> renameLTypes ltys
 renameType (HsExplicitTupleTy phs ltys) =
-    HsExplicitTupleTy phs <$> mapM renameLType ltys
+    HsExplicitTupleTy phs <$> renameLTypes ltys
 renameType t@(HsTyLit _) = pure t
 renameType (HsWrapTy wrap t) = HsWrapTy wrap <$> renameType t
 renameType HsWildcardTy = pure HsWildcardTy
@@ -148,14 +148,18 @@ renameLType :: Ord name => LHsType name -> Rename name (LHsType name)
 renameLType = located renameType
 
 
+renameLTypes :: Ord name => [LHsType name] -> Rename name [LHsType name]
+renameLTypes = mapM renameLType
+
+
+renameContext :: Ord name => HsContext name -> Rename name (HsContext name)
+renameContext = renameLTypes
+
+
 renameLTyVarBndrs :: Ord name => LHsTyVarBndrs name -> Rename name (LHsTyVarBndrs name)
 renameLTyVarBndrs lbndrs = do
     tys' <- mapM (located renameTyVarBndr) $ hsq_tvs lbndrs
     pure $ lbndrs { hsq_tvs = tys' }
-
-
-renameContext :: Ord name => HsContext name -> Rename name (HsContext name)
-renameContext = mapM $ located renameType
 
 
 renameTyVarBndr :: Ord name => HsTyVarBndr name -> Rename name (HsTyVarBndr name)

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -299,7 +299,7 @@ rebindName name = do
     case Map.lookup (getName name) rneCtx of
         Just name' -> pure name'
         Nothing | getNameRep name `Set.member` rneFV -> freshName name
-        Nothing -> pure name
+        Nothing -> reuseName name
 
 
 -- | Generate fresh occurrence name, put it into context and return.
@@ -314,6 +314,13 @@ freshName name = do
     elems' = Set.fromList . map getNameRep . Map.elems
     nname = getName name
     rep = getNameRep nname
+
+
+reuseName :: SetName name => name -> Rebind name name
+reuseName name = do
+    env@RenameEnv { .. } <- get
+    put $ env { rneCtx = Map.insert (getName name) name rneCtx }
+    return name
 
 
 findFreshName :: Set NameRep -> NameRep -> NameRep

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -11,6 +11,7 @@ module Haddock.Backends.Xhtml.Specialize
 
 
 import Haddock.Syb
+import Haddock.Types
 
 import GHC
 import Name
@@ -100,11 +101,6 @@ parseTupleArity ('(':commas) = do
     parseCommas ")" = Just 0
     parseCommas _ = Nothing
 parseTupleArity _ = Nothing
-
-
-class NamedThing name => SetName name where
-
-    setName :: Name -> name -> name
 
 
 setInternalOccName :: SetName name => OccName -> name -> name

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -6,7 +6,7 @@
 module Haddock.Backends.Xhtml.Specialize
     ( specialize, specialize'
     , specializeTyVarBndrs
-    , sugar
+    , sugar, rename
     ) where
 
 
@@ -16,7 +16,13 @@ import GHC
 import Name
 
 import Control.Monad
+import Control.Monad.Trans.RWS
+
 import Data.Data
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 
 specialize :: (Eq name, Typeable name)
@@ -92,3 +98,92 @@ parseTupleArity ('(':commas) = do
     parseCommas ")" = Just 0
     parseCommas _ = Nothing
 parseTupleArity _ = Nothing
+
+
+rename :: Ord name => HsType name -> HsType name
+rename = fst . evalRWS undefined Map.empty . renameType -- TODO.
+
+
+type Rename name a = RWS (Set name) () (Map name name) a
+
+
+renameType :: Ord name => HsType name -> Rename name (HsType name)
+renameType (HsForAllTy ex mspan lbndrs lctx lt) = do
+    lbndrs' <- renameLTyVarBndrs lbndrs
+    HsForAllTy
+        <$> pure ex
+        <*> pure mspan
+        <*> pure lbndrs'
+        <*> located renameContext lctx
+        <*> renameLType lt
+renameType (HsTyVar name) = HsTyVar <$> renameName name
+renameType (HsAppTy lf la) = HsAppTy <$> renameLType lf <*> renameLType la
+renameType (HsFunTy la lr) = HsFunTy <$> renameLType la <*> renameLType lr
+renameType (HsListTy lt) = HsListTy <$> renameLType lt
+renameType (HsPArrTy lt) = HsPArrTy <$> renameLType lt
+renameType (HsTupleTy srt lt) = HsTupleTy srt <$> mapM renameLType lt
+renameType (HsOpTy la lop lb) = HsOpTy
+    <$> renameLType la
+    <*> pure lop -- TODO.
+    <*> renameLType lb
+renameType (HsParTy lt) = HsParTy <$> renameLType lt
+renameType (HsIParamTy ip lt) = HsIParamTy ip <$> renameLType lt
+renameType (HsEqTy la lb) = HsEqTy <$> renameLType la <*> renameLType lb
+renameType (HsKindSig lt lk) = HsKindSig <$> renameLType lt <*> pure lk
+renameType t@(HsQuasiQuoteTy _) = pure t -- TODO.
+renameType t@(HsSpliceTy _ _) = pure t -- TODO.
+renameType t@(HsDocTy _ _) = pure t -- TODO.
+renameType (HsBangTy bang lt) = HsBangTy bang <$> renameLType lt
+renameType t@(HsRecTy _) = pure t -- TODO.
+renameType t@(HsCoreTy _) = pure t
+renameType t@(HsExplicitListTy _ _) = pure t -- TODO.
+renameType t@(HsExplicitTupleTy _ _) = pure t -- TODO.
+renameType t@(HsTyLit _) = pure t
+renameType (HsWrapTy wrap t) = HsWrapTy wrap <$> renameType t
+renameType HsWildcardTy = pure HsWildcardTy
+renameType t@(HsNamedWildcardTy _) = pure t -- TODO.
+
+
+renameLType :: Ord name => LHsType name -> Rename name (LHsType name)
+renameLType = located renameType
+
+
+renameLTyVarBndrs :: Ord name => LHsTyVarBndrs name -> Rename name (LHsTyVarBndrs name)
+renameLTyVarBndrs lbndrs = do
+    tys' <- mapM (located renameTyVarBndr) $ hsq_tvs lbndrs
+    pure $ lbndrs { hsq_tvs = tys' }
+
+
+renameContext :: Ord name => HsContext name -> Rename name (HsContext name)
+renameContext = mapM $ located renameType
+
+
+renameTyVarBndr :: Ord name => HsTyVarBndr name -> Rename name (HsTyVarBndr name)
+renameTyVarBndr (UserTyVar name) =
+    UserTyVar <$> renameNameBndr name
+renameTyVarBndr (KindedTyVar name kinds) =
+    KindedTyVar <$> located renameNameBndr name <*> pure kinds
+
+
+renameNameBndr :: Ord name => name -> Rename name name
+renameNameBndr name = do
+    fv <- ask
+    when (name `Set.member` fv) $
+        freshName name
+    renameName name
+
+
+renameName :: Ord name => name -> Rename name name
+renameName name = do
+    rnmap <- get
+    pure $ case Map.lookup name rnmap of
+        Just name' -> name'
+        Nothing -> name
+
+
+freshName :: Ord name => name -> Rename name ()
+freshName _ = pure () -- TODO.
+
+
+located :: Functor f => (a -> f b) -> Located a -> f (Located b)
+located f (L loc e) = L loc <$> f e

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -292,7 +292,7 @@ freshName :: SetName name => name -> Rename name name
 freshName name = do
     fv <- ask
     env <- get
-    let taken = Set.union fv (Set.fromList . map getNameRep . Map.keys $ env)
+    let taken = Set.union fv (Set.fromList . map getNameRep . Map.elems $ env)
     let name' = setInternalNameRep (findFreshName taken occ) name
     put $ Map.insert nname name' env
     return name'

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -159,7 +159,7 @@ renameType HsWildcardTy = pure HsWildcardTy
 renameType (HsNamedWildcardTy name) = HsNamedWildcardTy <$> renameName name
 
 
-freeVariables :: forall name. (NamedThing name, Data (HsType name))
+freeVariables :: forall name. (NamedThing name, DataId name)
               => HsType name -> Set OccName
 freeVariables =
     everythingWithState Set.empty Set.union query

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -7,6 +7,7 @@ module Haddock.Backends.Xhtml.Specialize
     ( specialize, specialize'
     , specializeTyVarBndrs
     , sugar, rename
+    , freeVariables
     ) where
 
 
@@ -111,8 +112,8 @@ setInternalOccName occ name =
     nname' = mkInternalName (nameUnique nname) occ (nameSrcSpan nname)
 
 
-rename :: SetName name => HsType name -> HsType name
-rename = fst . evalRWS undefined Map.empty . renameType -- TODO.
+rename :: SetName name => Set OccName -> HsType name -> HsType name
+rename fv typ = fst $ evalRWS (renameType typ) fv Map.empty
 
 
 type Rename name a = RWS (Set OccName) () (Map Name name) a

--- a/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Specialize.hs
@@ -241,7 +241,15 @@ findFreshName taken =
 
 
 alternativeNames :: OccName -> [OccName]
-alternativeNames name =
+alternativeNames name
+    | [_] <- occNameString name = letterNames ++ alternativeNames' name
+  where
+    letterNames = map (mkVarOcc . pure) ['a'..'z']
+alternativeNames name = alternativeNames' name
+
+
+alternativeNames' :: OccName -> [OccName]
+alternativeNames' name =
     [ mkVarOcc $ str ++ show i | i :: Int <- [0..] ]
   where
     str = occNameString name

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -390,13 +390,13 @@ synifyKindSig :: Kind -> LHsKind Name
 synifyKindSig k = synifyType WithinType k
 
 synifyInstHead :: ([TyVar], [PredType], Class, [Type]) -> InstHead Name
-synifyInstHead (tyvars, preds, cls, types) = InstHead
+synifyInstHead (_, preds, cls, types) = InstHead
     { ihdClsName = getName cls
     , ihdKinds = map (unLoc . synifyType WithinType) ks
     , ihdTypes = map (unLoc . synifyType WithinType) ts
     , ihdInstType = ClassInst
         { clsiCtx = map (unLoc . synifyType WithinType) preds
-        , clsiTyVars = synifyTyVars tyvars
+        , clsiTyVars = synifyTyVars $ classTyVars cls
         , clsiSigs = map synifyClsIdSig $ classMethods cls
         }
     }

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -25,7 +25,6 @@ import Data.Either (lefts, rights)
 import Data.List( partition )
 import DataCon
 import FamInstEnv
-import Haddock.Types
 import HsSyn
 import Kind ( splitKindFunTys, synTyConResKind, isKind )
 import Name
@@ -40,6 +39,9 @@ import TysPrim ( alphaTyVars )
 import TysWiredIn ( listTyConName, eqTyCon )
 import Unique ( getUnique )
 import Var
+
+import Haddock.Types
+import Haddock.Interface.Specialize
 
 
 
@@ -390,7 +392,7 @@ synifyKindSig :: Kind -> LHsKind Name
 synifyKindSig k = synifyType WithinType k
 
 synifyInstHead :: ([TyVar], [PredType], Class, [Type]) -> InstHead Name
-synifyInstHead (_, preds, cls, types) = InstHead
+synifyInstHead (_, preds, cls, types) = specializeInstHead $ InstHead
     { ihdClsName = getName cls
     , ihdKinds = map (unLoc . synifyType WithinType) ks
     , ihdTypes = map (unLoc . synifyType WithinType) ts

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -391,16 +391,18 @@ synifyKindSig k = synifyType WithinType k
 
 synifyInstHead :: ([TyVar], [PredType], Class, [Type]) -> InstHead Name
 synifyInstHead (tyvars, preds, cls, types) = InstHead
-  { ihdClsName = getName cls
-  , ihdKinds = map (unLoc . synifyType WithinType) ks
-  , ihdTypes = map (unLoc . synifyType WithinType) ts
-  , ihdInstType = ClassInst
-      { clsiCtx = map (unLoc . synifyType WithinType) preds
-      , clsiTyVars = synifyTyVars tyvars
-      , clsiSigs = map (synifyIdSig WithinType) $ classMethods cls
-      }
-  }
-  where (ks,ts) = break (not . isKind) types
+    { ihdClsName = getName cls
+    , ihdKinds = map (unLoc . synifyType WithinType) ks
+    , ihdTypes = map (unLoc . synifyType WithinType) ts
+    , ihdInstType = ClassInst
+        { clsiCtx = map (unLoc . synifyType WithinType) preds
+        , clsiTyVars = synifyTyVars tyvars
+        , clsiSigs = map synifyClsIdSig $ classMethods cls
+        }
+    }
+  where
+    (ks,ts) = break (not . isKind) types
+    synifyClsIdSig = synifyIdSig DeleteTopLevelQuantification
 
 -- Convert a family instance, this could be a type family or data family
 synifyFamInst :: FamInst -> Bool -> Either ErrMsg (InstHead Name)

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -390,11 +390,15 @@ synifyKindSig :: Kind -> LHsKind Name
 synifyKindSig k = synifyType WithinType k
 
 synifyInstHead :: ([TyVar], [PredType], Class, [Type]) -> InstHead Name
-synifyInstHead (_, preds, cls, types) = InstHead
+synifyInstHead (tyvars, preds, cls, types) = InstHead
   { ihdClsName = getName cls
   , ihdKinds = map (unLoc . synifyType WithinType) ks
   , ihdTypes = map (unLoc . synifyType WithinType) ts
-  , ihdInstType = ClassInst $ map (unLoc . synifyType WithinType) preds
+  , ihdInstType = ClassInst
+      { clsiCtx = map (unLoc . synifyType WithinType) preds
+      , clsiTyVars = synifyTyVars tyvars
+      , clsiSigs = map (synifyIdSig WithinType) $ classMethods cls
+      }
   }
   where (ks,ts) = break (not . isKind) types
 

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -398,6 +398,9 @@ synifyInstHead (_, preds, cls, types) = InstHead
         { clsiCtx = map (unLoc . synifyType WithinType) preds
         , clsiTyVars = synifyTyVars $ classTyVars cls
         , clsiSigs = map synifyClsIdSig $ classMethods cls
+        , clsiAssocTys = do
+            (Right (FamDecl fam)) <- map (synifyTyCon Nothing) $ classATs cls
+            pure fam
         }
     }
   where

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -400,7 +400,7 @@ synifyInstHead (_, preds, cls, types) = InstHead
         , clsiSigs = map synifyClsIdSig $ classMethods cls
         , clsiAssocTys = do
             (Right (FamDecl fam)) <- map (synifyTyCon Nothing) $ classATs cls
-            pure fam
+            pure $ mkPseudoFamilyDecl fam
         }
     }
   where

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -264,7 +264,10 @@ renameInstHead InstHead {..} = do
   kinds <- mapM renameType ihdKinds
   types <- mapM renameType ihdTypes
   itype <- case ihdInstType of
-    ClassInst cs -> ClassInst <$> mapM renameType cs
+    ClassInst ctx bndrs sigs -> ClassInst
+        <$> mapM renameType ctx
+        <*> renameLTyVarBndrs bndrs
+        <*> mapM renameSig sigs
     TypeInst  ts -> TypeInst  <$> traverse renameType ts
     DataInst  dd -> DataInst  <$> renameTyClD dd
   return InstHead

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -264,10 +264,11 @@ renameInstHead InstHead {..} = do
   kinds <- mapM renameType ihdKinds
   types <- mapM renameType ihdTypes
   itype <- case ihdInstType of
-    ClassInst ctx bndrs sigs -> ClassInst
-        <$> mapM renameType ctx
-        <*> renameLTyVarBndrs bndrs
-        <*> mapM renameSig sigs
+    ClassInst { .. } -> ClassInst
+        <$> mapM renameType clsiCtx
+        <*> renameLTyVarBndrs clsiTyVars
+        <*> mapM renameSig clsiSigs
+        <*> mapM renameFamilyDecl clsiAssocTys
     TypeInst  ts -> TypeInst  <$> traverse renameType ts
     DataInst  dd -> DataInst  <$> renameTyClD dd
   return InstHead

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -268,7 +268,7 @@ renameInstHead InstHead {..} = do
         <$> mapM renameType clsiCtx
         <*> renameLTyVarBndrs clsiTyVars
         <*> mapM renameSig clsiSigs
-        <*> mapM renameFamilyDecl clsiAssocTys
+        <*> mapM renamePseudoFamilyDecl clsiAssocTys
     TypeInst  ts -> TypeInst  <$> traverse renameType ts
     DataInst  dd -> DataInst  <$> renameTyClD dd
   return InstHead
@@ -351,6 +351,16 @@ renameFamilyDecl (FamilyDecl { fdInfo = info, fdLName = lname
     tckind'  <- renameMaybeLKind tckind
     return (FamilyDecl { fdInfo = info', fdLName = lname'
                        , fdTyVars = ltyvars', fdKindSig = tckind' })
+
+
+renamePseudoFamilyDecl :: PseudoFamilyDecl Name
+                       -> RnM (PseudoFamilyDecl DocName)
+renamePseudoFamilyDecl (PseudoFamilyDecl { .. }) =  PseudoFamilyDecl
+    <$> renameFamilyInfo pfdInfo
+    <*> renameL pfdLName
+    <*> mapM renameLType pfdTyVars
+    <*> renameMaybeLKind pfdKindSig
+
 
 renameFamilyInfo :: FamilyInfo Name -> RnM (FamilyInfo DocName)
 renameFamilyInfo DataFamily     = return DataFamily

--- a/haddock-api/src/Haddock/Interface/Specialize.hs
+++ b/haddock-api/src/Haddock/Interface/Specialize.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE RecordWildCards #-}
 
 
-module Haddock.Backends.Xhtml.Specialize
-    ( specializePseudoFamilyDecl, specializeSig
+module Haddock.Interface.Specialize
+    ( specializeInstHead
     ) where
 
 
@@ -86,6 +86,20 @@ specializeSig bndrs typs (TypeSig lnames (L loc typ) prn) =
     typ' = rename fv . sugar $ specializeTyVarBndrs bndrs typs typ
     fv = foldr Set.union Set.empty . map freeVariables $ typs
 specializeSig _ _ sig = sig
+
+
+specializeInstHead :: (Eq name, Typeable name, DataId name, SetName name)
+                   => InstHead name -> InstHead name
+specializeInstHead ihd@InstHead { ihdInstType = clsi@ClassInst { .. }, .. } =
+    ihd { ihdInstType = instType' }
+  where
+    instType' = clsi
+        { clsiSigs = map specializeSig' clsiSigs
+        , clsiAssocTys = map specializeFamilyDecl' clsiAssocTys
+        }
+    specializeSig' = specializeSig clsiTyVars ihdTypes
+    specializeFamilyDecl' = specializePseudoFamilyDecl clsiTyVars ihdTypes
+specializeInstHead ihd = ihd
 
 
 -- | Make given type use tuple and list literals where appropriate.

--- a/haddock-api/src/Haddock/Interface/Specialize.hs
+++ b/haddock-api/src/Haddock/Interface/Specialize.hs
@@ -88,6 +88,8 @@ specializeSig bndrs typs (TypeSig lnames (L loc typ) prn) =
 specializeSig _ _ sig = sig
 
 
+-- | Make all details of instance head (signatures, associated types)
+-- specialized to that particular instance type.
 specializeInstHead :: (Eq name, Typeable name, DataId name, SetName name)
                    => InstHead name -> InstHead name
 specializeInstHead ihd@InstHead { ihdInstType = clsi@ClassInst { .. }, .. } =

--- a/haddock-api/src/Haddock/Interface/Specialize.hs
+++ b/haddock-api/src/Haddock/Interface/Specialize.hs
@@ -147,7 +147,10 @@ sugarTuples typ =
 
 sugarOperators :: NamedThing name => HsType name -> HsType name
 sugarOperators (HsAppTy (L _ (HsAppTy (L loc (HsTyVar name)) la)) lb)
-    | isSymOcc $ getOccName name = mkHsOpTy la (L loc name) lb
+    | isSymOcc $ getOccName name' = mkHsOpTy la (L loc name) lb
+    | isBuiltInSyntax name' && getOccString name == "(->)" = HsFunTy la lb
+  where
+    name' = getName name
 sugarOperators typ = typ
 
 

--- a/haddock-api/src/Haddock/Interface/Specialize.hs
+++ b/haddock-api/src/Haddock/Interface/Specialize.hs
@@ -116,7 +116,7 @@ sugar =
     everywhere $ mkT step
   where
     step :: HsType name -> HsType name
-    step = sugarTuples . sugarLists
+    step = sugarOperators . sugarTuples . sugarLists
 
 
 sugarLists :: NamedThing name => HsType name -> HsType name
@@ -143,6 +143,12 @@ sugarTuples typ =
             Just arity -> arity == length apps
             Nothing -> False
     aux _ _ = typ
+
+
+sugarOperators :: NamedThing name => HsType name -> HsType name
+sugarOperators (HsAppTy (L _ (HsAppTy (L loc (HsTyVar name)) la)) lb)
+    | isSymOcc $ getOccName name = mkHsOpTy la (L loc name) lb
+sugarOperators typ = typ
 
 
 -- | Compute arity of given tuple operator.

--- a/haddock-api/src/Haddock/Syb.hs
+++ b/haddock-api/src/Haddock/Syb.hs
@@ -2,7 +2,7 @@
 
 
 module Haddock.Syb
-    ( everything, everywhere
+    ( everything, everythingWithState, everywhere
     , mkT
     , combine
     ) where
@@ -19,6 +19,20 @@ import Control.Applicative
 everything :: (r -> r -> r) -> (forall a. Data a => a -> r)
            -> (forall a. Data a => a -> r)
 everything k f x = foldl k (f x) (gmapQ (everything k f) x)
+
+
+-- | Perform a query with state on each level of a tree.
+--
+-- This is the same as 'everything' but allows for stateful computations. In
+-- SYB it is called @everythingWithContext@ but I find this name somewhat
+-- nicer.
+everythingWithState :: s -> (r -> r -> r)
+                    -> (forall a. Data a => a -> s -> (r, s))
+                    -> (forall a. Data a => a -> r)
+everythingWithState s k f x =
+    let (r, s') = f x s
+    in foldl k r (gmapQ (everythingWithState s' k f) x)
+
 
 -- | Apply transformation on each level of a tree.
 --

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -384,6 +384,24 @@ data InstHead name = InstHead
     , ihdInstType :: InstType name
     }
 
+
+-- | An instance origin information.
+--
+-- This is used primarily in HTML backend to generate unique instance
+-- identifiers (for expandable sections).
+data InstOrigin name
+    = OriginClass name
+    | OriginData name
+    | OriginFamily name
+
+
+instance NamedThing name => NamedThing (InstOrigin name) where
+
+    getName (OriginClass name) = getName name
+    getName (OriginData name) = getName name
+    getName (OriginFamily name) = getName name
+
+
 -----------------------------------------------------------------------------
 -- * Documentation comments
 -----------------------------------------------------------------------------

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveFoldable, DeriveTraversable, StandaloneDeriving, TypeFamilies #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveFoldable, DeriveTraversable, StandaloneDeriving, TypeFamilies, RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
@@ -324,12 +324,19 @@ instance SetName DocName where
 
 -- | The three types of instances
 data InstType name
-  = ClassInst [HsType name]         -- ^ Context
+  = ClassInst
+      { clsiCtx :: [HsType name]
+      , clsiTyVars :: LHsTyVarBndrs name
+      , clsiSigs :: [Sig name]
+      }
   | TypeInst  (Maybe (HsType name)) -- ^ Body (right-hand side)
   | DataInst (TyClDecl name)        -- ^ Data constructors
 
 instance OutputableBndr a => Outputable (InstType a) where
-  ppr (ClassInst a) = text "ClassInst" <+> ppr a
+  ppr (ClassInst { .. }) = text "ClassInst"
+      <+> ppr clsiCtx
+      <+> ppr clsiTyVars
+      <+> ppr clsiSigs
   ppr (TypeInst  a) = text "TypeInst"  <+> ppr a
   ppr (DataInst  a) = text "DataInst"  <+> ppr a
 

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -301,6 +301,23 @@ instance NamedThing DocName where
   getName (Undocumented name) = name
 
 
+class NamedThing name => SetName name where
+
+    setName :: Name -> name -> name
+
+
+instance SetName Name where
+
+    setName name' _ = name'
+
+
+instance SetName DocName where
+
+    setName name' (Documented _ mdl) = Documented name' mdl
+    setName name' (Undocumented _) = Undocumented name'
+
+
+
 -----------------------------------------------------------------------------
 -- * Instances
 -----------------------------------------------------------------------------

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -328,6 +328,7 @@ data InstType name
       { clsiCtx :: [HsType name]
       , clsiTyVars :: LHsTyVarBndrs name
       , clsiSigs :: [Sig name]
+      , clsiAssocTys :: [FamilyDecl name]
       }
   | TypeInst  (Maybe (HsType name)) -- ^ Body (right-hand side)
   | DataInst (TyClDecl name)        -- ^ Data constructors

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -328,7 +328,7 @@ data InstType name
       { clsiCtx :: [HsType name]
       , clsiTyVars :: LHsTyVarBndrs name
       , clsiSigs :: [Sig name]
-      , clsiAssocTys :: [FamilyDecl name]
+      , clsiAssocTys :: [PseudoFamilyDecl name]
       }
   | TypeInst  (Maybe (HsType name)) -- ^ Body (right-hand side)
   | DataInst (TyClDecl name)        -- ^ Data constructors

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -352,12 +352,6 @@ data InstHead name = InstHead
     , ihdInstType :: InstType name
     }
 
--- | Instance details used for printing specialized method signatures.
-data InstSpec name = InstSpec
-    { ispecTyVars :: LHsTyVarBndrs name
-    , ispecSigs :: [Sig name]
-    }
-
 -----------------------------------------------------------------------------
 -- * Documentation comments
 -----------------------------------------------------------------------------

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -90,6 +90,7 @@ executable haddock
       Haddock.Interface.AttachInstances
       Haddock.Interface.LexParseRn
       Haddock.Interface.ParseModuleHeader
+      Haddock.Interface.Specialize
       Haddock.Parser
       Haddock.Utils
       Haddock.Backends.Xhtml
@@ -97,7 +98,6 @@ executable haddock
       Haddock.Backends.Xhtml.DocMarkup
       Haddock.Backends.Xhtml.Layout
       Haddock.Backends.Xhtml.Names
-      Haddock.Backends.Xhtml.Specialize
       Haddock.Backends.Xhtml.Themes
       Haddock.Backends.Xhtml.Types
       Haddock.Backends.Xhtml.Utils

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -147,7 +147,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:C-45-1912746692-45-1" class="instance expander" onclick="toggleSection('i:ic:C-45-1912746692-45-1')"
+		    ><div id="control.i:ic:C:67:1" class="instance expander" onclick="toggleSection('i:ic:C:67:1')"
 		      ><a href=""
 			>C</a
 			> ()</div
@@ -164,7 +164,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:C-45-1912746692-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:C:67:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -147,9 +147,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >C</a
-		      > ()</span
+		    ><div id="control.i:ic:C-45-1912746692-45-1" class="instance expander" onclick="toggleSection('i:ic:C-45-1912746692-45-1')"
+		      ><a href=""
+			>C</a
+			> ()</div
+		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -158,6 +160,20 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 		    ><em
 		      >Since: 0.7.8</em
 		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:C-45-1912746692-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >c_f</a
+			  > :: ()</p
+			></div
+		      ></div
 		    ></td
 		  ></tr
 		></table

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -147,11 +147,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:C:67:1" class="instance expander" onclick="toggleSection('i:ic:C:67:1')"
-		      ><a href=""
-			>C</a
-			> ()</div
+		    ><span id="control.i:ic:C:C:1" class="instance expander" onclick="toggleSection('i:ic:C:C:1')"
 		      ></span
+		      > <a href=""
+		      >C</a
+		      > ()</span
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -164,7 +164,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:C:67:1" class="inst-details hide"
+		  ><div id="section.i:ic:C:C:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -106,7 +106,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Bar:1707333265:1" class="instance expander" onclick="toggleSection('i:id:Bar:1707333265:1')"
+		    ><div id="control.i:id:Bar:207865763473:1" class="instance expander" onclick="toggleSection('i:id:Bar:207865763473:1')"
 		      ><a href=""
 			>Bar</a
 			> <a href=""
@@ -123,7 +123,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Bar:1707333265:1" class="inst-details hide"
+		  ><div id="section.i:id:Bar:207865763473:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -150,7 +150,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Bar:1707333265:1" class="instance expander" onclick="toggleSection('i:ic:Bar:1707333265:1')"
+		    ><div id="control.i:ic:Bar:207865763473:1" class="instance expander" onclick="toggleSection('i:ic:Bar:207865763473:1')"
 		      ><a href=""
 			>Bar</a
 			> <a href=""
@@ -167,7 +167,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Bar:1707333265:1" class="inst-details hide"
+		  ><div id="section.i:ic:Bar:207865763473:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -106,7 +106,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Bar-45--45-1104323998-45-1" class="instance expander" onclick="toggleSection('i:id:Bar-45--45-1104323998-45-1')"
+		    ><div id="control.i:id:Bar:1707333265:1" class="instance expander" onclick="toggleSection('i:id:Bar:1707333265:1')"
 		      ><a href=""
 			>Bar</a
 			> <a href=""
@@ -123,7 +123,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Bar-45--45-1104323998-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Bar:1707333265:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -150,7 +150,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Bar-45--45-1104323998-45-1" class="instance expander" onclick="toggleSection('i:ic:Bar-45--45-1104323998-45-1')"
+		    ><div id="control.i:ic:Bar:1707333265:1" class="instance expander" onclick="toggleSection('i:ic:Bar:1707333265:1')"
 		      ><a href=""
 			>Bar</a
 			> <a href=""
@@ -167,7 +167,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Bar-45--45-1104323998-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:Bar:1707333265:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -106,14 +106,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Bar:207865763473:1" class="instance expander" onclick="toggleSection('i:id:Bar:207865763473:1')"
-		      ><a href=""
-			>Bar</a
-			> <a href=""
-			>Foo</a
-			> <a href=""
-			>Foo</a
-			></div
+		    ><span id="control.i:id:Foo:Bar:1" class="instance expander" onclick="toggleSection('i:id:Foo:Bar:1')"
+		      ></span
+		      > <a href=""
+		      >Bar</a
+		      > <a href=""
+		      >Foo</a
+		      > <a href=""
+		      >Foo</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -123,7 +123,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Bar:207865763473:1" class="inst-details hide"
+		  ><div id="section.i:id:Foo:Bar:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -150,14 +150,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Bar:207865763473:1" class="instance expander" onclick="toggleSection('i:ic:Bar:207865763473:1')"
-		      ><a href=""
-			>Bar</a
-			> <a href=""
-			>Foo</a
-			> <a href=""
-			>Foo</a
-			></div
+		    ><span id="control.i:ic:Bar:Bar:1" class="instance expander" onclick="toggleSection('i:ic:Bar:Bar:1')"
+		      ></span
+		      > <a href=""
+		      >Bar</a
+		      > <a href=""
+		      >Foo</a
+		      > <a href=""
+		      >Foo</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -167,7 +167,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Bar:207865763473:1" class="inst-details hide"
+		  ><div id="section.i:ic:Bar:Bar:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -106,17 +106,25 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Bar</a
-		      > <a href=""
-		      >Foo</a
-		      > <a href=""
-		      >Foo</a
+		    ><div id="control.i:id:Bar-45--45-1104323998-45-1" class="instance expander" onclick="toggleSection('i:id:Bar-45--45-1104323998-45-1')"
+		      ><a href=""
+			>Bar</a
+			> <a href=""
+			>Foo</a
+			> <a href=""
+			>Foo</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Just one instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Bar-45--45-1104323998-45-1" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table
@@ -142,17 +150,25 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Bar</a
-		      > <a href=""
-		      >Foo</a
-		      > <a href=""
-		      >Foo</a
+		    ><div id="control.i:ic:Bar-45--45-1104323998-45-1" class="instance expander" onclick="toggleSection('i:ic:Bar-45--45-1104323998-45-1')"
+		      ><a href=""
+			>Bar</a
+			> <a href=""
+			>Foo</a
+			> <a href=""
+			>Foo</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Just one instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Bar-45--45-1104323998-45-1" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -278,12 +278,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash:21988135:1" class="instance expander" onclick="toggleSection('i:ic:Hash:21988135:1')"
-		      ><a href=""
-			>Hash</a
-			> <a href=""
-			>Float</a
-			></div
+		    ><span id="control.i:ic:Hash:Hash:1" class="instance expander" onclick="toggleSection('i:ic:Hash:Hash:1')"
+		      ></span
+		      > <a href=""
+		      >Hash</a
+		      > <a href=""
+		      >Float</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -291,7 +291,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash:21988135:1" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:Hash:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -310,12 +310,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash:210564486212:2" class="instance expander" onclick="toggleSection('i:ic:Hash:210564486212:2')"
-		      ><a href=""
-			>Hash</a
-			> <a href=""
-			>Int</a
-			></div
+		    ><span id="control.i:ic:Hash:Hash:2" class="instance expander" onclick="toggleSection('i:ic:Hash:Hash:2')"
+		      ></span
+		      > <a href=""
+		      >Hash</a
+		      > <a href=""
+		      >Int</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -323,7 +323,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash:210564486212:2" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:Hash:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -342,22 +342,22 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash:6952216853681:3" class="instance expander" onclick="toggleSection('i:ic:Hash:6952216853681:3')"
-		      >(<a href=""
-			>Hash</a
-			> a, <a href=""
-			>Hash</a
-			> b) =&gt; <a href=""
-			>Hash</a
-			> (a, b)</div
+		    ><span id="control.i:ic:Hash:Hash:3" class="instance expander" onclick="toggleSection('i:ic:Hash:Hash:3')"
 		      ></span
+		      > (<a href=""
+		      >Hash</a
+		      > a, <a href=""
+		      >Hash</a
+		      > b) =&gt; <a href=""
+		      >Hash</a
+		      > (a, b)</span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash:6952216853681:3" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:Hash:3" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -310,7 +310,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash:111088708:2" class="instance expander" onclick="toggleSection('i:ic:Hash:111088708:2')"
+		    ><div id="control.i:ic:Hash:210564486212:2" class="instance expander" onclick="toggleSection('i:ic:Hash:210564486212:2')"
 		      ><a href=""
 			>Hash</a
 			> <a href=""
@@ -323,7 +323,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash:111088708:2" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:210564486212:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -342,7 +342,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash:-45-1335198543:3" class="instance expander" onclick="toggleSection('i:ic:Hash:-45-1335198543:3')"
+		    ><div id="control.i:ic:Hash:6952216853681:3" class="instance expander" onclick="toggleSection('i:ic:Hash:6952216853681:3')"
 		      >(<a href=""
 			>Hash</a
 			> a, <a href=""
@@ -357,7 +357,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash:-45-1335198543:3" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:6952216853681:3" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -278,7 +278,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash-45--45-2126105278-45-1" class="instance expander" onclick="toggleSection('i:ic:Hash-45--45-2126105278-45-1')"
+		    ><div id="control.i:ic:Hash:21988135:1" class="instance expander" onclick="toggleSection('i:ic:Hash:21988135:1')"
 		      ><a href=""
 			>Hash</a
 			> <a href=""
@@ -291,7 +291,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash-45--45-2126105278-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:21988135:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -310,7 +310,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash-45--45-2126105269-45-2" class="instance expander" onclick="toggleSection('i:ic:Hash-45--45-2126105269-45-2')"
+		    ><div id="control.i:ic:Hash:111088708:2" class="instance expander" onclick="toggleSection('i:ic:Hash:111088708:2')"
 		      ><a href=""
 			>Hash</a
 			> <a href=""
@@ -323,7 +323,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash-45--45-2126105269-45-2" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:111088708:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -342,7 +342,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Hash-45-1562016313-45-3" class="instance expander" onclick="toggleSection('i:ic:Hash-45-1562016313-45-3')"
+		    ><div id="control.i:ic:Hash:-45-1335198543:3" class="instance expander" onclick="toggleSection('i:ic:Hash:-45-1335198543:3')"
 		      >(<a href=""
 			>Hash</a
 			> a, <a href=""
@@ -357,7 +357,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Hash-45-1562016313-45-3" class="inst-details hide"
+		  ><div id="section.i:ic:Hash:-45-1335198543:3" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -278,40 +278,98 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Hash</a
-		      > <a href=""
-		      >Float</a
+		    ><div id="control.i:ic:Hash-45--45-2126105278-45-1" class="instance expander" onclick="toggleSection('i:ic:Hash-45--45-2126105278-45-1')"
+		      ><a href=""
+			>Hash</a
+			> <a href=""
+			>Float</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Hash-45--45-2126105278-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >hash</a
+			  > :: <a href=""
+			  >Float</a
+			  > -&gt; <a href=""
+			  >Int</a
+			  ></p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Hash</a
-		      > <a href=""
-		      >Int</a
+		    ><div id="control.i:ic:Hash-45--45-2126105269-45-2" class="instance expander" onclick="toggleSection('i:ic:Hash-45--45-2126105269-45-2')"
+		      ><a href=""
+			>Hash</a
+			> <a href=""
+			>Int</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Hash-45--45-2126105269-45-2" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >hash</a
+			  > :: <a href=""
+			  >Int</a
+			  > -&gt; <a href=""
+			  >Int</a
+			  ></p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    >(<a href=""
-		      >Hash</a
-		      > a, <a href=""
-		      >Hash</a
-		      > b) =&gt; <a href=""
-		      >Hash</a
-		      > (a, b)</span
+		    ><div id="control.i:ic:Hash-45-1562016313-45-3" class="instance expander" onclick="toggleSection('i:ic:Hash-45-1562016313-45-3')"
+		      >(<a href=""
+			>Hash</a
+			> a, <a href=""
+			>Hash</a
+			> b) =&gt; <a href=""
+			>Hash</a
+			> (a, b)</div
+		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Hash-45-1562016313-45-3" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >hash</a
+			  > :: (a, b) -&gt; <a href=""
+			  >Int</a
+			  ></p
+			></div
+		      ></div
+		    ></td
 		  ></tr
 		></table
 	      ></div

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -81,7 +81,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:VisibleClass:659775798:1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:659775798:1')"
+		    ><div id="control.i:ic:VisibleClass:9201309550724210998:1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:9201309550724210998:1')"
 		      ><a href=""
 			>VisibleClass</a
 			> <a href=""
@@ -96,14 +96,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:VisibleClass:659775798:1" class="inst-details hide"
+		  ><div id="section.i:ic:VisibleClass:9201309550724210998:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:VisibleClass:13734107:2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:13734107:2')"
+		    ><div id="control.i:ic:VisibleClass:13853490573166612699:2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:13853490573166612699:2')"
 		      ><a href=""
 			>VisibleClass</a
 			> <a href=""
@@ -118,7 +118,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:VisibleClass:13734107:2" class="inst-details hide"
+		  ><div id="section.i:ic:VisibleClass:13853490573166612699:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -145,7 +145,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Num:1345746733:1" class="instance expander" onclick="toggleSection('i:id:Num:1345746733:1')"
+		    ><div id="control.i:id:Num:13830803011052926765:1" class="instance expander" onclick="toggleSection('i:id:Num:13830803011052926765:1')"
 		      ><a href=""
 			>Num</a
 			> <a href=""
@@ -160,7 +160,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Num:1345746733:1" class="inst-details hide"
+		  ><div id="section.i:id:Num:13830803011052926765:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -233,7 +233,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:VisibleClass:13734107:2" class="instance expander" onclick="toggleSection('i:id:VisibleClass:13734107:2')"
+		    ><div id="control.i:id:VisibleClass:13853490573166612699:2" class="instance expander" onclick="toggleSection('i:id:VisibleClass:13853490573166612699:2')"
 		      ><a href=""
 			>VisibleClass</a
 			> <a href=""
@@ -248,7 +248,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:VisibleClass:13734107:2" class="inst-details hide"
+		  ><div id="section.i:id:VisibleClass:13853490573166612699:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -81,10 +81,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >VisibleClass</a
-		      > <a href=""
-		      >Int</a
+		    ><div id="control.i:ic:VisibleClass-45--45-2124522046-45-1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass-45--45-2124522046-45-1')"
+		      ><a href=""
+			>VisibleClass</a
+			> <a href=""
+			>Int</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -93,17 +95,31 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:VisibleClass-45--45-2124522046-45-1" class="inst-details hide"
+		    ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >VisibleClass</a
-		      > <a href=""
-		      >VisibleData</a
+		    ><div id="control.i:ic:VisibleClass-45--45-1067567935-45-2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass-45--45-1067567935-45-2')"
+		      ><a href=""
+			>VisibleClass</a
+			> <a href=""
+			>VisibleData</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Should be visible</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:VisibleClass-45--45-1067567935-45-2" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table
@@ -129,10 +145,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Num</a
-		      > <a href=""
-		      >VisibleData</a
+		    ><div id="control.i:id:Num-45-5833280-45-1" class="instance expander" onclick="toggleSection('i:id:Num-45-5833280-45-1')"
+		      ><a href=""
+			>Num</a
+			> <a href=""
+			>VisibleData</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -141,17 +159,97 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Num-45-5833280-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >(+)</a
+			  > :: <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >(-)</a
+			  > :: <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >(*)</a
+			  > :: <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >negate</a
+			  > :: <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >abs</a
+			  > :: <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >signum</a
+			  > :: <a href=""
+			  >VisibleData</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >fromInteger</a
+			  > :: <a href=""
+			  >Integer</a
+			  > -&gt; <a href=""
+			  >VisibleData</a
+			  ></p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >VisibleClass</a
-		      > <a href=""
-		      >VisibleData</a
+		    ><div id="control.i:id:VisibleClass-45--45-1067567935-45-2" class="instance expander" onclick="toggleSection('i:id:VisibleClass-45--45-1067567935-45-2')"
+		      ><a href=""
+			>VisibleClass</a
+			> <a href=""
+			>VisibleData</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Should be visible</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:VisibleClass-45--45-1067567935-45-2" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -81,12 +81,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:VisibleClass:9201309550724210998:1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:9201309550724210998:1')"
-		      ><a href=""
-			>VisibleClass</a
-			> <a href=""
-			>Int</a
-			></div
+		    ><span id="control.i:ic:VisibleClass:VisibleClass:1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:VisibleClass:1')"
+		      ></span
+		      > <a href=""
+		      >VisibleClass</a
+		      > <a href=""
+		      >Int</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -96,19 +96,19 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:VisibleClass:9201309550724210998:1" class="inst-details hide"
+		  ><div id="section.i:ic:VisibleClass:VisibleClass:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:VisibleClass:13853490573166612699:2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:13853490573166612699:2')"
-		      ><a href=""
-			>VisibleClass</a
-			> <a href=""
-			>VisibleData</a
-			></div
+		    ><span id="control.i:ic:VisibleClass:VisibleClass:2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:VisibleClass:2')"
+		      ></span
+		      > <a href=""
+		      >VisibleClass</a
+		      > <a href=""
+		      >VisibleData</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -118,7 +118,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:VisibleClass:13853490573166612699:2" class="inst-details hide"
+		  ><div id="section.i:ic:VisibleClass:VisibleClass:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -145,12 +145,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Num:13830803011052926765:1" class="instance expander" onclick="toggleSection('i:id:Num:13830803011052926765:1')"
-		      ><a href=""
-			>Num</a
-			> <a href=""
-			>VisibleData</a
-			></div
+		    ><span id="control.i:id:VisibleData:Num:1" class="instance expander" onclick="toggleSection('i:id:VisibleData:Num:1')"
+		      ></span
+		      > <a href=""
+		      >Num</a
+		      > <a href=""
+		      >VisibleData</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -160,7 +160,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Num:13830803011052926765:1" class="inst-details hide"
+		  ><div id="section.i:id:VisibleData:Num:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -233,12 +233,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:VisibleClass:13853490573166612699:2" class="instance expander" onclick="toggleSection('i:id:VisibleClass:13853490573166612699:2')"
-		      ><a href=""
-			>VisibleClass</a
-			> <a href=""
-			>VisibleData</a
-			></div
+		    ><span id="control.i:id:VisibleData:VisibleClass:2" class="instance expander" onclick="toggleSection('i:id:VisibleData:VisibleClass:2')"
+		      ></span
+		      > <a href=""
+		      >VisibleClass</a
+		      > <a href=""
+		      >VisibleData</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -248,7 +248,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:VisibleClass:13853490573166612699:2" class="inst-details hide"
+		  ><div id="section.i:id:VisibleData:VisibleClass:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -81,7 +81,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:VisibleClass-45--45-2124522046-45-1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass-45--45-2124522046-45-1')"
+		    ><div id="control.i:ic:VisibleClass:659775798:1" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:659775798:1')"
 		      ><a href=""
 			>VisibleClass</a
 			> <a href=""
@@ -96,14 +96,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:VisibleClass-45--45-2124522046-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:VisibleClass:659775798:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:VisibleClass-45--45-1067567935-45-2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass-45--45-1067567935-45-2')"
+		    ><div id="control.i:ic:VisibleClass:13734107:2" class="instance expander" onclick="toggleSection('i:ic:VisibleClass:13734107:2')"
 		      ><a href=""
 			>VisibleClass</a
 			> <a href=""
@@ -118,7 +118,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:VisibleClass-45--45-1067567935-45-2" class="inst-details hide"
+		  ><div id="section.i:ic:VisibleClass:13734107:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -145,7 +145,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Num-45-5833280-45-1" class="instance expander" onclick="toggleSection('i:id:Num-45-5833280-45-1')"
+		    ><div id="control.i:id:Num:1345746733:1" class="instance expander" onclick="toggleSection('i:id:Num:1345746733:1')"
 		      ><a href=""
 			>Num</a
 			> <a href=""
@@ -160,7 +160,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Num-45-5833280-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Num:1345746733:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -233,7 +233,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:VisibleClass-45--45-1067567935-45-2" class="instance expander" onclick="toggleSection('i:id:VisibleClass-45--45-1067567935-45-2')"
+		    ><div id="control.i:id:VisibleClass:13734107:2" class="instance expander" onclick="toggleSection('i:id:VisibleClass:13734107:2')"
 		      ><a href=""
 			>VisibleClass</a
 			> <a href=""
@@ -248,7 +248,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:VisibleClass-45--45-1067567935-45-2" class="inst-details hide"
+		  ><div id="section.i:id:VisibleClass:13734107:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -81,7 +81,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Foo-45--45-1068927686-45-1" class="instance expander" onclick="toggleSection('i:ic:Foo-45--45-1068927686-45-1')"
+		    ><div id="control.i:ic:Foo:2007140402:1" class="instance expander" onclick="toggleSection('i:ic:Foo:2007140402:1')"
 		      ><a href=""
 			>Foo</a
 			> <a href=""
@@ -96,7 +96,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Foo-45--45-1068927686-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:Foo:2007140402:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -123,7 +123,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Foo-45--45-1068927686-45-1" class="instance expander" onclick="toggleSection('i:id:Foo-45--45-1068927686-45-1')"
+		    ><div id="control.i:id:Foo:2007140402:1" class="instance expander" onclick="toggleSection('i:id:Foo:2007140402:1')"
 		      ><a href=""
 			>Foo</a
 			> <a href=""
@@ -138,7 +138,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Foo-45--45-1068927686-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Foo:2007140402:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -81,15 +81,23 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Foo</a
-		      > <a href=""
-		      >Bar</a
+		    ><div id="control.i:ic:Foo-45--45-1068927686-45-1" class="instance expander" onclick="toggleSection('i:ic:Foo-45--45-1068927686-45-1')"
+		      ><a href=""
+			>Foo</a
+			> <a href=""
+			>Bar</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Should be visible</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Foo-45--45-1068927686-45-1" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table
@@ -115,15 +123,23 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Foo</a
-		      > <a href=""
-		      >Bar</a
+		    ><div id="control.i:id:Foo-45--45-1068927686-45-1" class="instance expander" onclick="toggleSection('i:id:Foo-45--45-1068927686-45-1')"
+		      ><a href=""
+			>Foo</a
+			> <a href=""
+			>Bar</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Should be visible</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Foo-45--45-1068927686-45-1" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -81,7 +81,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Foo:2007140402:1" class="instance expander" onclick="toggleSection('i:ic:Foo:2007140402:1')"
+		    ><div id="control.i:ic:Foo:6302107698:1" class="instance expander" onclick="toggleSection('i:ic:Foo:6302107698:1')"
 		      ><a href=""
 			>Foo</a
 			> <a href=""
@@ -96,7 +96,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Foo:2007140402:1" class="inst-details hide"
+		  ><div id="section.i:ic:Foo:6302107698:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -123,7 +123,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Foo:2007140402:1" class="instance expander" onclick="toggleSection('i:id:Foo:2007140402:1')"
+		    ><div id="control.i:id:Foo:6302107698:1" class="instance expander" onclick="toggleSection('i:id:Foo:6302107698:1')"
 		      ><a href=""
 			>Foo</a
 			> <a href=""
@@ -138,7 +138,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Foo:2007140402:1" class="inst-details hide"
+		  ><div id="section.i:id:Foo:6302107698:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -81,12 +81,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Foo:6302107698:1" class="instance expander" onclick="toggleSection('i:ic:Foo:6302107698:1')"
-		      ><a href=""
-			>Foo</a
-			> <a href=""
-			>Bar</a
-			></div
+		    ><span id="control.i:ic:Foo:Foo:1" class="instance expander" onclick="toggleSection('i:ic:Foo:Foo:1')"
+		      ></span
+		      > <a href=""
+		      >Foo</a
+		      > <a href=""
+		      >Bar</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -96,7 +96,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Foo:6302107698:1" class="inst-details hide"
+		  ><div id="section.i:ic:Foo:Foo:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -123,12 +123,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Foo:6302107698:1" class="instance expander" onclick="toggleSection('i:id:Foo:6302107698:1')"
-		      ><a href=""
-			>Foo</a
-			> <a href=""
-			>Bar</a
-			></div
+		    ><span id="control.i:id:Bar:Foo:1" class="instance expander" onclick="toggleSection('i:id:Bar:Foo:1')"
+		      ></span
+		      > <a href=""
+		      >Foo</a
+		      > <a href=""
+		      >Bar</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -138,7 +138,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Foo:6302107698:1" class="inst-details hide"
+		  ><div id="section.i:id:Bar:Foo:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -109,14 +109,52 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Show</a
-		      > <a href=""
-		      >Expr</a
+		    ><div id="control.i:id:Show-45-5839412-45-1" class="instance expander" onclick="toggleSection('i:id:Show-45-5839412-45-1')"
+		      ><a href=""
+			>Show</a
+			> <a href=""
+			>Expr</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Show-45-5839412-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >showsPrec</a
+			  > :: <a href=""
+			  >Int</a
+			  > -&gt; <a href=""
+			  >Expr</a
+			  > -&gt; <a href=""
+			  >ShowS</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >show</a
+			  > :: <a href=""
+			  >Expr</a
+			  > -&gt; <a href=""
+			  >String</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >showList</a
+			  > :: [<a href=""
+			  >Expr</a
+			  >] -&gt; <a href=""
+			  >ShowS</a
+			  ></p
+			></div
+		      ></div
+		    ></td
 		  ></tr
 		></table
 	      ></div
@@ -175,14 +213,52 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Show</a
-		      > <a href=""
-		      >BinOp</a
+		    ><div id="control.i:id:Show-45-5839300-45-1" class="instance expander" onclick="toggleSection('i:id:Show-45-5839300-45-1')"
+		      ><a href=""
+			>Show</a
+			> <a href=""
+			>BinOp</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Show-45-5839300-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >showsPrec</a
+			  > :: <a href=""
+			  >Int</a
+			  > -&gt; <a href=""
+			  >BinOp</a
+			  > -&gt; <a href=""
+			  >ShowS</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >show</a
+			  > :: <a href=""
+			  >BinOp</a
+			  > -&gt; <a href=""
+			  >String</a
+			  ></p
+			><p class="src"
+			><a href=""
+			  >showList</a
+			  > :: [<a href=""
+			  >BinOp</a
+			  >] -&gt; <a href=""
+			  >ShowS</a
+			  ></p
+			></div
+		      ></div
+		    ></td
 		  ></tr
 		></table
 	      ></div

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -109,7 +109,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Show:1911009977:1" class="instance expander" onclick="toggleSection('i:id:Show:1911009977:1')"
+		    ><div id="control.i:id:Show:208069440185:1" class="instance expander" onclick="toggleSection('i:id:Show:208069440185:1')"
 		      ><a href=""
 			>Show</a
 			> <a href=""
@@ -122,7 +122,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Show:1911009977:1" class="inst-details hide"
+		  ><div id="section.i:id:Show:208069440185:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -109,12 +109,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Show:208069440185:1" class="instance expander" onclick="toggleSection('i:id:Show:208069440185:1')"
-		      ><a href=""
-			>Show</a
-			> <a href=""
-			>Expr</a
-			></div
+		    ><span id="control.i:id:Expr:Show:1" class="instance expander" onclick="toggleSection('i:id:Expr:Show:1')"
+		      ></span
+		      > <a href=""
+		      >Show</a
+		      > <a href=""
+		      >Expr</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -122,7 +122,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Show:208069440185:1" class="inst-details hide"
+		  ><div id="section.i:id:Expr:Show:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -213,12 +213,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Show:16916860:1" class="instance expander" onclick="toggleSection('i:id:Show:16916860:1')"
-		      ><a href=""
-			>Show</a
-			> <a href=""
-			>BinOp</a
-			></div
+		    ><span id="control.i:id:BinOp:Show:1" class="instance expander" onclick="toggleSection('i:id:BinOp:Show:1')"
+		      ></span
+		      > <a href=""
+		      >Show</a
+		      > <a href=""
+		      >BinOp</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -226,7 +226,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Show:16916860:1" class="inst-details hide"
+		  ><div id="section.i:id:BinOp:Show:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -109,7 +109,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Show-45-5839412-45-1" class="instance expander" onclick="toggleSection('i:id:Show-45-5839412-45-1')"
+		    ><div id="control.i:id:Show:1911009977:1" class="instance expander" onclick="toggleSection('i:id:Show:1911009977:1')"
 		      ><a href=""
 			>Show</a
 			> <a href=""
@@ -122,7 +122,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Show-45-5839412-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Show:1911009977:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -213,7 +213,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Show-45-5839300-45-1" class="instance expander" onclick="toggleSection('i:id:Show-45-5839300-45-1')"
+		    ><div id="control.i:id:Show:16916860:1" class="instance expander" onclick="toggleSection('i:id:Show:16916860:1')"
 		      ><a href=""
 			>Show</a
 			> <a href=""
@@ -226,7 +226,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Show-45-5839300-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Show:16916860:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -85,7 +85,7 @@ Fix spurious superclass constraints bug.</pre
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Functor-45-1786401847-45-1" class="instance expander" onclick="toggleSection('i:id:Functor-45-1786401847-45-1')"
+		    ><div id="control.i:id:Functor:-45-1648444259:1" class="instance expander" onclick="toggleSection('i:id:Functor:-45-1648444259:1')"
 		      ><a href=""
 			>Functor</a
 			> (<a href=""
@@ -98,7 +98,7 @@ Fix spurious superclass constraints bug.</pre
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Functor-45-1786401847-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Functor:-45-1648444259:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -125,7 +125,7 @@ Fix spurious superclass constraints bug.</pre
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Applicative-45-1786377800-45-2" class="instance expander" onclick="toggleSection('i:id:Applicative-45-1786377800-45-2')"
+		    ><div id="control.i:id:Applicative:-45-1896307582:2" class="instance expander" onclick="toggleSection('i:id:Applicative:-45-1896307582:2')"
 		      ><a href=""
 			>Applicative</a
 			> f =&gt; <a href=""
@@ -140,7 +140,7 @@ Fix spurious superclass constraints bug.</pre
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Applicative-45-1786377800-45-2" class="inst-details hide"
+		  ><div id="section.i:id:Applicative:-45-1896307582:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -85,7 +85,7 @@ Fix spurious superclass constraints bug.</pre
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Functor:-45-1648444259:1" class="instance expander" onclick="toggleSection('i:id:Functor:-45-1648444259:1')"
+		    ><div id="control.i:id:Functor:125458641239197:1" class="instance expander" onclick="toggleSection('i:id:Functor:125458641239197:1')"
 		      ><a href=""
 			>Functor</a
 			> (<a href=""
@@ -98,7 +98,7 @@ Fix spurious superclass constraints bug.</pre
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Functor:-45-1648444259:1" class="inst-details hide"
+		  ><div id="section.i:id:Functor:125458641239197:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -125,7 +125,7 @@ Fix spurious superclass constraints bug.</pre
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Applicative:-45-1896307582:2" class="instance expander" onclick="toggleSection('i:id:Applicative:-45-1896307582:2')"
+		    ><div id="control.i:id:Applicative:18341860631142507650:2" class="instance expander" onclick="toggleSection('i:id:Applicative:18341860631142507650:2')"
 		      ><a href=""
 			>Applicative</a
 			> f =&gt; <a href=""
@@ -140,7 +140,7 @@ Fix spurious superclass constraints bug.</pre
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Applicative:-45-1896307582:2" class="inst-details hide"
+		  ><div id="section.i:id:Applicative:18341860631142507650:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -85,28 +85,104 @@ Fix spurious superclass constraints bug.</pre
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Functor</a
-		      > (<a href=""
-		      >SomeType</a
-		      > f)</span
+		    ><div id="control.i:id:Functor-45-1786401847-45-1" class="instance expander" onclick="toggleSection('i:id:Functor-45-1786401847-45-1')"
+		      ><a href=""
+			>Functor</a
+			> (<a href=""
+			>SomeType</a
+			> f)</div
+		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Functor-45-1786401847-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >fmap</a
+			  > :: (a -&gt; b) -&gt; <a href=""
+			  >SomeType</a
+			  > f a -&gt; <a href=""
+			  >SomeType</a
+			  > f b</p
+			><p class="src"
+			><a href=""
+			  >(&lt;$)</a
+			  > :: a -&gt; <a href=""
+			  >SomeType</a
+			  > f b -&gt; <a href=""
+			  >SomeType</a
+			  > f a</p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Applicative</a
-		      > f =&gt; <a href=""
-		      >Applicative</a
-		      > (<a href=""
-		      >SomeType</a
-		      > f)</span
+		    ><div id="control.i:id:Applicative-45-1786377800-45-2" class="instance expander" onclick="toggleSection('i:id:Applicative-45-1786377800-45-2')"
+		      ><a href=""
+			>Applicative</a
+			> f =&gt; <a href=""
+			>Applicative</a
+			> (<a href=""
+			>SomeType</a
+			> f)</div
+		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Applicative-45-1786377800-45-2" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >pure</a
+			  > :: a -&gt; <a href=""
+			  >SomeType</a
+			  > f a</p
+			><p class="src"
+			><a href=""
+			  >(&lt;*&gt;)</a
+			  > :: <a href=""
+			  >SomeType</a
+			  > f (a -&gt; b) -&gt; <a href=""
+			  >SomeType</a
+			  > f a -&gt; <a href=""
+			  >SomeType</a
+			  > f b</p
+			><p class="src"
+			><a href=""
+			  >(*&gt;)</a
+			  > :: <a href=""
+			  >SomeType</a
+			  > f a -&gt; <a href=""
+			  >SomeType</a
+			  > f b -&gt; <a href=""
+			  >SomeType</a
+			  > f b</p
+			><p class="src"
+			><a href=""
+			  >(&lt;*)</a
+			  > :: <a href=""
+			  >SomeType</a
+			  > f a -&gt; <a href=""
+			  >SomeType</a
+			  > f b -&gt; <a href=""
+			  >SomeType</a
+			  > f a</p
+			></div
+		      ></div
+		    ></td
 		  ></tr
 		></table
 	      ></div

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -85,20 +85,20 @@ Fix spurious superclass constraints bug.</pre
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Functor:125458641239197:1" class="instance expander" onclick="toggleSection('i:id:Functor:125458641239197:1')"
-		      ><a href=""
-			>Functor</a
-			> (<a href=""
-			>SomeType</a
-			> f)</div
+		    ><span id="control.i:id:SomeType:Functor:1" class="instance expander" onclick="toggleSection('i:id:SomeType:Functor:1')"
 		      ></span
+		      > <a href=""
+		      >Functor</a
+		      > (<a href=""
+		      >SomeType</a
+		      > f)</span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Functor:125458641239197:1" class="inst-details hide"
+		  ><div id="section.i:id:SomeType:Functor:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -125,22 +125,22 @@ Fix spurious superclass constraints bug.</pre
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Applicative:18341860631142507650:2" class="instance expander" onclick="toggleSection('i:id:Applicative:18341860631142507650:2')"
-		      ><a href=""
-			>Applicative</a
-			> f =&gt; <a href=""
-			>Applicative</a
-			> (<a href=""
-			>SomeType</a
-			> f)</div
+		    ><span id="control.i:id:SomeType:Applicative:2" class="instance expander" onclick="toggleSection('i:id:SomeType:Applicative:2')"
 		      ></span
+		      > <a href=""
+		      >Applicative</a
+		      > f =&gt; <a href=""
+		      >Applicative</a
+		      > (<a href=""
+		      >SomeType</a
+		      > f)</span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Applicative:18341860631142507650:2" class="inst-details hide"
+		  ><div id="section.i:id:SomeType:Applicative:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -1531,7 +1531,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:D:207047825:1" class="instance expander" onclick="toggleSection('i:ic:D:207047825:1')"
+		    ><div id="control.i:ic:D:210660445329:1" class="instance expander" onclick="toggleSection('i:ic:D:210660445329:1')"
 		      ><a href=""
 			>D</a
 			> <a href=""
@@ -1544,7 +1544,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:D:207047825:1" class="inst-details hide"
+		  ><div id="section.i:ic:D:210660445329:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -1531,7 +1531,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:D-45--45-2126042836-45-1" class="instance expander" onclick="toggleSection('i:ic:D-45--45-2126042836-45-1')"
+		    ><div id="control.i:ic:D:207047825:1" class="instance expander" onclick="toggleSection('i:ic:D:207047825:1')"
 		      ><a href=""
 			>D</a
 			> <a href=""
@@ -1544,7 +1544,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:D-45--45-2126042836-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:D:207047825:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -1571,7 +1571,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:D-45--45-2126042843-45-2" class="instance expander" onclick="toggleSection('i:ic:D-45--45-2126042843-45-2')"
+		    ><div id="control.i:ic:D:193453042:2" class="instance expander" onclick="toggleSection('i:ic:D:193453042:2')"
 		      ><a href=""
 			>D</a
 			> <a href=""
@@ -1584,7 +1584,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:D-45--45-2126042843-45-2" class="inst-details hide"
+		  ><div id="section.i:ic:D:193453042:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -1531,12 +1531,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:D:210660445329:1" class="instance expander" onclick="toggleSection('i:ic:D:210660445329:1')"
-		      ><a href=""
-			>D</a
-			> <a href=""
-			>Float</a
-			></div
+		    ><span id="control.i:ic:D:D:1" class="instance expander" onclick="toggleSection('i:ic:D:D:1')"
+		      ></span
+		      > <a href=""
+		      >D</a
+		      > <a href=""
+		      >Float</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -1544,7 +1544,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:D:210660445329:1" class="inst-details hide"
+		  ><div id="section.i:ic:D:D:1" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
@@ -1571,12 +1571,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:D:193453042:2" class="instance expander" onclick="toggleSection('i:ic:D:193453042:2')"
-		      ><a href=""
-			>D</a
-			> <a href=""
-			>Int</a
-			></div
+		    ><span id="control.i:ic:D:D:2" class="instance expander" onclick="toggleSection('i:ic:D:D:2')"
+		      ></span
+		      > <a href=""
+		      >D</a
+		      > <a href=""
+		      >Int</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -1584,7 +1584,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:D:193453042:2" class="inst-details hide"
+		  ><div id="section.i:ic:D:D:2" class="inst-details hide"
 		    ><div class="subs methods"
 		      ><p class="caption"
 			>Methods</p

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -1531,26 +1531,82 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >D</a
-		      > <a href=""
-		      >Float</a
+		    ><div id="control.i:ic:D-45--45-2126042836-45-1" class="instance expander" onclick="toggleSection('i:ic:D-45--45-2126042836-45-1')"
+		      ><a href=""
+			>D</a
+			> <a href=""
+			>Float</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:D-45--45-2126042836-45-1" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >d</a
+			  > :: <a href=""
+			  >T</a
+			  > <a href=""
+			  >Float</a
+			  > b</p
+			><p class="src"
+			><a href=""
+			  >e</a
+			  > :: (<a href=""
+			  >Float</a
+			  >, <a href=""
+			  >Float</a
+			  >)</p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >D</a
-		      > <a href=""
-		      >Int</a
+		    ><div id="control.i:ic:D-45--45-2126042843-45-2" class="instance expander" onclick="toggleSection('i:ic:D-45--45-2126042843-45-2')"
+		      ><a href=""
+			>D</a
+			> <a href=""
+			>Int</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:D-45--45-2126042843-45-2" class="inst-details hide"
+		    ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href=""
+			  >d</a
+			  > :: <a href=""
+			  >T</a
+			  > <a href=""
+			  >Int</a
+			  > b</p
+			><p class="src"
+			><a href=""
+			  >e</a
+			  > :: (<a href=""
+			  >Int</a
+			  >, <a href=""
+			  >Int</a
+			  >)</p
+			></div
+		      ></div
+		    ></td
 		  ></tr
 		></table
 	      ></div

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -213,7 +213,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Assoc-45--45-94738534-45-1" class="instance expander" onclick="toggleSection('i:id:Assoc-45--45-94738534-45-1')"
+		    ><div id="control.i:id:Assoc:784462559:1" class="instance expander" onclick="toggleSection('i:id:Assoc:784462559:1')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -228,7 +228,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Assoc-45--45-94738534-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Assoc:784462559:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -255,7 +255,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Test-45--45-94757499-45-2" class="instance expander" onclick="toggleSection('i:id:Test-45--45-94757499-45-2')"
+		    ><div id="control.i:id:Test:-45-897274780:2" class="instance expander" onclick="toggleSection('i:id:Test:-45-897274780:2')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -270,14 +270,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Test-45--45-94757499-45-2" class="inst-details hide"
+		  ><div id="section.i:id:Test:-45-897274780:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:-62--60--45-1434405301-45-3" class="instance expander" onclick="toggleSection('i:id:-62--60--45-1434405301-45-3')"
+		    ><div id="control.i:id:-62--60-:1404642119:3" class="instance expander" onclick="toggleSection('i:id:-62--60-:1404642119:3')"
 		      ><a href=""
 			>(&gt;&lt;)</a
 			> <a href=""
@@ -294,7 +294,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:-62--60--45-1434405301-45-3" class="inst-details hide"
+		  ><div id="section.i:id:-62--60-:1404642119:3" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -469,7 +469,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Assoc-45--45-94738565-45-1" class="instance expander" onclick="toggleSection('i:id:Assoc-45--45-94738565-45-1')"
+		    ><div id="control.i:id:Assoc:784462590:1" class="instance expander" onclick="toggleSection('i:id:Assoc:784462590:1')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -484,7 +484,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Assoc-45--45-94738565-45-1" class="inst-details hide"
+		  ><div id="section.i:id:Assoc:784462590:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -511,7 +511,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Test-45--45-94757468-45-2" class="instance expander" onclick="toggleSection('i:id:Test-45--45-94757468-45-2')"
+		    ><div id="control.i:id:Test:-45-897274811:2" class="instance expander" onclick="toggleSection('i:id:Test:-45-897274811:2')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -526,7 +526,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Test-45--45-94757468-45-2" class="inst-details hide"
+		  ><div id="section.i:id:Test:-45-897274811:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -751,7 +751,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Test-45--45-94757468-45-1" class="instance expander" onclick="toggleSection('i:ic:Test-45--45-94757468-45-1')"
+		    ><div id="control.i:ic:Test:-45-897274811:1" class="instance expander" onclick="toggleSection('i:ic:Test:-45-897274811:1')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -766,14 +766,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Test-45--45-94757468-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:Test:-45-897274811:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Test-45--45-94757499-45-2" class="instance expander" onclick="toggleSection('i:ic:Test-45--45-94757499-45-2')"
+		    ><div id="control.i:ic:Test:-45-897274780:2" class="instance expander" onclick="toggleSection('i:ic:Test:-45-897274780:2')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -788,7 +788,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Test-45--45-94757499-45-2" class="inst-details hide"
+		  ><div id="section.i:ic:Test:-45-897274780:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -1033,7 +1033,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Assoc-45--45-94738565-45-1" class="instance expander" onclick="toggleSection('i:ic:Assoc-45--45-94738565-45-1')"
+		    ><div id="control.i:ic:Assoc:784462590:1" class="instance expander" onclick="toggleSection('i:ic:Assoc:784462590:1')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -1048,7 +1048,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Assoc-45--45-94738565-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:Assoc:784462590:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -1075,7 +1075,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Assoc-45--45-94738534-45-2" class="instance expander" onclick="toggleSection('i:ic:Assoc-45--45-94738534-45-2')"
+		    ><div id="control.i:ic:Assoc:784462559:2" class="instance expander" onclick="toggleSection('i:ic:Assoc:784462559:2')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -1090,7 +1090,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Assoc-45--45-94738534-45-2" class="inst-details hide"
+		  ><div id="section.i:ic:Assoc:784462559:2" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -1239,7 +1239,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:-62--60--45-1434405301-45-1" class="instance expander" onclick="toggleSection('i:ic:-62--60--45-1434405301-45-1')"
+		    ><div id="control.i:ic:-62--60-:1404642119:1" class="instance expander" onclick="toggleSection('i:ic:-62--60-:1404642119:1')"
 		      ><a href=""
 			>(&gt;&lt;)</a
 			> <a href=""
@@ -1256,7 +1256,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:-62--60--45-1434405301-45-1" class="inst-details hide"
+		  ><div id="section.i:ic:-62--60-:1404642119:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -213,10 +213,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Assoc</a
-		      > * <a href=""
-		      >X</a
+		    ><div id="control.i:id:Assoc-45--45-94738534-45-1" class="instance expander" onclick="toggleSection('i:id:Assoc-45--45-94738534-45-1')"
+		      ><a href=""
+			>Assoc</a
+			> * <a href=""
+			>X</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -225,12 +227,40 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Assoc-45--45-94738534-45-1" class="inst-details hide"
+		    ><div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >data</span
+			  > <a href=""
+			  >AssocD</a
+			  > (<a href=""
+			  >X</a
+			  > :: k)</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href=""
+			  >AssocT</a
+			  > (<a href=""
+			  >X</a
+			  > :: k) :: *</p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Test</a
-		      > * <a href=""
-		      >X</a
+		    ><div id="control.i:id:Test-45--45-94757499-45-2" class="instance expander" onclick="toggleSection('i:id:Test-45--45-94757499-45-2')"
+		      ><a href=""
+			>Test</a
+			> * <a href=""
+			>X</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -239,20 +269,34 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Test-45--45-94757499-45-2" class="inst-details hide"
+		    ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >(&gt;&lt;)</a
-		      > <a href=""
-		      >X</a
-		      > <a href=""
-		      >XX</a
-		      > <a href=""
-		      >XXX</a
+		    ><div id="control.i:id:-62--60--45-1434405301-45-3" class="instance expander" onclick="toggleSection('i:id:-62--60--45-1434405301-45-3')"
+		      ><a href=""
+			>(&gt;&lt;)</a
+			> <a href=""
+			>X</a
+			> <a href=""
+			>XX</a
+			> <a href=""
+			>XXX</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:-62--60--45-1434405301-45-3" class="inst-details hide"
+		    ></div
+		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
@@ -425,10 +469,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Assoc</a
-		      > * <a href=""
-		      >Y</a
+		    ><div id="control.i:id:Assoc-45--45-94738565-45-1" class="instance expander" onclick="toggleSection('i:id:Assoc-45--45-94738565-45-1')"
+		      ><a href=""
+			>Assoc</a
+			> * <a href=""
+			>Y</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -437,17 +483,51 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Assoc-45--45-94738565-45-1" class="inst-details hide"
+		    ><div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >data</span
+			  > <a href=""
+			  >AssocD</a
+			  > (<a href=""
+			  >Y</a
+			  > :: k)</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href=""
+			  >AssocT</a
+			  > (<a href=""
+			  >Y</a
+			  > :: k) :: *</p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Test</a
-		      > * <a href=""
-		      >Y</a
+		    ><div id="control.i:id:Test-45--45-94757468-45-2" class="instance expander" onclick="toggleSection('i:id:Test-45--45-94757468-45-2')"
+		      ><a href=""
+			>Test</a
+			> * <a href=""
+			>Y</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Doc for: instance Test Y</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:id:Test-45--45-94757468-45-2" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		><tr
@@ -671,10 +751,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Test</a
-		      > * <a href=""
-		      >Y</a
+		    ><div id="control.i:ic:Test-45--45-94757468-45-1" class="instance expander" onclick="toggleSection('i:ic:Test-45--45-94757468-45-1')"
+		      ><a href=""
+			>Test</a
+			> * <a href=""
+			>Y</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -683,17 +765,31 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Test-45--45-94757468-45-1" class="inst-details hide"
+		    ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Test</a
-		      > * <a href=""
-		      >X</a
+		    ><div id="control.i:ic:Test-45--45-94757499-45-2" class="instance expander" onclick="toggleSection('i:ic:Test-45--45-94757499-45-2')"
+		      ><a href=""
+			>Test</a
+			> * <a href=""
+			>X</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Doc for: instance Test X</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Test-45--45-94757499-45-2" class="inst-details hide"
+		    ></div
 		    ></td
 		  ></tr
 		></table
@@ -937,10 +1033,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Assoc</a
-		      > * <a href=""
-		      >Y</a
+		    ><div id="control.i:ic:Assoc-45--45-94738565-45-1" class="instance expander" onclick="toggleSection('i:ic:Assoc-45--45-94738565-45-1')"
+		      ><a href=""
+			>Assoc</a
+			> * <a href=""
+			>Y</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -949,17 +1047,71 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		    ></td
 		  ></tr
 		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Assoc-45--45-94738565-45-1" class="inst-details hide"
+		    ><div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >data</span
+			  > <a href=""
+			  >AssocD</a
+			  > (<a href=""
+			  >Y</a
+			  > :: k)</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href=""
+			  >AssocT</a
+			  > (<a href=""
+			  >Y</a
+			  > :: k) :: *</p
+			></div
+		      ></div
+		    ></td
+		  ></tr
+		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >Assoc</a
-		      > * <a href=""
-		      >X</a
+		    ><div id="control.i:ic:Assoc-45--45-94738534-45-2" class="instance expander" onclick="toggleSection('i:ic:Assoc-45--45-94738534-45-2')"
+		      ><a href=""
+			>Assoc</a
+			> * <a href=""
+			>X</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc"
 		  ><p
 		    >Doc for: instance Assoc X</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:Assoc-45--45-94738534-45-2" class="inst-details hide"
+		    ><div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >data</span
+			  > <a href=""
+			  >AssocD</a
+			  > (<a href=""
+			  >X</a
+			  > :: k)</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href=""
+			  >AssocT</a
+			  > (<a href=""
+			  >X</a
+			  > :: k) :: *</p
+			></div
+		      ></div
 		    ></td
 		  ></tr
 		></table
@@ -1087,18 +1239,26 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><a href=""
-		      >(&gt;&lt;)</a
-		      > <a href=""
-		      >X</a
-		      > <a href=""
-		      >XX</a
-		      > <a href=""
-		      >XXX</a
+		    ><div id="control.i:ic:-62--60--45-1434405301-45-1" class="instance expander" onclick="toggleSection('i:ic:-62--60--45-1434405301-45-1')"
+		      ><a href=""
+			>(&gt;&lt;)</a
+			> <a href=""
+			>X</a
+			> <a href=""
+			>XX</a
+			> <a href=""
+			>XXX</a
+			></div
 		      ></span
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><div id="section.i:ic:-62--60--45-1434405301-45-1" class="inst-details hide"
+		    ></div
+		    ></td
 		  ></tr
 		></table
 	      ></div

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -213,7 +213,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Assoc:784462559:1" class="instance expander" onclick="toggleSection('i:id:Assoc:784462559:1')"
+		    ><div id="control.i:id:Assoc:229407872643807:1" class="instance expander" onclick="toggleSection('i:id:Assoc:229407872643807:1')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -228,7 +228,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Assoc:784462559:1" class="inst-details hide"
+		  ><div id="section.i:id:Assoc:229407872643807:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -255,7 +255,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Test:-45-897274780:2" class="instance expander" onclick="toggleSection('i:id:Test:-45-897274780:2')"
+		    ><div id="control.i:id:Test:6952654777444:2" class="instance expander" onclick="toggleSection('i:id:Test:6952654777444:2')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -270,14 +270,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Test:-45-897274780:2" class="inst-details hide"
+		  ><div id="section.i:id:Test:6952654777444:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:-62--60-:1404642119:3" class="instance expander" onclick="toggleSection('i:id:-62--60-:1404642119:3')"
+		    ><div id="control.i:id:-62--60-:207563072327:3" class="instance expander" onclick="toggleSection('i:id:-62--60-:207563072327:3')"
 		      ><a href=""
 			>(&gt;&lt;)</a
 			> <a href=""
@@ -294,7 +294,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:-62--60-:1404642119:3" class="inst-details hide"
+		  ><div id="section.i:id:-62--60-:207563072327:3" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -469,7 +469,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Assoc:784462590:1" class="instance expander" onclick="toggleSection('i:id:Assoc:784462590:1')"
+		    ><div id="control.i:id:Assoc:229407872643838:1" class="instance expander" onclick="toggleSection('i:id:Assoc:229407872643838:1')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -484,7 +484,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Assoc:784462590:1" class="inst-details hide"
+		  ><div id="section.i:id:Assoc:229407872643838:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -511,7 +511,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Test:-45-897274811:2" class="instance expander" onclick="toggleSection('i:id:Test:-45-897274811:2')"
+		    ><div id="control.i:id:Test:6952654777413:2" class="instance expander" onclick="toggleSection('i:id:Test:6952654777413:2')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -526,7 +526,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Test:-45-897274811:2" class="inst-details hide"
+		  ><div id="section.i:id:Test:6952654777413:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -751,7 +751,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Test:-45-897274811:1" class="instance expander" onclick="toggleSection('i:ic:Test:-45-897274811:1')"
+		    ><div id="control.i:ic:Test:6952654777413:1" class="instance expander" onclick="toggleSection('i:ic:Test:6952654777413:1')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -766,14 +766,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Test:-45-897274811:1" class="inst-details hide"
+		  ><div id="section.i:ic:Test:6952654777413:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Test:-45-897274780:2" class="instance expander" onclick="toggleSection('i:ic:Test:-45-897274780:2')"
+		    ><div id="control.i:ic:Test:6952654777444:2" class="instance expander" onclick="toggleSection('i:ic:Test:6952654777444:2')"
 		      ><a href=""
 			>Test</a
 			> * <a href=""
@@ -788,7 +788,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Test:-45-897274780:2" class="inst-details hide"
+		  ><div id="section.i:ic:Test:6952654777444:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -1033,7 +1033,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Assoc:784462590:1" class="instance expander" onclick="toggleSection('i:ic:Assoc:784462590:1')"
+		    ><div id="control.i:ic:Assoc:229407872643838:1" class="instance expander" onclick="toggleSection('i:ic:Assoc:229407872643838:1')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -1048,7 +1048,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Assoc:784462590:1" class="inst-details hide"
+		  ><div id="section.i:ic:Assoc:229407872643838:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -1075,7 +1075,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Assoc:784462559:2" class="instance expander" onclick="toggleSection('i:ic:Assoc:784462559:2')"
+		    ><div id="control.i:ic:Assoc:229407872643807:2" class="instance expander" onclick="toggleSection('i:ic:Assoc:229407872643807:2')"
 		      ><a href=""
 			>Assoc</a
 			> * <a href=""
@@ -1090,7 +1090,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Assoc:784462559:2" class="inst-details hide"
+		  ><div id="section.i:ic:Assoc:229407872643807:2" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -1239,7 +1239,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:-62--60-:1404642119:1" class="instance expander" onclick="toggleSection('i:ic:-62--60-:1404642119:1')"
+		    ><div id="control.i:ic:-62--60-:207563072327:1" class="instance expander" onclick="toggleSection('i:ic:-62--60-:207563072327:1')"
 		      ><a href=""
 			>(&gt;&lt;)</a
 			> <a href=""
@@ -1256,7 +1256,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:-62--60-:1404642119:1" class="inst-details hide"
+		  ><div id="section.i:ic:-62--60-:207563072327:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -213,12 +213,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Assoc:229407872643807:1" class="instance expander" onclick="toggleSection('i:id:Assoc:229407872643807:1')"
-		      ><a href=""
-			>Assoc</a
-			> * <a href=""
-			>X</a
-			></div
+		    ><span id="control.i:id:X:Assoc:1" class="instance expander" onclick="toggleSection('i:id:X:Assoc:1')"
+		      ></span
+		      > <a href=""
+		      >Assoc</a
+		      > * <a href=""
+		      >X</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -228,7 +228,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Assoc:229407872643807:1" class="inst-details hide"
+		  ><div id="section.i:id:X:Assoc:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -255,12 +255,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Test:6952654777444:2" class="instance expander" onclick="toggleSection('i:id:Test:6952654777444:2')"
-		      ><a href=""
-			>Test</a
-			> * <a href=""
-			>X</a
-			></div
+		    ><span id="control.i:id:X:Test:2" class="instance expander" onclick="toggleSection('i:id:X:Test:2')"
+		      ></span
+		      > <a href=""
+		      >Test</a
+		      > * <a href=""
+		      >X</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -270,23 +270,23 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Test:6952654777444:2" class="inst-details hide"
+		  ><div id="section.i:id:X:Test:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:-62--60-:207563072327:3" class="instance expander" onclick="toggleSection('i:id:-62--60-:207563072327:3')"
-		      ><a href=""
-			>(&gt;&lt;)</a
-			> <a href=""
-			>X</a
-			> <a href=""
-			>XX</a
-			> <a href=""
-			>XXX</a
-			></div
+		    ><span id="control.i:id:X:-62--60-:3" class="instance expander" onclick="toggleSection('i:id:X:-62--60-:3')"
+		      ></span
+		      > <a href=""
+		      >(&gt;&lt;)</a
+		      > <a href=""
+		      >X</a
+		      > <a href=""
+		      >XX</a
+		      > <a href=""
+		      >XXX</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -294,7 +294,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:-62--60-:207563072327:3" class="inst-details hide"
+		  ><div id="section.i:id:X:-62--60-:3" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -469,12 +469,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Assoc:229407872643838:1" class="instance expander" onclick="toggleSection('i:id:Assoc:229407872643838:1')"
-		      ><a href=""
-			>Assoc</a
-			> * <a href=""
-			>Y</a
-			></div
+		    ><span id="control.i:id:Y:Assoc:1" class="instance expander" onclick="toggleSection('i:id:Y:Assoc:1')"
+		      ></span
+		      > <a href=""
+		      >Assoc</a
+		      > * <a href=""
+		      >Y</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -484,7 +484,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Assoc:229407872643838:1" class="inst-details hide"
+		  ><div id="section.i:id:Y:Assoc:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -511,12 +511,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:id:Test:6952654777413:2" class="instance expander" onclick="toggleSection('i:id:Test:6952654777413:2')"
-		      ><a href=""
-			>Test</a
-			> * <a href=""
-			>Y</a
-			></div
+		    ><span id="control.i:id:Y:Test:2" class="instance expander" onclick="toggleSection('i:id:Y:Test:2')"
+		      ></span
+		      > <a href=""
+		      >Test</a
+		      > * <a href=""
+		      >Y</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -526,7 +526,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:id:Test:6952654777413:2" class="inst-details hide"
+		  ><div id="section.i:id:Y:Test:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -751,12 +751,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Test:6952654777413:1" class="instance expander" onclick="toggleSection('i:ic:Test:6952654777413:1')"
-		      ><a href=""
-			>Test</a
-			> * <a href=""
-			>Y</a
-			></div
+		    ><span id="control.i:ic:Test:Test:1" class="instance expander" onclick="toggleSection('i:ic:Test:Test:1')"
+		      ></span
+		      > <a href=""
+		      >Test</a
+		      > * <a href=""
+		      >Y</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -766,19 +766,19 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Test:6952654777413:1" class="inst-details hide"
+		  ><div id="section.i:ic:Test:Test:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Test:6952654777444:2" class="instance expander" onclick="toggleSection('i:ic:Test:6952654777444:2')"
-		      ><a href=""
-			>Test</a
-			> * <a href=""
-			>X</a
-			></div
+		    ><span id="control.i:ic:Test:Test:2" class="instance expander" onclick="toggleSection('i:ic:Test:Test:2')"
+		      ></span
+		      > <a href=""
+		      >Test</a
+		      > * <a href=""
+		      >X</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -788,7 +788,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Test:6952654777444:2" class="inst-details hide"
+		  ><div id="section.i:ic:Test:Test:2" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr
@@ -1033,12 +1033,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Assoc:229407872643838:1" class="instance expander" onclick="toggleSection('i:ic:Assoc:229407872643838:1')"
-		      ><a href=""
-			>Assoc</a
-			> * <a href=""
-			>Y</a
-			></div
+		    ><span id="control.i:ic:Assoc:Assoc:1" class="instance expander" onclick="toggleSection('i:ic:Assoc:Assoc:1')"
+		      ></span
+		      > <a href=""
+		      >Assoc</a
+		      > * <a href=""
+		      >Y</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -1048,7 +1048,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Assoc:229407872643838:1" class="inst-details hide"
+		  ><div id="section.i:ic:Assoc:Assoc:1" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -1075,12 +1075,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:Assoc:229407872643807:2" class="instance expander" onclick="toggleSection('i:ic:Assoc:229407872643807:2')"
-		      ><a href=""
-			>Assoc</a
-			> * <a href=""
-			>X</a
-			></div
+		    ><span id="control.i:ic:Assoc:Assoc:2" class="instance expander" onclick="toggleSection('i:ic:Assoc:Assoc:2')"
+		      ></span
+		      > <a href=""
+		      >Assoc</a
+		      > * <a href=""
+		      >X</a
 		      ></span
 		    ></td
 		  ><td class="doc"
@@ -1090,7 +1090,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:Assoc:229407872643807:2" class="inst-details hide"
+		  ><div id="section.i:ic:Assoc:Assoc:2" class="inst-details hide"
 		    ><div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
@@ -1239,16 +1239,16 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	      ><tr
 		><td class="src clearfix"
 		  ><span class="inst-left"
-		    ><div id="control.i:ic:-62--60-:207563072327:1" class="instance expander" onclick="toggleSection('i:ic:-62--60-:207563072327:1')"
-		      ><a href=""
-			>(&gt;&lt;)</a
-			> <a href=""
-			>X</a
-			> <a href=""
-			>XX</a
-			> <a href=""
-			>XXX</a
-			></div
+		    ><span id="control.i:ic:-62--60-:-62--60-:1" class="instance expander" onclick="toggleSection('i:ic:-62--60-:-62--60-:1')"
+		      ></span
+		      > <a href=""
+		      >(&gt;&lt;)</a
+		      > <a href=""
+		      >X</a
+		      > <a href=""
+		      >XX</a
+		      > <a href=""
+		      >XXX</a
 		      ></span
 		    ></td
 		  ><td class="doc empty"
@@ -1256,7 +1256,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		  ></tr
 		><tr
 		><td colspan="2"
-		  ><div id="section.i:ic:-62--60-:207563072327:1" class="inst-details hide"
+		  ><div id="section.i:ic:-62--60-:-62--60-:1" class="inst-details hide"
 		    ></div
 		    ></td
 		  ></tr

--- a/html-test/ref/ocean.css
+++ b/html-test/ref/ocean.css
@@ -146,15 +146,21 @@ ul.links li a {
   background-image: url(plus.gif);
   background-repeat: no-repeat;
 }
-p.caption.collapser,
-p.caption.expander {
-  background-position: 0 0.4em;
-}
 .collapser, .expander {
   padding-left: 14px;
   margin-left: -14px;
   cursor: pointer;
 }
+p.caption.collapser,
+p.caption.expander {
+  background-position: 0 0.4em;
+}
+
+.instance.collapser, .instance.expander {
+  margin-left: 0px;
+  background-position: left center;
+}
+
 
 pre {
   padding: 0.25em;

--- a/html-test/src/Instances.hs
+++ b/html-test/src/Instances.hs
@@ -43,13 +43,13 @@ instance Foo ((,,) a b) => Bar ((,,) a b) (a, b, a)
 
 class Baz a where
 
-	baz :: a -> (forall a. a -> a) -> (b, forall c. c -> a) -> (b, c)
-	baz' :: b -> (forall b. b -> a) -> (forall b. b -> a) -> [(b, a)]
-	baz'' :: b -> (forall b. (forall b. b -> a) -> c) -> (forall c. c -> b)
+    baz :: a -> (forall a. a -> a) -> (b, forall c. c -> a) -> (b, c)
+    baz' :: b -> (forall b. b -> a) -> (forall b. b -> a) -> [(b, a)]
+    baz'' :: b -> (forall b. (forall b. b -> a) -> c) -> (forall c. c -> b)
 
-	baz = undefined
-	baz' = undefined
-	baz'' = undefined
+    baz = undefined
+    baz' = undefined
+    baz'' = undefined
 
 
 instance Baz (a -> b)

--- a/html-test/src/Instances.hs
+++ b/html-test/src/Instances.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 
 
 module Instances where
@@ -63,3 +64,30 @@ data Quux a b c = Qx a | Qux a b | Quux a b c
 instance Foo (Quux a b)
 instance Bar (Quux a c) (Quux a b c)
 instance Baz (Quux a b c)
+
+
+class Norf a b where
+
+    type Plugh a c b
+    data Thud a c
+
+    norf :: Plugh a c b -> a -> (a -> c) -> b
+
+    norf = undefined
+
+
+instance Norf Int Bool where
+
+    type Plugh Int [a] Bool = a
+    type Plugh Int (a, b) Bool = (a, [b])
+
+    data Thud Int (Quux a [a] c) = Thuud a | Thuuud Int Int
+    data Thud Int [a] = Thuuuud Bool
+
+
+instance Norf [a] [b] where
+
+    type Plugh [a] (Maybe a) [b] = a
+    type Plugh [a] [b] [b] = Quux a b (a, b)
+
+    data Thud [a] (a, a, a) = Thd a

--- a/html-test/src/Instances.hs
+++ b/html-test/src/Instances.hs
@@ -26,9 +26,13 @@ class Foo f => Bar f a where
 
     bar :: f a -> f Bool -> a
     bar' :: f (f a) -> f (f (f b))
+    bar0, bar1 :: (f a, f a) -> (f b, f c)
 
     bar = undefined
     bar' = undefined
+    bar0 = undefined
+    bar1 = undefined
+
 
 instance Bar Maybe Bool
 instance Bar Maybe [a]

--- a/html-test/src/Instances.hs
+++ b/html-test/src/Instances.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 
 
 module Instances where
@@ -34,3 +35,20 @@ instance Bar Maybe [a]
 instance Bar [] (a, a)
 instance Foo f => Bar (Either a) (f a)
 instance Foo ((,,) a b) => Bar ((,,) a b) (a, b, a)
+
+
+class Baz a where
+
+	baz :: a -> (forall a. a -> a) -> (b, forall c. c -> a) -> (b, c)
+	baz' :: b -> (forall b. b -> a) -> (forall b. b -> a) -> [(b, a)]
+	baz'' :: b -> (forall b. (forall b. b -> a) -> c) -> (forall c. c -> b)
+
+	baz = undefined
+	baz' = undefined
+	baz'' = undefined
+
+
+instance Baz (a -> b)
+instance Baz [c]
+instance Baz (a, b, c)
+instance Baz (a, [b], b, a)

--- a/html-test/src/Instances.hs
+++ b/html-test/src/Instances.hs
@@ -3,9 +3,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 
 module Instances where
+
+
+newtype (<~~) a b = Xyzzy (b -> (a, a))
 
 
 class Foo f where
@@ -21,6 +25,8 @@ instance Foo []
 instance (Eq a, Foo f) => Foo ((,) (f a))
 instance Foo (Either a)
 instance Foo ((,,) a a)
+instance Foo ((->) a)
+instance Foo ((<~~) a)
 
 
 class Foo f => Bar f a where

--- a/html-test/src/Instances.hs
+++ b/html-test/src/Instances.hs
@@ -56,3 +56,10 @@ instance Baz (a -> b)
 instance Baz [c]
 instance Baz (a, b, c)
 instance Baz (a, [b], b, a)
+
+
+data Quux a b c = Qx a | Qux a b | Quux a b c
+
+instance Foo (Quux a b)
+instance Bar (Quux a c) (Quux a b c)
+instance Baz (Quux a b c)


### PR DESCRIPTION
[Second part](https://ghc.haskell.org/trac/summer-of-code/ticket/1670) of my Google Summer of Code project.

Note that specialization does not generally work for associated types (only partially) - that is because [ClsInst](https://downloads.haskell.org/~ghc/7.8.2/docs/html/libraries/ghc-7.8.2/InstEnv.html#t:ClsInst) object from which Haddock obtains all necessary information does not hold relevant type family data.