### PR TITLE
Remove PhaseFailed

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -118,11 +118,8 @@ handleGhcExceptions =
   -- error messages propagated as exceptions
   handleGhcException $ \e -> do
     hFlush stdout
-    case e of
-      PhaseFailed _ code -> exitWith code
-      _ -> do
-        print (e :: GhcException)
-        exitFailure
+    print (e :: GhcException)
+    exitFailure
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
As part of https://phabricator.haskell.org/D1256 we are removing `PhaseFailed` which requires it to be removed from haddock as well.