### PR TITLE
HsBang is split into HsSrcBang and HsImplBang

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -822,9 +822,7 @@ pp_hs_context cxt unicode = parenList (map (ppType unicode) cxt)
 -------------------------------------------------------------------------------
 
 
-ppBang :: HsBang -> LaTeX
-ppBang HsStrict                  = char '!'
-ppBang (HsUnpack {})             = char '!'
+ppBang :: HsSrcBang -> LaTeX
 ppBang (HsSrcBang _ _ SrcStrict) = char '!'
 ppBang (HsSrcBang _ _ SrcLazy)   = char '~'
 ppBang _                         = empty

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -768,9 +768,7 @@ ppDataHeader _ _ _ _ = error "ppDataHeader: illegal argument"
 --------------------------------------------------------------------------------
 
 
-ppBang :: HsBang -> Html
-ppBang HsStrict                  = toHtml "!"
-ppBang (HsUnpack {})             = toHtml "!"
+ppBang :: HsSrcBang -> Html
 ppBang (HsSrcBang _ _ SrcStrict) = toHtml "!"
 ppBang (HsSrcBang _ _ SrcLazy)   = toHtml "~"
 ppBang _                         = noHtml

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -266,18 +266,14 @@ synifyDataCon use_gadt_syntax dc =
   -- skip any EqTheta, use 'orig'inal syntax
   ctx = synifyCtx theta
 
-  linear_tys = zipWith (\ty bang ->
-            let tySyn = synifyType WithinType ty
-                src_bang = case bang of
-                             HsUnpack {} -> HsSrcBang Nothing SrcUnpack SrcStrict
-                             HsStrict    -> HsSrcBang Nothing SrcNoUnpack SrcStrict
-                             HsLazy      -> HsSrcBang Nothing NoSrcUnpack NoSrcStrictness
-                             _           -> bang
-            in case src_bang of
-                 (HsSrcBang _ NoSrcUnpack NoSrcStrictness) -> tySyn
-                 _        -> noLoc $ HsBangTy bang tySyn
-          )
-          arg_tys (dataConSrcBangs dc)
+  linear_tys =
+    zipWith (\ty bang ->
+               let tySyn = synifyType WithinType ty
+               in case bang of
+                    (HsSrcBang _ NoSrcUnpack NoSrcStrict) -> tySyn
+                    bang' -> noLoc $ HsBangTy bang' tySyn)
+            arg_tys (dataConSrcBangs dc)
+
   field_tys = zipWith (\field synTy -> noLoc $ ConDeclField
                                                [synifyName field] synTy Nothing)
                 (dataConFieldLabels dc) linear_tys


### PR DESCRIPTION
With recent changes in GHC handling of strictness annotations in Haddock
is simplified.

For when [D1069][1] is to be merged.

[1]: https://phabricator.haskell.org/D1069