### PR TITLE
Hoogle backend improvements

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -175,6 +175,12 @@ ppClass dflags decl subdocs = (out dflags decl' ++ " " ++ ppTyFams) : ppMethods
             , map (ppr . tyFamEqnToSyn . unLoc) (tcdATDefs decl)
             ]
 
+        whereWrapper elems = vcat'
+            [ text "where" <+> lbrace
+            , nest 4 . vcat . map (<> semi) $ elems
+            , rbrace
+            ]
+
         addContext (TypeSig name (L l sig) nwcs) = TypeSig name (L l $ f sig) nwcs
         addContext (MinimalSig src sig) = MinimalSig src sig
         addContext _ = error "expected TypeSig"
@@ -390,9 +396,6 @@ escape = concatMap f
         f x = [x]
 
 
-semiSeparate :: [SDoc] -> SDoc
-semiSeparate = sep . punctuate semi
-
-
-whereWrapper :: [SDoc] -> SDoc
-whereWrapper xs = text "where" <+> braces (space <> semiSeparate xs <> space)
+-- | Just like 'vcat' but uses '($+$)' instead of '($$)'.
+vcat' :: [SDoc] -> SDoc
+vcat' = foldr ($+$) empty

--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -20,6 +20,8 @@ import InstEnv (ClsInst(..))
 import Haddock.GhcUtils
 import Haddock.Types hiding (Version)
 import Haddock.Utils hiding (out)
+
+import Bag
 import GHC
 import Outputable
 
@@ -154,9 +156,11 @@ ppSig dflags x  = ppSigWithDoc dflags x []
 
 -- note: does not yet output documentation for class methods
 ppClass :: DynFlags -> TyClDecl Name -> [(Name, DocForDecl Name)] -> [String]
-ppClass dflags x subdocs = out dflags x{tcdSigs=[]} :
+ppClass dflags x subdocs = out dflags decl' :
             concatMap (flip (ppSigWithDoc dflags) subdocs . addContext . unL) (tcdSigs x)
     where
+        decl' = x { tcdSigs = [], tcdMeths = emptyBag }
+
         addContext (TypeSig name (L l sig) nwcs) = TypeSig name (L l $ f sig) nwcs
         addContext (MinimalSig src sig) = MinimalSig src sig
         addContext _ = error "expected TypeSig"

--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -28,6 +28,7 @@ import Outputable
 import Data.Char
 import Data.List
 import Data.Maybe
+import qualified Data.Map as Map
 import Data.Version
 import System.FilePath
 import System.IO
@@ -57,7 +58,8 @@ ppModule dflags iface =
   "" : ppDocumentation dflags (ifaceDoc iface) ++
   ["module " ++ moduleString (ifaceMod iface)] ++
   concatMap (ppExport dflags) (ifaceExportItems iface) ++
-  concatMap (ppInstance dflags) (ifaceInstances iface)
+  concatMap (ppInstance dflags) (ifaceInstances iface) ++
+  concatMap (ppFixity dflags) (Map.toList $ ifaceFixMap iface)
 
 
 ---------------------------------------------------------------------
@@ -232,6 +234,10 @@ ppCtor dflags dat subdocs con
             ResTyH98 -> apps $ map (reL . HsTyVar) $
                         (tcdName dat) : [hsTyVarName v | L _ v@(UserTyVar _) <- hsQTvBndrs $ tyClDeclTyVars dat]
             ResTyGADT _ x -> x
+
+
+ppFixity :: DynFlags -> (Name, Fixity) -> [String]
+ppFixity dflags (name, fixity) = [out dflags (FixitySig [noLoc name] fixity)]
 
 
 ---------------------------------------------------------------------

--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -160,7 +160,7 @@ ppSig dflags x  = ppSigWithDoc dflags x []
 
 -- note: does not yet output documentation for class methods
 ppClass :: DynFlags -> TyClDecl Name -> [(Name, DocForDecl Name)] -> [String]
-ppClass dflags decl subdocs = (out dflags decl' ++ " " ++ ppTyFams) : ppMethods
+ppClass dflags decl subdocs = (out dflags decl' ++ ppTyFams) : ppMethods
     where
         decl' = decl
             { tcdSigs = [], tcdMeths = emptyBag
@@ -170,10 +170,12 @@ ppClass dflags decl subdocs = (out dflags decl' ++ " " ++ ppTyFams) : ppMethods
         ppMethods = concat . map (ppSig' . unLoc) $ tcdSigs decl
         ppSig' = flip (ppSigWithDoc dflags) subdocs . addContext
 
-        ppTyFams = showSDocUnqual dflags . whereWrapper $ concat
-            [ map ppr (tcdATs decl)
-            , map (ppr . tyFamEqnToSyn . unLoc) (tcdATDefs decl)
-            ]
+        ppTyFams
+            | null $ tcdATs decl = ""
+            | otherwise = (" " ++) . showSDocUnqual dflags . whereWrapper $ concat
+                [ map ppr (tcdATs decl)
+                , map (ppr . tyFamEqnToSyn . unLoc) (tcdATDefs decl)
+                ]
 
         whereWrapper elems = vcat'
             [ text "where" <+> lbrace


### PR DESCRIPTION
This implements improvements suggested in #415 and #417.

While default methods are now removed from Hoogle output, type families are not. So, this:

    class Foo a where

        type Bar a b
        type Baz a

        type Baz a = [(a, a)]

        bar :: Bar a a
        bar = undefined


    instance Foo [a] where

        type Bar [a] Int = [(a, Bool)]
        type Bar [a] Bool = [(Int, a)]

        type Baz [a] = (a, a, a)

will produce following output:

    class Foo a where type family Bar a b type family Baz a Baz a = [(a, a)]
    bar :: Foo a => Bar a a
    instance Test.Foo [a]

@ndmitchell - if you want to get rid of type families as well, let me know. 