### PR TITLE
Deleted code responsible for: 'hypsrc-test/run.hs:1:2: parse error on…

### DIFF
--- a/hypsrc-test/run.hs
+++ b/hypsrc-test/run.hs
@@ -1,6 +1,3 @@
-#!/usr/bin/env runhaskell
-{-# LANGUAGE CPP #-}
-
 
 import Control.Monad
 


### PR DESCRIPTION
Running ```cabal build -j4``` currently fails with the error ```hypsrc-test/run.hs:1:2: parse error on input ‘#!/’```.

The tiny change in this pull request fixes it.