### PR TITLE
Move the permalinks to "#" on the right side

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -381,21 +381,16 @@ div#style-menu-holder {
 #interface h5 + div.top {
  	margin-top: 1em;
 }
-#interface p.src .link {
+#interface .src .selflink,
+#interface .src .link {
   float: right;
   color: #919191;
-  border-left: 1px solid #919191;
   background: #f0f0f0;
   padding: 0 0.5em 0.2em;
-  margin: 0 -0.5em 0 0.5em;
+  margin: 0 -0.5em 0 0;
 }
-
-#interface td.src .link {
-  float: right;
-  color: #919191;
+#interface .src .selflink {
   border-left: 1px solid #919191;
-  background: #f0f0f0;
-  padding: 0 0.5em 0.2em;
   margin: 0 -0.5em 0 0.5em;
 }
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -43,12 +43,13 @@ import Haddock.Backends.Xhtml.DocMarkup
 import Haddock.Backends.Xhtml.Types
 import Haddock.Backends.Xhtml.Utils
 import Haddock.Types
-import Haddock.Utils (makeAnchorId)
+import Haddock.Utils (makeAnchorId, nameAnchorId)
 import qualified Data.Map as Map
 import Text.XHtml hiding ( name, title, p, quote )
 
 import FastString            ( unpackFS )
 import GHC
+import Name (nameOccName)
 
 --------------------------------------------------------------------------------
 -- * Sections of the document
@@ -246,9 +247,11 @@ topDeclElem lnks loc splice names html =
 -- | Adds a source and wiki link at the right hand side of the box.
 -- Name must be documented, otherwise we wouldn't get here.
 links :: LinksInfo -> SrcSpan -> Bool -> DocName -> Html
-links ((_,_,sourceMap,lineMap), (_,_,maybe_wiki_url)) loc splice (Documented n mdl) =
-   (srcLink <+> wikiLink)
-  where srcLink = let nameUrl = Map.lookup origPkg sourceMap
+links ((_,_,sourceMap,lineMap), (_,_,maybe_wiki_url)) loc splice docName@(Documented n mdl) =
+  srcLink <+> wikiLink <+> (selfLink ! [theclass "selflink"] << "#")
+  where selfLink = linkedAnchor (nameAnchorId (nameOccName (getName docName)))
+
+        srcLink = let nameUrl = Map.lookup origPkg sourceMap
                       lineUrl = Map.lookup origPkg lineMap
                       mUrl | splice    = lineUrl
                                         -- Use the lineUrl as a backup

--- a/haddock-api/src/Haddock/Backends/Xhtml/Names.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Names.hs
@@ -120,11 +120,11 @@ ppBinderWith :: Notation -> Bool -> OccName -> Html
 -- the documentation or is the actual definition; in the latter case, we also
 -- set the 'id' and 'class' attributes.
 ppBinderWith notation isRef n =
-  linkedAnchor name ! attributes << ppBinder' notation n
+  makeAnchor << ppBinder' notation n
   where
     name = nameAnchorId n
-    attributes | isRef     = []
-               | otherwise = [identifier name, theclass "def"]
+    makeAnchor | isRef     = linkedAnchor name
+               | otherwise = namedAnchor name ! [theclass "def"]
 
 ppBinder' :: Notation -> OccName -> Html
 ppBinder' notation n = wrapInfix notation n $ ppOccName n

--- a/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
@@ -195,7 +195,7 @@ dot = toHtml "."
 
 -- | Generate a named anchor
 namedAnchor :: String -> Html -> Html
-namedAnchor n = anchor ! [XHtml.name n]
+namedAnchor n = anchor ! [XHtml.identifier n]
 
 
 linkedAnchor :: String -> Html -> Html

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -88,8 +88,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:A" class="def"
+	    > <a id="t:A" class="def"
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -97,7 +99,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A" class="def"
+		><a id="v:A" class="def"
 		  >A</a
 		  ></td
 		><td class="doc empty"
@@ -108,18 +110,22 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:other" class="def"
+	  ><a id="v:other" class="def"
 	    >other</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:test2" class="def"
+	  ><a id="v:test2" class="def"
 	    >test2</a
 	    > :: <a href=""
 	    >Bool</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -130,8 +136,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:X" class="def"
+	    > <a id="t:X" class="def"
 	    >X</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -143,7 +151,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:X" class="def"
+		><a id="v:X" class="def"
 		  >X</a
 		  ></td
 		><td class="doc"
@@ -156,10 +164,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_A.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:reExport" class="def"
+	  ><a id="v:reExport" class="def"
 	    >reExport</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/B.html
+++ b/html-test/ref/B.html
@@ -82,10 +82,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_B.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:test" class="def"
+	  ><a id="v:test" class="def"
 	    >test</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -120,10 +122,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_B.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:reExport" class="def"
+	  ><a id="v:reExport" class="def"
 	    >reExport</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -134,8 +138,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_B.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:X" class="def"
+	    > <a id="t:X" class="def"
 	    >X</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -147,7 +153,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_B.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:X" class="def"
+		><a id="v:X" class="def"
 		  >X</a
 		  ></td
 		><td class="doc"

--- a/html-test/ref/Bold.html
+++ b/html-test/ref/Bold.html
@@ -56,9 +56,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bold.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Some <strong

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -62,8 +62,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug1.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T" class="def"
+	    > <a id="t:T" class="def"
 	    >T</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -80,7 +82,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug1.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:T" class="def"
+		><a id="v:T" class="def"
 		  >T</a
 		  ></td
 		><td class="doc empty"

--- a/html-test/ref/Bug195.html
+++ b/html-test/ref/Bug195.html
@@ -48,8 +48,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T" class="def"
+	    > <a id="t:T" class="def"
 	    >T</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -57,7 +59,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A" class="def"
+		><a id="v:A" class="def"
 		  >A</a
 		  ></td
 		><td class="doc empty"
@@ -71,7 +73,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:someField" class="def"
+			><a id="v:someField" class="def"
 			  >someField</a
 			  > :: ()</dfn
 			><div class="doc"
@@ -81,7 +83,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:someOtherField" class="def"
+			><a id="v:someOtherField" class="def"
 			  >someOtherField</a
 			  > :: ()</dfn
 			><div class="doc"
@@ -95,7 +97,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:B" class="def"
+		><a id="v:B" class="def"
 		  >B</a
 		  ></td
 		><td class="doc empty"
@@ -109,7 +111,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:someField" class="def"
+			><a id="v:someField" class="def"
 			  >someField</a
 			  > :: ()</dfn
 			><div class="doc"
@@ -119,7 +121,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:someOtherField" class="def"
+			><a id="v:someOtherField" class="def"
 			  >someOtherField</a
 			  > :: ()</dfn
 			><div class="doc"
@@ -133,7 +135,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:C" class="def"
+		><a id="v:C" class="def"
 		  >C</a
 		  ></td
 		><td class="doc empty"
@@ -147,7 +149,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:someField" class="def"
+			><a id="v:someField" class="def"
 			  >someField</a
 			  > :: ()</dfn
 			><div class="doc"
@@ -157,7 +159,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug195.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:someOtherField" class="def"
+			><a id="v:someOtherField" class="def"
 			  >someOtherField</a
 			  > :: ()</dfn
 			><div class="doc"

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -46,10 +46,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug2.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:x" class="def"
+	  ><a id="v:x" class="def"
 	    >x</a
 	    > :: <a href=""
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/Bug201.html
+++ b/html-test/ref/Bug201.html
@@ -60,9 +60,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug201.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><pre
 	    >This leading whitespace
@@ -72,9 +74,11 @@ should be dropped
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><pre
 	    > But this one

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -17,11 +17,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug253.html");};
   ><div id="package-header"
     ><ul class="links" id="page-menu"
       ><li
-	><a href="index.html"
+	><a href=""
 	  >Contents</a
 	  ></li
 	><li
-	><a href="doc-index.html"
+	><a href=""
 	  >Index</a
 	  ></li
 	></ul
@@ -62,7 +62,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug253.html");};
 	>Synopsis</p
 	><ul id="section.syn" class="hide" onclick="toggleSection('syn')"
 	><li class="src short"
-	  ><a href="#v:foo"
+	  ><a href=""
 	    >foo</a
 	    > :: ()</li
 	  ></ul
@@ -72,15 +72,17 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug253.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="#v:foo" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >This link should generate <code
 	      >#v</code
 	      > anchor: <code
-	      ><a href="DoesNotExist.html#v:fakeFakeFake"
+	      ><a href=""
 		>fakeFakeFake</a
 		></code
 	      ></p
@@ -90,7 +92,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug253.html");};
       ></div
     ><div id="footer"
     ><p
-      >Produced by <a href="http://www.haskell.org/haddock/"
+      >Produced by <a href=""
 	>Haddock</a
 	> version 2.16.2</p
       ></div

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -86,9 +86,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Foo</p
@@ -100,9 +102,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Bar</p
@@ -112,10 +116,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:C" class="def"
+	    > <a id="t:C" class="def"
 	    >C</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -129,9 +135,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:c_f" class="def"
+	    ><a id="v:c_f" class="def"
 	      >c_f</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      ><em
@@ -152,6 +160,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 		      > <a href=""
 		      >C</a
 		      > ()</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -171,7 +181,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug26.html");};
 			><p class="src"
 			><a href=""
 			  >c_f</a
-			  > :: ()</p
+			  > :: () <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -48,8 +48,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug294.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:A" class="def"
+	    > <a id="t:A" class="def"
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs instances"
 	  ><p id="control.i:A" class="caption collapser" onclick="toggleSection('i:A')"
@@ -65,11 +67,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug294.html");};
 		      >DP</a
 		      > <a href=""
 		      >A</a
-		      > = <a href="" id="v:ProblemCtor-39-" class="def"
+		      > = <a id="v:ProblemCtor-39-" class="def"
 		      >ProblemCtor'</a
 		      > <a href=""
 		      >A</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -81,11 +85,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug294.html");};
 		      >data</span
 		      > TP <a href=""
 		      >A</a
-		      > = <a href="" id="v:ProblemCtor" class="def"
+		      > = <a id="v:ProblemCtor" class="def"
 		      >ProblemCtor</a
 		      > <a href=""
 		      >A</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -96,41 +102,49 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug294.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:problemField" class="def"
+	  ><a id="v:problemField" class="def"
 	    >problemField</a
 	    > :: TO <a href=""
 	    >A</a
 	    > -&gt; <a href=""
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:problemField-39-" class="def"
+	  ><a id="v:problemField-39-" class="def"
 	    >problemField'</a
 	    > :: DO <a href=""
 	    >A</a
 	    > -&gt; <a href=""
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:gadtField" class="def"
+	  ><a id="v:gadtField" class="def"
 	    >gadtField</a
 	    > :: GADT <a href=""
 	    >A</a
 	    > -&gt; <a href=""
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
-	    > <a href="" id="t:DP" class="def"
+	    > <a id="t:DP" class="def"
 	    >DP</a
-	    > t :: *</p
+	    > t :: * <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs instances"
 	  ><p id="control.i:DP" class="caption collapser" onclick="toggleSection('i:DP')"
 	    >Instances</p
@@ -145,11 +159,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug294.html");};
 		      >DP</a
 		      > <a href=""
 		      >A</a
-		      > = <a href="" id="v:ProblemCtor-39-" class="def"
+		      > = <a id="v:ProblemCtor-39-" class="def"
 		      >ProblemCtor'</a
 		      > <a href=""
 		      >A</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -72,33 +72,43 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug298.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-60--94--62-" class="def"
+	  ><a id="v:-60--94--62-" class="def"
 	    >(&lt;^&gt;)</a
-	    > :: (a -&gt; a) -&gt; a -&gt; a</p
+	    > :: (a -&gt; a) -&gt; a -&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-60--94-" class="def"
+	  ><a id="v:-60--94-" class="def"
 	    >(&lt;^)</a
-	    > :: a -&gt; a -&gt; a</p
+	    > :: a -&gt; a -&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-94--62-" class="def"
+	  ><a id="v:-94--62-" class="def"
 	    >(^&gt;)</a
-	    > :: a -&gt; a -&gt; a</p
+	    > :: a -&gt; a -&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-8902--94-" class="def"
+	  ><a id="v:-8902--94-" class="def"
 	    >(&#8902;^)</a
-	    > :: a -&gt; a -&gt; a</p
+	    > :: a -&gt; a -&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Links to <code

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug3.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/Bug308.html
+++ b/html-test/ref/Bug308.html
@@ -60,25 +60,29 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug308.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
-	    >start<a name="startAnchor"
+	    >start<a id="startAnchor"
 	      ></a
-	      > followed by middle<a name="middleAnchor"
+	      > followed by middle<a id="middleAnchor"
 	      ></a
-	      > and end<a name="endAnchor"
+	      > and end<a id="endAnchor"
 	      ></a
 	      ></p
 	    ></div
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >start <a href=""

--- a/html-test/ref/Bug308CrossModule.html
+++ b/html-test/ref/Bug308CrossModule.html
@@ -56,9 +56,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug308CrossModule.html
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:h" class="def"
+	  ><a id="v:h" class="def"
 	    >h</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >start <a href=""

--- a/html-test/ref/Bug310.html
+++ b/html-test/ref/Bug310.html
@@ -62,7 +62,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug310.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > a <a href="" id="t:-43-" class="def"
+	    > a <a id="t:-43-" class="def"
 	    >+</a
 	    > b :: <a href=""
 	    >Nat</a
@@ -70,6 +70,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug310.html");};
 	    >infixl 6</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/Bug313.html
+++ b/html-test/ref/Bug313.html
@@ -73,9 +73,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug313.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:a" class="def"
+	  ><a id="v:a" class="def"
 	    >a</a
-	    > :: a</p
+	    > :: a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Some text.</p
@@ -97,9 +99,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug313.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:b" class="def"
+	  ><a id="v:b" class="def"
 	    >b</a
-	    > :: a</p
+	    > :: a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Some text.</p

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -60,9 +60,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug335.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><h3 id="control.ch:f0" class="caption expander" onclick="toggleSection('ch:f0')"
 	    >ExF:</h3
@@ -74,9 +76,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug335.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: ()</p
+	    > :: () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><h3 id="control.ch:g0" class="caption expander" onclick="toggleSection('ch:g0')"
 	    >ExG:</h3

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -75,27 +75,31 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug387.html");};
 	></div
       ><div id="interface"
       ><h1 id="g:1"
-	>Section1<a name="a:section1"
+	>Section1<a id="a:section1"
 	  ></a
 	  ></h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:test1" class="def"
+	  ><a id="v:test1" class="def"
 	    >test1</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><h1 id="g:2"
-	>Section2<a name="a:section2"
+	>Section2<a id="a:section2"
 	  ></a
 	  ></h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:test2" class="def"
+	  ><a id="v:test2" class="def"
 	    >test2</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug4.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -132,8 +132,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:A" class="def"
+	    > <a id="t:A" class="def"
 	    >A</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -145,7 +147,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A" class="def"
+		><a id="v:A" class="def"
 		  >A</a
 		  > <a href=""
 		  >Int</a
@@ -160,8 +162,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:B" class="def"
+	    > <a id="t:B" class="def"
 	    >B</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -174,7 +178,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:B" class="def"
+		><a id="v:B" class="def"
 		  >B</a
 		  ></td
 		><td class="doc empty"
@@ -188,7 +192,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:b" class="def"
+			><a id="v:b" class="def"
 			  >b</a
 			  > :: <a href=""
 			  >Int</a
@@ -207,8 +211,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:C" class="def"
+	    > <a id="t:C" class="def"
 	    >C</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -220,7 +226,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:C" class="def"
+		><a id="v:C" class="def"
 		  >C</a
 		  ></td
 		><td class="doc empty"
@@ -234,7 +240,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:c1" class="def"
+			><a id="v:c1" class="def"
 			  >c1</a
 			  > :: <a href=""
 			  >Int</a
@@ -244,7 +250,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:c2" class="def"
+			><a id="v:c2" class="def"
 			  >c2</a
 			  > :: <a href=""
 			  >Int</a
@@ -263,8 +269,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:D" class="def"
+	    > <a id="t:D" class="def"
 	    >D</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -277,7 +285,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:D" class="def"
+		><a id="v:D" class="def"
 		  >D</a
 		  > <a href=""
 		  >Int</a
@@ -294,8 +302,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:E" class="def"
+	    > <a id="t:E" class="def"
 	    >E</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -307,7 +317,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug6.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:E" class="def"
+		><a id="v:E" class="def"
 		  >E</a
 		  > <a href=""
 		  >Int</a

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -77,8 +77,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -90,7 +92,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Foo" class="def"
+		><a id="v:Foo" class="def"
 		  >Foo</a
 		  ></td
 		><td class="doc empty"
@@ -115,6 +117,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		      > <a href=""
 		      >Foo</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -135,9 +139,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Bar" class="def"
+	    > <a id="t:Bar" class="def"
 	    >Bar</a
-	    > x y</p
+	    > x y <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >The Bar class</p
@@ -159,6 +165,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug7.html");};
 		      > <a href=""
 		      >Foo</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -48,8 +48,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Typ" class="def"
+	    > <a id="t:Typ" class="def"
 	    >Typ</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -57,7 +59,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Type" class="def"
+		><a id="v:Type" class="def"
 		  >Type</a
 		  > (<a href=""
 		  >Typ</a
@@ -69,7 +71,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:TFree" class="def"
+		><a id="v:TFree" class="def"
 		  >TFree</a
 		  > (<a href=""
 		  >Typ</a
@@ -84,7 +86,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-45--45--62-" class="def"
+	  ><a id="v:-45--45--62-" class="def"
 	    >(--&gt;)</a
 	    > :: t -&gt; t1 -&gt; <a href=""
 	    >Typ</a
@@ -92,11 +94,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	    >infix 9</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-45--45--45--62-" class="def"
+	  ><a id="v:-45--45--45--62-" class="def"
 	    >(---&gt;)</a
 	    > :: <a href=""
 	    >Foldable</a
@@ -108,25 +112,33 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug8.html");};
 	    >infix 9</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:s" class="def"
+	  ><a id="v:s" class="def"
 	    >s</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:t" class="def"
+	  ><a id="v:t" class="def"
 	    >t</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:main" class="def"
+	  ><a id="v:main" class="def"
 	    >main</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	></div
       ></div

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -48,10 +48,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
 	    > :: (* -&gt; *) -&gt; * -&gt; * <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -59,7 +61,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Bar" class="def"
+		><a id="v:Bar" class="def"
 		  >Bar</a
 		  > ::  f x -&gt; <a href=""
 		  >Foo</a
@@ -74,10 +76,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Baz" class="def"
+	    > <a id="t:Baz" class="def"
 	    >Baz</a
 	    > :: * <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -85,7 +89,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Baz-39-" class="def"
+		><a id="v:Baz-39-" class="def"
 		  >Baz'</a
 		  > ::  <a href=""
 		  >Baz</a
@@ -100,10 +104,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Qux" class="def"
+	    > <a id="t:Qux" class="def"
 	    >Qux</a
 	    > <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -111,7 +117,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug85.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Quux" class="def"
+		><a id="v:Quux" class="def"
 		  >Quux</a
 		  > ::  <a href=""
 		  >Qux</a

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -88,10 +88,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -102,10 +104,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:bar" class="def"
+	  ><a id="v:bar" class="def"
 	    >bar</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -116,10 +120,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:baz" class="def"
+	  ><a id="v:baz" class="def"
 	    >baz</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -130,10 +136,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:one" class="def"
+	  ><a id="v:one" class="def"
 	    >one</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -146,10 +154,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:two" class="def"
+	  ><a id="v:two" class="def"
 	    >two</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -160,10 +170,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugDeprecated.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:three" class="def"
+	  ><a id="v:three" class="def"
 	    >three</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -118,40 +118,48 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugExportHeadings.html
 	>Foo</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><h1 id="g:2"
 	>Bar</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:bar" class="def"
+	  ><a id="v:bar" class="def"
 	    >bar</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><h1 id="g:3"
 	>Baz</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:baz" class="def"
+	  ><a id="v:baz" class="def"
 	    >baz</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><h1 id="g:4"
 	>One</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:one" class="def"
+	  ><a id="v:one" class="def"
 	    >one</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -164,10 +172,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugExportHeadings.html
 	>Two</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:two" class="def"
+	  ><a id="v:two" class="def"
 	    >two</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -180,10 +190,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_BugExportHeadings.html
 	>Three</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:three" class="def"
+	  ><a id="v:three" class="def"
 	    >three</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -48,16 +48,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bugs.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:A" class="def"
+	    > <a id="t:A" class="def"
 	    >A</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A" class="def"
+		><a id="v:A" class="def"
 		  >A</a
 		  > a (a -&gt; <a href=""
 		  >Int</a

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -82,10 +82,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedClass.html")
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:SomeClass" class="def"
+	    > <a id="t:SomeClass" class="def"
 	    >SomeClass</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -99,9 +101,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedClass.html")
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:foo" class="def"
+	    ><a id="v:foo" class="def"
 	      >foo</a
-	      > :: a -&gt; a</p
+	      > :: a -&gt; a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><div class="warning"
 	      ><p
@@ -116,10 +120,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedClass.html")
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:SomeOtherClass" class="def"
+	    > <a id="t:SomeOtherClass" class="def"
 	    >SomeOtherClass</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -131,9 +137,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedClass.html")
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:bar" class="def"
+	    ><a id="v:bar" class="def"
 	      >bar</a
-	      > :: a -&gt; a</p
+	      > :: a -&gt; a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><div class="warning"
 	      ><p

--- a/html-test/ref/DeprecatedData.html
+++ b/html-test/ref/DeprecatedData.html
@@ -86,8 +86,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -103,7 +105,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Foo" class="def"
+		><a id="v:Foo" class="def"
 		  >Foo</a
 		  ></td
 		><td class="doc"
@@ -117,7 +119,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:Bar" class="def"
+		><a id="v:Bar" class="def"
 		  >Bar</a
 		  ></td
 		><td class="doc"
@@ -136,8 +138,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:One" class="def"
+	    > <a id="t:One" class="def"
 	    >One</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -151,7 +155,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:One" class="def"
+		><a id="v:One" class="def"
 		  >One</a
 		  ></td
 		><td class="doc"
@@ -163,7 +167,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedData.html");
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:Two" class="def"
+		><a id="v:Two" class="def"
 		  >Two</a
 		  ></td
 		><td class="doc"

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -64,10 +64,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction.htm
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -84,10 +86,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction.htm
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:bar" class="def"
+	  ><a id="v:bar" class="def"
 	    >bar</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction2.ht
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedFunction3.ht
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -62,10 +62,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedModule.html"
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -56,10 +56,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedModule2.html
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -74,8 +74,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedNewtype.html
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:SomeNewType" class="def"
+	    > <a id="t:SomeNewType" class="def"
 	    >SomeNewType</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -91,7 +93,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedNewtype.html
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:SomeNewTypeConst" class="def"
+		><a id="v:SomeNewTypeConst" class="def"
 		  >SomeNewTypeConst</a
 		  > <a href=""
 		  >String</a
@@ -112,8 +114,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedNewtype.html
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:SomeOtherNewType" class="def"
+	    > <a id="t:SomeOtherNewType" class="def"
 	    >SomeOtherNewType</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -127,7 +131,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedNewtype.html
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:SomeOtherNewTypeConst" class="def"
+		><a id="v:SomeOtherNewTypeConst" class="def"
 		  >SomeOtherNewTypeConst</a
 		  > <a href=""
 		  >String</a

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -84,10 +84,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedReExport.htm
 	>Re-exported from an other module</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -76,8 +76,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedRecord.html"
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -89,7 +91,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedRecord.html"
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Foo" class="def"
+		><a id="v:Foo" class="def"
 		  >Foo</a
 		  ></td
 		><td class="doc empty"
@@ -103,7 +105,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedRecord.html"
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:fooName" class="def"
+			><a id="v:fooName" class="def"
 			  >fooName</a
 			  > :: <a href=""
 			  >String</a
@@ -115,7 +117,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedRecord.html"
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:fooValue" class="def"
+			><a id="v:fooValue" class="def"
 			  >fooValue</a
 			  > :: <a href=""
 			  >Int</a

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -66,9 +66,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeFamily.h
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
-	    > <a href="" id="t:SomeTypeFamily" class="def"
+	    > <a id="t:SomeTypeFamily" class="def"
 	    >SomeTypeFamily</a
-	    > k :: * -&gt; *</p
+	    > k :: * -&gt; * <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
 	    ><p
@@ -82,9 +84,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeFamily.h
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
-	    > <a href="" id="t:SomeOtherTypeFamily" class="def"
+	    > <a id="t:SomeOtherTypeFamily" class="def"
 	    >SomeOtherTypeFamily</a
-	    > k :: * -&gt; *</p
+	    > k :: * -&gt; * <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
 	    ><p

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -70,10 +70,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeSynonym.
 	><p class="src"
 	  ><span class="keyword"
 	    >type</span
-	    > <a href="" id="t:TypeSyn" class="def"
+	    > <a id="t:TypeSyn" class="def"
 	    >TypeSyn</a
 	    > = <a href=""
 	    >String</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"
@@ -88,10 +90,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_DeprecatedTypeSynonym.
 	><p class="src"
 	  ><span class="keyword"
 	    >type</span
-	    > <a href="" id="t:OtherTypeSyn" class="def"
+	    > <a id="t:OtherTypeSyn" class="def"
 	    >OtherTypeSyn</a
 	    > = <a href=""
 	    >String</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><div class="warning"

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -60,12 +60,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Examples.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:fib" class="def"
+	  ><a id="v:fib" class="def"
 	    >fib</a
 	    > :: <a href=""
 	    >Integer</a
 	    > -&gt; <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/Extensions.html
+++ b/html-test/ref/Extensions.html
@@ -68,9 +68,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Extensions.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foobar" class="def"
+	  ><a id="v:foobar" class="def"
 	    >foobar</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Bar</p

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -46,8 +46,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_FunArgs.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -110,8 +112,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_FunArgs.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -154,8 +158,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_FunArgs.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:h" class="def"
+	  ><a id="v:h" class="def"
 	    >h</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -198,8 +204,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_FunArgs.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:i" class="def"
+	  ><a id="v:i" class="def"
 	    >i</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -238,8 +246,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_FunArgs.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:j" class="def"
+	  ><a id="v:j" class="def"
 	    >j</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -110,10 +110,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:H1" class="def"
+	    > <a id="t:H1" class="def"
 	    >H1</a
 	    > a b <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -125,7 +127,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:C1" class="def"
+		><a id="v:C1" class="def"
 		  >C1</a
 		  > ::  <a href=""
 		  >H1</a
@@ -135,7 +137,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:C2" class="def"
+		><a id="v:C2" class="def"
 		  >C2</a
 		  > :: <a href=""
 		  >Ord</a
@@ -147,7 +149,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:C3" class="def"
+		><a id="v:C3" class="def"
 		  >C3</a
 		  > ::  <a href=""
 		  >Int</a
@@ -169,7 +171,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:field" class="def"
+			><a id="v:field" class="def"
 			  >field</a
 			  > :: <a href=""
 			  >Int</a
@@ -185,7 +187,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:C4" class="def"
+		><a id="v:C4" class="def"
 		  >C4</a
 		  > ::  a -&gt; <a href=""
 		  >H1</a
@@ -203,7 +205,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_GADTRecords.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:field2" class="def"
+			><a id="v:field2" class="def"
 			  >field2</a
 			  > :: a</dfn
 			><div class="doc"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -147,9 +147,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:HashTable" class="def"
+	    > <a id="t:HashTable" class="def"
 	    >HashTable</a
-	    > key val</p
+	    > key val <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >A hash table with keys of type <code
@@ -172,7 +174,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	  >s</h2
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:new" class="def"
+	  ><a id="v:new" class="def"
 	    >new</a
 	    > :: (<a href=""
 	    >Eq</a
@@ -184,7 +186,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	    >IO</a
 	    > (<a href=""
 	    >HashTable</a
-	    > key val)</p
+	    > key val) <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Builds a new hash table with a given size</p
@@ -192,7 +196,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:insert" class="def"
+	  ><a id="v:insert" class="def"
 	    >insert</a
 	    > :: (<a href=""
 	    >Eq</a
@@ -200,7 +204,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	    >Hash</a
 	    > key) =&gt; key -&gt; val -&gt; <a href=""
 	    >IO</a
-	    > ()</p
+	    > () <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Inserts a new element into the hash table</p
@@ -208,7 +214,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:lookup" class="def"
+	  ><a id="v:lookup" class="def"
 	    >lookup</a
 	    > :: <a href=""
 	    >Hash</a
@@ -216,7 +222,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	    >IO</a
 	    > (<a href=""
 	    >Maybe</a
-	    > val)</p
+	    > val) <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Looks up a key in the hash table, returns <code
@@ -241,10 +249,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Hash" class="def"
+	    > <a id="t:Hash" class="def"
 	    >Hash</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -254,10 +264,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:hash" class="def"
+	    ><a id="v:hash" class="def"
 	      >hash</a
 	      > :: a -&gt; <a href=""
 	      >Int</a
+	      > <a href="" class="selflink"
+	      >#</a
 	      ></p
 	    ><div class="doc"
 	    ><p
@@ -285,6 +297,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		      > <a href=""
 		      >Float</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -302,6 +316,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 			  >Float</a
 			  > -&gt; <a href=""
 			  >Int</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			></div
 		      ></div
@@ -317,6 +333,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		      > <a href=""
 		      >Int</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -334,6 +352,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 			  >Int</a
 			  > -&gt; <a href=""
 			  >Int</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			></div
 		      ></div
@@ -351,6 +371,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 		      > b) =&gt; <a href=""
 		      >Hash</a
 		      > (a, b)</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -366,6 +388,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hash.html");};
 			  >hash</a
 			  > :: (a, b) -&gt; <a href=""
 			  >Int</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			></div
 		      ></div

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -66,9 +66,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:VisibleClass" class="def"
+	    > <a id="t:VisibleClass" class="def"
 	    >VisibleClass</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Should be visible</p
@@ -88,6 +90,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		      > <a href=""
 		      >Int</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -110,6 +114,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		      > <a href=""
 		      >VisibleData</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -130,8 +136,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:VisibleData" class="def"
+	    > <a id="t:VisibleData" class="def"
 	    >VisibleData</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -152,6 +160,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		      > <a href=""
 		      >VisibleData</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -173,6 +183,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >VisibleData</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -183,6 +195,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >VisibleData</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -193,6 +207,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >VisibleData</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -201,6 +217,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >VisibleData</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -209,6 +227,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >VisibleData</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -217,6 +237,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >VisibleData</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -225,6 +247,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 			  >Integer</a
 			  > -&gt; <a href=""
 			  >VisibleData</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			></div
 		      ></div
@@ -240,6 +264,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstances.html")
 		      > <a href=""
 		      >VisibleData</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -66,9 +66,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Should be visible</p
@@ -88,6 +90,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		      > <a href=""
 		      >Bar</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -108,8 +112,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Bar" class="def"
+	    > <a id="t:Bar" class="def"
 	    >Bar</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -130,6 +136,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_HiddenInstancesB.html"
 		      > <a href=""
 		      >Bar</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Hyperlinks.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/IgnoreExports.html
+++ b/html-test/ref/IgnoreExports.html
@@ -64,10 +64,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_IgnoreExports.html");}
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -76,10 +78,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_IgnoreExports.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:bar" class="def"
+	  ><a id="v:bar" class="def"
 	    >bar</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -48,8 +48,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_ImplicitParams.html");
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:X" class="def"
+	    > <a id="t:X" class="def"
 	    >X</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -57,7 +59,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_ImplicitParams.html");
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:X" class="def"
+		><a id="v:X" class="def"
 		  >X</a
 		  ></td
 		><td class="doc empty"
@@ -68,17 +70,19 @@ window.onload = function () {pageLoad();setSynopsis("mini_ImplicitParams.html");
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:c" class="def"
+	  ><a id="v:c" class="def"
 	    >c</a
 	    > :: (?x :: <a href=""
 	    >X</a
 	    >) =&gt; <a href=""
 	    >X</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:d" class="def"
+	  ><a id="v:d" class="def"
 	    >d</a
 	    > :: (?x :: <a href=""
 	    >X</a
@@ -88,15 +92,19 @@ window.onload = function () {pageLoad();setSynopsis("mini_ImplicitParams.html");
 	    >X</a
 	    >, <a href=""
 	    >X</a
-	    >)</p
+	    >) <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
 	    > :: ((?x :: <a href=""
 	    >X</a
-	    >) =&gt; a) -&gt; a</p
+	    >) =&gt; a) -&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	></div
       ></div

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -56,10 +56,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs minimal"
 	  ><p class="caption"
@@ -85,25 +87,33 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:foo" class="def"
+	    ><a id="v:foo" class="def"
 	      >foo</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >Any two of these are required...</p
 	      ></div
 	    ><p class="src"
-	    ><a href="" id="v:bar" class="def"
+	    ><a id="v:bar" class="def"
 	      >bar</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:bat" class="def"
+	    ><a id="v:bat" class="def"
 	      >bat</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:fooBarBat" class="def"
+	    ><a id="v:fooBarBat" class="def"
 	      >fooBarBat</a
-	      > :: (a, a, a)</p
+	      > :: (a, a, a) <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >.. or just this</p
@@ -114,10 +124,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Weird" class="def"
+	    > <a id="t:Weird" class="def"
 	    >Weird</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs minimal"
 	  ><p class="caption"
@@ -143,43 +155,59 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:a" class="def"
+	    ><a id="v:a" class="def"
 	      >a</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:b" class="def"
+	    ><a id="v:b" class="def"
 	      >b</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:c" class="def"
+	    ><a id="v:c" class="def"
 	      >c</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:d" class="def"
+	    ><a id="v:d" class="def"
 	      >d</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:e" class="def"
+	    ><a id="v:e" class="def"
 	      >e</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:f" class="def"
+	    ><a id="v:f" class="def"
 	      >f</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:g" class="def"
+	    ><a id="v:g" class="def"
 	      >g</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:NoMins" class="def"
+	    > <a id="t:NoMins" class="def"
 	    >NoMins</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs minimal"
 	  ><p class="caption"
@@ -195,49 +223,63 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:x" class="def"
+	    ><a id="v:x" class="def"
 	      >x</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:y" class="def"
+	    ><a id="v:y" class="def"
 	      >y</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:z" class="def"
+	    ><a id="v:z" class="def"
 	      >z</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:FullMin" class="def"
+	    > <a id="t:FullMin" class="def"
 	    >FullMin</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:aaa" class="def"
+	    ><a id="v:aaa" class="def"
 	      >aaa</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:bbb" class="def"
+	    ><a id="v:bbb" class="def"
 	      >bbb</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:PartialMin" class="def"
+	    > <a id="t:PartialMin" class="def"
 	    >PartialMin</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs minimal"
 	  ><p class="caption"
@@ -251,19 +293,23 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:ccc" class="def"
+	    ><a id="v:ccc" class="def"
 	      >ccc</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:EmptyMin" class="def"
+	    > <a id="t:EmptyMin" class="def"
 	    >EmptyMin</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs minimal"
 	  ><p class="caption"
@@ -275,13 +321,17 @@ window.onload = function () {pageLoad();setSynopsis("mini_Minimal.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:eee" class="def"
+	    ><a id="v:eee" class="def"
 	      >eee</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:fff" class="def"
+	    ><a id="v:fff" class="def"
 	      >fff</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ></div
 	></div

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -62,10 +62,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_ModuleWithWarning.html
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -84,9 +84,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Nesting.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:d" class="def"
+	  ><a id="v:d" class="def"
 	    >d</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li
@@ -116,9 +118,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Nesting.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:e" class="def"
+	  ><a id="v:e" class="def"
 	    >e</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li
@@ -137,9 +141,11 @@ the presence of this text pushes it out of nesting back to the top.</li
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li
@@ -155,9 +161,11 @@ the presence of this text pushes it out of nesting back to the top.</li
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li
@@ -173,9 +181,11 @@ the presence of this text pushes it out of nesting back to the top.</li
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:h" class="def"
+	  ><a id="v:h" class="def"
 	    >h</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li
@@ -191,9 +201,11 @@ tracks</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:i" class="def"
+	  ><a id="v:i" class="def"
 	    >i</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li
@@ -241,9 +253,11 @@ More of the indented list.</p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:j" class="def"
+	  ><a id="v:j" class="def"
 	    >j</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><dl
 	    ><dt
@@ -309,9 +323,11 @@ with more of the indented list content.</p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:k" class="def"
+	  ><a id="v:k" class="def"
 	    >k</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><ul
 	    ><li

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_NoLayout.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/NonGreedy.html
+++ b/html-test/ref/NonGreedy.html
@@ -56,9 +56,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_NonGreedy.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: a</p
+	    > :: a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    ><a href=""

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -176,9 +176,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-43--45-" class="def"
+	  ><a id="v:-43--45-" class="def"
 	    >(+-)</a
-	    > :: a -&gt; a -&gt; a</p
+	    > :: a -&gt; a -&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Operator with no fixity</p
@@ -186,12 +188,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:-42--47-" class="def"
+	  ><a id="v:-42--47-" class="def"
 	    >(*/)</a
 	    > :: a -&gt; a -&gt; a <span class="fixity"
 	    >infixr 7</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -200,12 +204,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: a -&gt; a -&gt; a <span class="fixity"
 	    >infixl 3</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -216,8 +222,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -231,7 +239,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	      ><td class="src"
 		><a href=""
 		  >Foo</a
-		  > <a href="" id="v:Bar" class="def"
+		  > <a id="v:Bar" class="def"
 		  >`Bar`</a
 		  > <a href=""
 		  >Foo</a
@@ -249,7 +257,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	      ><td class="src"
 		><a href=""
 		  >Foo</a
-		  > <a href="" id="v::-45-" class="def"
+		  > <a id="v::-45-" class="def"
 		  >:-</a
 		  > <a href=""
 		  >Foo</a
@@ -270,12 +278,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >pattern</span
-	    > <a href="" id="v::-43-" class="def"
+	    > <a id="v::-43-" class="def"
 	    >(:+)</a
 	    > ::   t -&gt; t -&gt; [t] <span class="fixity"
 	    >infixr 3</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -286,7 +296,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > a <a href="" id="t:-60--45--62-" class="def"
+	    > a <a id="t:-60--45--62-" class="def"
 	    >&lt;-&gt;</a
 	    > b <span class="keyword"
 	    >where</span
@@ -294,6 +304,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	    >infixl 6</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -305,7 +317,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v::-60--45--62-" class="def"
+		><a id="v::-60--45--62-" class="def"
 		  >(:&lt;-&gt;)</a
 		  > ::  a -&gt; b -&gt; a <a href=""
 		  >&lt;-&gt;</a
@@ -324,12 +336,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > a <a href="" id="t:-43--43-" class="def"
+	    > a <a id="t:-43--43-" class="def"
 	    >++</a
 	    > b <span class="fixity"
 	    >infix 3</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -340,12 +354,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
-	    > a <a href="" id="t:-42--42-" class="def"
+	    > a <a id="t:-42--42-" class="def"
 	    >**</a
 	    > b <span class="fixity"
 	    >infix 9</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -356,7 +372,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > a <a href="" id="t:-62--60--62-" class="def"
+	    > a <a id="t:-62--60--62-" class="def"
 	    >&gt;&lt;&gt;</a
 	    > b <span class="keyword"
 	    >where</span
@@ -364,6 +380,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	    >infixr 1</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -375,31 +393,35 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	    ><p class="src"
 	    ><span class="keyword"
 	      >type</span
-	      > a <a href="" id="t:-60--62--60-" class="def"
+	      > a <a id="t:-60--62--60-" class="def"
 	      >&lt;&gt;&lt;</a
 	      > b :: * <span class="fixity"
 	      >infixl 2</span
 	      ><span class="rightedge"
 	      ></span
+	      > <a href="" class="selflink"
+	      >#</a
 	      ></p
 	    ><p class="src"
 	    ><span class="keyword"
 	      >data</span
-	      > a <a href="" id="t:-62--60--60-" class="def"
+	      > a <a id="t:-62--60--60-" class="def"
 	      >&gt;&lt;&lt;</a
 	      > b <span class="fixity"
 	      >infixl 3</span
 	      ><span class="rightedge"
 	      ></span
+	      > <a href="" class="selflink"
+	      >#</a
 	      ></p
 	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:-62--62--60-" class="def"
+	    ><a id="v:-62--62--60-" class="def"
 	      >(&gt;&gt;&lt;)</a
-	      >, <a href="" id="v:-60--60--62-" class="def"
+	      >, <a id="v:-60--60--62-" class="def"
 	      >(&lt;&lt;&gt;)</a
 	      > :: a -&gt; b -&gt; () <span class="fixity"
 	      >infixl 5 &lt;&lt;&gt;</span
@@ -407,15 +429,17 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	      >infixr 4 &gt;&gt;&lt;</span
 	      ><span class="rightedge"
 	      ></span
+	      > <a href="" class="selflink"
+	      >#</a
 	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:-42--42--62-" class="def"
+	    ><a id="v:-42--42--62-" class="def"
 	      >(**&gt;)</a
-	      >, <a href="" id="v:-42--42--60-" class="def"
+	      >, <a id="v:-42--42--60-" class="def"
 	      >(**&lt;)</a
-	      >, <a href="" id="v:-62--42--42-" class="def"
+	      >, <a id="v:-62--42--42-" class="def"
 	      >(&gt;**)</a
-	      >, <a href="" id="v:-60--42--42-" class="def"
+	      >, <a id="v:-60--42--42-" class="def"
 	      >(&lt;**)</a
 	      > :: a -&gt; a -&gt; () <span class="fixity"
 	      >infixr 8 **&gt;, &gt;**</span
@@ -423,6 +447,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	      >infixl 8 **&lt;, &lt;**</span
 	      ><span class="rightedge"
 	      ></span
+	      > <a href="" class="selflink"
+	      >#</a
 	      ></p
 	    ><div class="doc"
 	    ><p
@@ -434,7 +460,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >type</span
-	    > <a href="" id="t:-62--45--60-" class="def"
+	    > <a id="t:-62--45--60-" class="def"
 	    >(&gt;-&lt;)</a
 	    > a b = a <a href=""
 	    >&lt;-&gt;</a
@@ -442,6 +468,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Operators.html");};
 	    >infixl 6</span
 	    ><span class="rightedge"
 	    ></span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -116,9 +116,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:FooType" class="def"
+	    > <a id="t:FooType" class="def"
 	    >FooType</a
-	    > x</p
+	    > x <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >FooType doc</p
@@ -129,7 +131,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:FooCtor" class="def"
+		><a id="v:FooCtor" class="def"
 		  >FooCtor</a
 		  > x</td
 		><td class="doc empty"
@@ -142,11 +144,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >pattern</span
-	    > <a href="" id="v:Foo" class="def"
+	    > <a id="v:Foo" class="def"
 	    >Foo</a
 	    > ::   t -&gt; <a href=""
 	    >FooType</a
-	    > t</p
+	    > t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for <code
@@ -160,13 +164,15 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >pattern</span
-	    > <a href="" id="v:Bar" class="def"
+	    > <a id="v:Bar" class="def"
 	    >Bar</a
 	    > ::   t -&gt; <a href=""
 	    >FooType</a
 	    > (<a href=""
 	    >FooType</a
-	    > t)</p
+	    > t) <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for <code
@@ -180,7 +186,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >pattern</span
-	    > <a href="" id="v::-60--45--62-" class="def"
+	    > <a id="v::-60--45--62-" class="def"
 	    >(:&lt;-&gt;)</a
 	    > ::   t -&gt; t -&gt; (<a href=""
 	    >FooType</a
@@ -188,7 +194,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	    >FooType</a
 	    > (<a href=""
 	    >FooType</a
-	    > t))</p
+	    > t)) <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for (<code
@@ -202,9 +210,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > a <a href="" id="t:-62--60-" class="def"
+	    > a <a id="t:-62--60-" class="def"
 	    >&gt;&lt;</a
-	    > b</p
+	    > b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Doc for (<code
@@ -219,7 +229,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Empty" class="def"
+		><a id="v:Empty" class="def"
 		  >Empty</a
 		  ></td
 		><td class="doc empty"
@@ -232,11 +242,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_PatternSyns.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >pattern</span
-	    > <a href="" id="v:E" class="def"
+	    > <a id="v:E" class="def"
 	    >E</a
 	    > ::   <a href=""
 	    >(&gt;&lt;)</a
-	    > k t t</p
+	    > k t t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Pattern for <code

--- a/html-test/ref/PromotedTypes.html
+++ b/html-test/ref/PromotedTypes.html
@@ -48,16 +48,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:RevList" class="def"
+	    > <a id="t:RevList" class="def"
 	    >RevList</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:RNil" class="def"
+		><a id="v:RNil" class="def"
 		  >RNil</a
 		  ></td
 		><td class="doc empty"
@@ -67,7 +69,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	      ><td class="src"
 		>(<a href=""
 		  >RevList</a
-		  > a) <a href="" id="v::-62-" class="def"
+		  > a) <a id="v::-62-" class="def"
 		  >:&gt;</a
 		  > a</td
 		><td class="doc empty"
@@ -80,10 +82,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Pattern" class="def"
+	    > <a id="t:Pattern" class="def"
 	    >Pattern</a
 	    > :: [*] -&gt; * <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -91,17 +95,17 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Nil" class="def"
+		><a id="v:Nil" class="def"
 		  >Nil</a
 		  > ::  <a href=""
 		  >Pattern</a
-		  > '[]</td
+		  > []</td
 		><td class="doc empty"
 		>&nbsp;</td
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:Cons" class="def"
+		><a id="v:Cons" class="def"
 		  >Cons</a
 		  > ::  <a href=""
 		  >Maybe</a
@@ -120,12 +124,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:RevPattern" class="def"
+	    > <a id="t:RevPattern" class="def"
 	    >RevPattern</a
 	    > :: <a href=""
 	    >RevList</a
 	    > * -&gt; * <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -133,7 +139,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:RevNil" class="def"
+		><a id="v:RevNil" class="def"
 		  >RevNil</a
 		  > ::  <a href=""
 		  >RevPattern</a
@@ -145,7 +151,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:RevCons" class="def"
+		><a id="v:RevCons" class="def"
 		  >RevCons</a
 		  > ::  <a href=""
 		  >Maybe</a
@@ -166,10 +172,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Tuple" class="def"
+	    > <a id="t:Tuple" class="def"
 	    >Tuple</a
 	    > :: (*, *) -&gt; * <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -177,7 +185,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_PromotedTypes.html");}
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Tuple" class="def"
+		><a id="v:Tuple" class="def"
 		  >Tuple</a
 		  > ::  a -&gt; b -&gt; <a href=""
 		  >Tuple</a

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -60,12 +60,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Properties.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:fib" class="def"
+	  ><a id="v:fib" class="def"
 	    >fib</a
 	    > :: <a href=""
 	    >Integer</a
 	    > -&gt; <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -48,8 +48,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Expr" class="def"
+	    > <a id="t:Expr" class="def"
 	    >Expr</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -57,7 +59,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:IntExpr" class="def"
+		><a id="v:IntExpr" class="def"
 		  >IntExpr</a
 		  > <a href=""
 		  >Integer</a
@@ -67,7 +69,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:AntiIntExpr" class="def"
+		><a id="v:AntiIntExpr" class="def"
 		  >AntiIntExpr</a
 		  > <a href=""
 		  >String</a
@@ -77,7 +79,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:BinopExpr" class="def"
+		><a id="v:BinopExpr" class="def"
 		  >BinopExpr</a
 		  > <a href=""
 		  >BinOp</a
@@ -91,7 +93,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:AntiExpr" class="def"
+		><a id="v:AntiExpr" class="def"
 		  >AntiExpr</a
 		  > <a href=""
 		  >String</a
@@ -116,6 +118,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		      > <a href=""
 		      >Expr</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -135,6 +139,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 			  >Expr</a
 			  > -&gt; <a href=""
 			  >ShowS</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -143,6 +149,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 			  >Expr</a
 			  > -&gt; <a href=""
 			  >String</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -151,6 +159,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 			  >Expr</a
 			  >] -&gt; <a href=""
 			  >ShowS</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			></div
 		      ></div
@@ -164,8 +174,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:BinOp" class="def"
+	    > <a id="t:BinOp" class="def"
 	    >BinOp</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
@@ -173,7 +185,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:AddOp" class="def"
+		><a id="v:AddOp" class="def"
 		  >AddOp</a
 		  ></td
 		><td class="doc empty"
@@ -181,7 +193,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:SubOp" class="def"
+		><a id="v:SubOp" class="def"
 		  >SubOp</a
 		  ></td
 		><td class="doc empty"
@@ -189,7 +201,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:MulOp" class="def"
+		><a id="v:MulOp" class="def"
 		  >MulOp</a
 		  ></td
 		><td class="doc empty"
@@ -197,7 +209,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:DivOp" class="def"
+		><a id="v:DivOp" class="def"
 		  >DivOp</a
 		  ></td
 		><td class="doc empty"
@@ -220,6 +232,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 		      > <a href=""
 		      >BinOp</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -239,6 +253,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 			  >BinOp</a
 			  > -&gt; <a href=""
 			  >ShowS</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -247,6 +263,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 			  >BinOp</a
 			  > -&gt; <a href=""
 			  >String</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			><p class="src"
 			><a href=""
@@ -255,6 +273,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 			  >BinOp</a
 			  >] -&gt; <a href=""
 			  >ShowS</a
+			  > <a href="" class="selflink"
+			  >#</a
 			  ></p
 			></div
 		      ></div
@@ -266,27 +286,33 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiExpr.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:eval" class="def"
+	  ><a id="v:eval" class="def"
 	    >eval</a
 	    > :: <a href=""
 	    >Expr</a
 	    > -&gt; <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:expr" class="def"
+	  ><a id="v:expr" class="def"
 	    >expr</a
-	    > :: QuasiQuoter</p
+	    > :: QuasiQuoter <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:parseExprExp" class="def"
+	  ><a id="v:parseExprExp" class="def"
 	    >parseExprExp</a
 	    > :: <a href=""
 	    >String</a
-	    > -&gt; Q Exp</p
+	    > -&gt; Q Exp <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	></div
       ></div

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -46,10 +46,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_QuasiQuote.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:val" class="def"
+	  ><a id="v:val" class="def"
 	    >val</a
 	    > :: <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -74,9 +74,11 @@ Fix spurious superclass constraints bug.</pre
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:SomeType" class="def"
+	    > <a id="t:SomeType" class="def"
 	    >SomeType</a
-	    > f a</p
+	    > f a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs instances"
 	  ><p id="control.i:SomeType" class="caption collapser" onclick="toggleSection('i:SomeType')"
 	    >Instances</p
@@ -92,6 +94,8 @@ Fix spurious superclass constraints bug.</pre
 		      > (<a href=""
 		      >SomeType</a
 		      > f)</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -109,7 +113,9 @@ Fix spurious superclass constraints bug.</pre
 			  >SomeType</a
 			  > f a -&gt; <a href=""
 			  >SomeType</a
-			  > f b</p
+			  > f b <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><a href=""
 			  >(&lt;$)</a
@@ -117,7 +123,9 @@ Fix spurious superclass constraints bug.</pre
 			  >SomeType</a
 			  > f b -&gt; <a href=""
 			  >SomeType</a
-			  > f a</p
+			  > f a <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -134,6 +142,8 @@ Fix spurious superclass constraints bug.</pre
 		      > (<a href=""
 		      >SomeType</a
 		      > f)</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -149,7 +159,9 @@ Fix spurious superclass constraints bug.</pre
 			  >pure</a
 			  > :: a -&gt; <a href=""
 			  >SomeType</a
-			  > f a</p
+			  > f a <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><a href=""
 			  >(&lt;*&gt;)</a
@@ -159,7 +171,9 @@ Fix spurious superclass constraints bug.</pre
 			  >SomeType</a
 			  > f a -&gt; <a href=""
 			  >SomeType</a
-			  > f b</p
+			  > f b <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><a href=""
 			  >(*&gt;)</a
@@ -169,7 +183,9 @@ Fix spurious superclass constraints bug.</pre
 			  >SomeType</a
 			  > f b -&gt; <a href=""
 			  >SomeType</a
-			  > f b</p
+			  > f b <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><a href=""
 			  >(&lt;*)</a
@@ -179,7 +195,9 @@ Fix spurious superclass constraints bug.</pre
 			  >SomeType</a
 			  > f b -&gt; <a href=""
 			  >SomeType</a
-			  > f a</p
+			  > f a <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td

--- a/html-test/ref/TH.html
+++ b/html-test/ref/TH.html
@@ -46,9 +46,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TH.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:decl" class="def"
+	  ><a id="v:decl" class="def"
 	    >decl</a
-	    > :: Q [Dec]</p
+	    > :: Q [Dec] <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	></div
       ></div

--- a/html-test/ref/TH2.html
+++ b/html-test/ref/TH2.html
@@ -46,9 +46,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TH2.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: t -&gt; t</p
+	    > :: t -&gt; t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	></div
       ></div

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -661,9 +661,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T" class="def"
+	    > <a id="t:T" class="def"
 	    >T</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >This comment applies to the <em
@@ -677,7 +679,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A" class="def"
+		><a id="v:A" class="def"
 		  >A</a
 		  > <a href=""
 		  >Int</a
@@ -697,7 +699,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:B" class="def"
+		><a id="v:B" class="def"
 		  >B</a
 		  > (<a href=""
 		  >T</a
@@ -724,9 +726,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T2" class="def"
+	    > <a id="t:T2" class="def"
 	    >T2</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >An abstract data declaration</p
@@ -736,9 +740,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T3" class="def"
+	    > <a id="t:T3" class="def"
 	    >T3</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >A data declaration with no documentation annotations on the constructors</p
@@ -749,7 +755,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A1" class="def"
+		><a id="v:A1" class="def"
 		  >A1</a
 		  > a</td
 		><td class="doc empty"
@@ -757,7 +763,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:B1" class="def"
+		><a id="v:B1" class="def"
 		  >B1</a
 		  > b</td
 		><td class="doc empty"
@@ -770,16 +776,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T4" class="def"
+	    > <a id="t:T4" class="def"
 	    >T4</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A2" class="def"
+		><a id="v:A2" class="def"
 		  >A2</a
 		  > a</td
 		><td class="doc empty"
@@ -787,7 +795,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:B2" class="def"
+		><a id="v:B2" class="def"
 		  >B2</a
 		  > b</td
 		><td class="doc empty"
@@ -800,16 +808,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T5" class="def"
+	    > <a id="t:T5" class="def"
 	    >T5</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A3" class="def"
+		><a id="v:A3" class="def"
 		  >A3</a
 		  > a</td
 		><td class="doc"
@@ -823,7 +833,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:B3" class="def"
+		><a id="v:B3" class="def"
 		  >B3</a
 		  > b</td
 		><td class="doc"
@@ -842,8 +852,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:T6" class="def"
+	    > <a id="t:T6" class="def"
 	    >T6</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -855,7 +867,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:A4" class="def"
+		><a id="v:A4" class="def"
 		  >A4</a
 		  ></td
 		><td class="doc"
@@ -869,7 +881,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:B4" class="def"
+		><a id="v:B4" class="def"
 		  >B4</a
 		  ></td
 		><td class="doc"
@@ -883,7 +895,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:C4" class="def"
+		><a id="v:C4" class="def"
 		  >C4</a
 		  ></td
 		><td class="doc"
@@ -902,9 +914,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:N1" class="def"
+	    > <a id="t:N1" class="def"
 	    >N1</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >A newtype</p
@@ -915,7 +929,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:N1" class="def"
+		><a id="v:N1" class="def"
 		  >N1</a
 		  > a</td
 		><td class="doc empty"
@@ -928,9 +942,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:N2" class="def"
+	    > <a id="t:N2" class="def"
 	    >N2</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >A newtype with a fieldname</p
@@ -941,7 +957,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:N2" class="def"
+		><a id="v:N2" class="def"
 		  >N2</a
 		  ></td
 		><td class="doc empty"
@@ -955,7 +971,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:n" class="def"
+			><a id="v:n" class="def"
 			  >n</a
 			  > :: a b</dfn
 			><div class="doc empty"
@@ -972,9 +988,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:N3" class="def"
+	    > <a id="t:N3" class="def"
 	    >N3</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >A newtype with a fieldname, documentation on the field</p
@@ -985,7 +1003,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:N3" class="def"
+		><a id="v:N3" class="def"
 		  >N3</a
 		  ></td
 		><td class="doc empty"
@@ -999,7 +1017,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:n3" class="def"
+			><a id="v:n3" class="def"
 			  >n3</a
 			  > :: a b</dfn
 			><div class="doc"
@@ -1022,9 +1040,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:N4" class="def"
+	    > <a id="t:N4" class="def"
 	    >N4</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >An abstract newtype - we show this one as data rather than newtype because
@@ -1035,16 +1055,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:N5" class="def"
+	    > <a id="t:N5" class="def"
 	    >N5</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:N5" class="def"
+		><a id="v:N5" class="def"
 		  >N5</a
 		  ></td
 		><td class="doc empty"
@@ -1058,7 +1080,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:n5" class="def"
+			><a id="v:n5" class="def"
 			  >n5</a
 			  > :: a b</dfn
 			><div class="doc"
@@ -1077,16 +1099,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:N6" class="def"
+	    > <a id="t:N6" class="def"
 	    >N6</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:N6" class="def"
+		><a id="v:N6" class="def"
 		  >N6</a
 		  ></td
 		><td class="doc"
@@ -1102,7 +1126,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:n6" class="def"
+			><a id="v:n6" class="def"
 			  >n6</a
 			  > :: a b</dfn
 			><div class="doc empty"
@@ -1119,9 +1143,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:N7" class="def"
+	    > <a id="t:N7" class="def"
 	    >N7</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >docs on the newtype and the constructor</p
@@ -1132,7 +1158,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:N7" class="def"
+		><a id="v:N7" class="def"
 		  >N7</a
 		  ></td
 		><td class="doc"
@@ -1152,7 +1178,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:n7" class="def"
+			><a id="v:n7" class="def"
 			  >n7</a
 			  > :: a b</dfn
 			><div class="doc empty"
@@ -1171,8 +1197,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:R" class="def"
+	    > <a id="t:R" class="def"
 	    >R</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -1205,7 +1233,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:C1" class="def"
+		><a id="v:C1" class="def"
 		  >C1</a
 		  ></td
 		><td class="doc"
@@ -1225,7 +1253,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:p" class="def"
+			><a id="v:p" class="def"
 			  >p</a
 			  > :: <a href=""
 			  >Int</a
@@ -1241,7 +1269,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:q" class="def"
+			><a id="v:q" class="def"
 			  >q</a
 			  > :: <span class="keyword"
 			  >forall</span
@@ -1257,9 +1285,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:r" class="def"
+			><a id="v:r" class="def"
 			  >r</a
-			  >, <a href="" id="v:s" class="def"
+			  >, <a id="v:s" class="def"
 			  >s</a
 			  > :: <a href=""
 			  >Int</a
@@ -1283,7 +1311,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:C2" class="def"
+		><a id="v:C2" class="def"
 		  >C2</a
 		  ></td
 		><td class="doc"
@@ -1303,7 +1331,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:t" class="def"
+			><a id="v:t" class="def"
 			  >t</a
 			  > :: T1 -&gt; <a href=""
 			  >T2</a
@@ -1331,9 +1359,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:u" class="def"
+			><a id="v:u" class="def"
 			  >u</a
-			  >, <a href="" id="v:v" class="def"
+			  >, <a id="v:v" class="def"
 			  >v</a
 			  > :: <a href=""
 			  >Int</a
@@ -1352,8 +1380,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:R1" class="def"
+	    > <a id="t:R1" class="def"
 	    >R1</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -1365,7 +1395,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:C3" class="def"
+		><a id="v:C3" class="def"
 		  >C3</a
 		  ></td
 		><td class="doc"
@@ -1385,7 +1415,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:s1" class="def"
+			><a id="v:s1" class="def"
 			  >s1</a
 			  > :: <a href=""
 			  >Int</a
@@ -1401,7 +1431,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:s2" class="def"
+			><a id="v:s2" class="def"
 			  >s2</a
 			  > :: <a href=""
 			  >Int</a
@@ -1417,7 +1447,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			></li
 		      ><li
 		      ><dfn class="src"
-			><a href="" id="v:s3" class="def"
+			><a id="v:s3" class="def"
 			  >s3</a
 			  > :: <a href=""
 			  >Int</a
@@ -1450,10 +1480,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	    >class</span
 	    > <a href=""
 	    >D</a
-	    > a =&gt; <a href="" id="t:C" class="def"
+	    > a =&gt; <a id="t:C" class="def"
 	    >C</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -1469,11 +1501,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:a" class="def"
+	    ><a id="v:a" class="def"
 	      >a</a
 	      > :: <a href=""
 	      >IO</a
-	      > a</p
+	      > a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >this is a description of the <code
@@ -1483,9 +1517,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		> method</p
 	      ></div
 	    ><p class="src"
-	    ><a href="" id="v:b" class="def"
+	    ><a id="v:b" class="def"
 	      >b</a
-	      > :: [a]</p
+	      > :: [a] <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >this is a description of the <code
@@ -1500,10 +1536,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:D" class="def"
+	    > <a id="t:D" class="def"
 	    >D</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -1513,15 +1551,19 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:d" class="def"
+	    ><a id="v:d" class="def"
 	      >d</a
 	      > :: <a href=""
 	      >T</a
-	      > a b</p
+	      > a b <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><p class="src"
-	    ><a href="" id="v:e" class="def"
+	    ><a id="v:e" class="def"
 	      >e</a
-	      > :: (a, a)</p
+	      > :: (a, a) <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ><div class="subs instances"
 	  ><p id="control.i:D" class="caption collapser" onclick="toggleSection('i:D')"
@@ -1538,6 +1580,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		      > <a href=""
 		      >Float</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -1555,7 +1599,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			  >T</a
 			  > <a href=""
 			  >Float</a
-			  > b</p
+			  > b <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><a href=""
 			  >e</a
@@ -1563,7 +1609,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			  >Float</a
 			  >, <a href=""
 			  >Float</a
-			  >)</p
+			  >) <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -1578,6 +1626,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 		      > <a href=""
 		      >Int</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -1595,7 +1645,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			  >T</a
 			  > <a href=""
 			  >Int</a
-			  > b</p
+			  > b <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><a href=""
 			  >e</a
@@ -1603,7 +1655,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 			  >Int</a
 			  >, <a href=""
 			  >Int</a
-			  >)</p
+			  >) <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -1616,9 +1670,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:E" class="def"
+	    > <a id="t:E" class="def"
 	    >E</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >This is a class declaration with no methods (or no methods exported)</p
@@ -1634,18 +1690,22 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:F" class="def"
+	    > <a id="t:F" class="def"
 	    >F</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:ff" class="def"
+	    ><a id="v:ff" class="def"
 	      >ff</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ></div
 	  ></div
 	><div class="doc"
@@ -1656,12 +1716,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Test.html");};
 	>Function types</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
 	    > :: <a href=""
 	    >C</a
 	    > a =&gt; a -&gt; <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -1718,13 +1780,15 @@ using double quotes: <a href=""
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
 	    > :: <a href=""
 	    >Int</a
 	    > -&gt; <a href=""
 	    >IO</a
-	    > CInt</p
+	    > CInt <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >we can export foreign declarations too</p
@@ -1827,12 +1891,14 @@ is at the beginning of the line).</pre
 	>A hidden module</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:hidden" class="def"
+	  ><a id="v:hidden" class="def"
 	    >hidden</a
 	    > :: <a href=""
 	    >Int</a
 	    > -&gt; <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	><h1 id="g:8"
@@ -1853,9 +1919,11 @@ is at the beginning of the line).</pre
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Ex" class="def"
+	    > <a id="t:Ex" class="def"
 	    >Ex</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >A data-type using existential/universal types</p
@@ -1870,7 +1938,7 @@ is at the beginning of the line).</pre
 		  >forall</span
 		  > b . <a href=""
 		  >C</a
-		  > b =&gt; <a href="" id="v:Ex1" class="def"
+		  > b =&gt; <a id="v:Ex1" class="def"
 		  >Ex1</a
 		  > b</td
 		><td class="doc empty"
@@ -1880,7 +1948,7 @@ is at the beginning of the line).</pre
 	      ><td class="src"
 		><span class="keyword"
 		  >forall</span
-		  > b . <a href="" id="v:Ex2" class="def"
+		  > b . <a id="v:Ex2" class="def"
 		  >Ex2</a
 		  > b</td
 		><td class="doc empty"
@@ -1892,7 +1960,7 @@ is at the beginning of the line).</pre
 		  >forall</span
 		  > b . <a href=""
 		  >C</a
-		  > a =&gt; <a href="" id="v:Ex3" class="def"
+		  > a =&gt; <a id="v:Ex3" class="def"
 		  >Ex3</a
 		  > b</td
 		><td class="doc empty"
@@ -1900,7 +1968,7 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:Ex4" class="def"
+		><a id="v:Ex4" class="def"
 		  >Ex4</a
 		  > (<span class="keyword"
 		  >forall</span
@@ -1915,8 +1983,10 @@ is at the beginning of the line).</pre
 	>Type signatures with argument docs</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:k" class="def"
+	  ><a id="v:k" class="def"
 	    >k</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -2003,8 +2073,10 @@ is at the beginning of the line).</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:l" class="def"
+	  ><a id="v:l" class="def"
 	    >l</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -2043,8 +2115,10 @@ is at the beginning of the line).</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:m" class="def"
+	  ><a id="v:m" class="def"
 	    >m</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -2089,8 +2163,10 @@ is at the beginning of the line).</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:o" class="def"
+	  ><a id="v:o" class="def"
 	    >o</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs arguments"
 	  ><p class="caption"
@@ -2139,10 +2215,12 @@ is at the beginning of the line).</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f-39-" class="def"
+	  ><a id="v:f-39-" class="def"
 	    >f'</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -2156,10 +2234,12 @@ is at the beginning of the line).</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:withType" class="def"
+	  ><a id="v:withType" class="def"
 	    >withType</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -2168,9 +2248,11 @@ is at the beginning of the line).</pre
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:withoutType" class="def"
+	  ><a id="v:withoutType" class="def"
 	    >withoutType</a
-	    > :: t</p
+	    > :: t <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Comment on a definition without type signature</p

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -68,10 +68,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Threaded.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
 	    > :: <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -56,9 +56,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket112.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: a</p
+	    > :: a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >...given a raw <code

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -48,18 +48,22 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket61.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:C" class="def"
+	    > <a id="t:C" class="def"
 	    >C</a
 	    > a <span class="keyword"
 	    >where</span
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
 	    ><p class="src"
-	    ><a href="" id="v:f" class="def"
+	    ><a id="v:f" class="def"
 	      >f</a
-	      > :: a</p
+	      > :: a <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >A comment about f</p

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -68,16 +68,18 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket75.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > a <a href="" id="t::-45-" class="def"
+	    > a <a id="t::-45-" class="def"
 	    >:-</a
-	    > b</p
+	    > b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:Q" class="def"
+		><a id="v:Q" class="def"
 		  >Q</a
 		  ></td
 		><td class="doc empty"
@@ -88,10 +90,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Ticket75.html");};
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -64,10 +64,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TitledPicture.html");}
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:foo" class="def"
+	  ><a id="v:foo" class="def"
 	    >foo</a
 	    > :: <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -81,10 +83,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_TitledPicture.html");}
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:bar" class="def"
+	  ><a id="v:bar" class="def"
 	    >bar</a
 	    > :: <a href=""
 	    >Integer</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -162,8 +162,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:X" class="def"
+	    > <a id="t:X" class="def"
 	    >X</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -175,7 +177,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:X" class="def"
+		><a id="v:X" class="def"
 		  >X</a
 		  ></td
 		><td class="doc"
@@ -185,7 +187,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:XX" class="def"
+		><a id="v:XX" class="def"
 		  >XX</a
 		  ></td
 		><td class="doc"
@@ -195,7 +197,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:XXX" class="def"
+		><a id="v:XXX" class="def"
 		  >XXX</a
 		  ></td
 		><td class="doc"
@@ -220,6 +222,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -239,7 +243,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocD</a
 			  > (<a href=""
 			  >X</a
-			  > :: k)</p
+			  > :: k) <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><span class="keyword"
 			  >type</span
@@ -247,7 +253,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocT</a
 			  > (<a href=""
 			  >X</a
-			  > :: k) :: *</p
+			  > :: k) :: * <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -262,6 +270,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -288,6 +298,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > <a href=""
 		      >XXX</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -310,6 +322,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -325,9 +339,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >AssocD</a
 		      > * <a href=""
 		      >X</a
-		      > = <a href="" id="v:AssocX" class="def"
+		      > = <a id="v:AssocX" class="def"
 		      >AssocX</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -346,6 +362,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -361,23 +379,23 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >X</a
 		      > <ul class="inst"
 		      ><li class="inst"
-			>= <a href="" id="v:BatX" class="def"
+			>= <a id="v:BatX" class="def"
 			  >BatX</a
 			  > <a href=""
 			  >X</a
 			  ></li
 			><li class="inst"
-			>| <a href="" id="v:BatXX" class="def"
+			>| <a id="v:BatXX" class="def"
 			  >BatXX</a
 			  > { <ul class="subs"
 			  ><li
-			    ><a href="" id="v:aaa" class="def"
+			    ><a id="v:aaa" class="def"
 			      >aaa</a
 			      > :: <a href=""
 			      >X</a
 			      ></li
 			    ><li
-			    ><a href="" id="v:bbb" class="def"
+			    ><a id="v:bbb" class="def"
 			      >bbb</a
 			      > :: <a href=""
 			      >Y</a
@@ -386,6 +404,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  > }</li
 			></ul
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -404,6 +424,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -422,6 +444,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > a = <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -442,6 +466,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -454,8 +480,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Y" class="def"
+	    > <a id="t:Y" class="def"
 	    >Y</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -476,6 +504,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -495,7 +525,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocD</a
 			  > (<a href=""
 			  >Y</a
-			  > :: k)</p
+			  > :: k) <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><span class="keyword"
 			  >type</span
@@ -503,7 +535,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocT</a
 			  > (<a href=""
 			  >Y</a
-			  > :: k) :: *</p
+			  > :: k) :: * <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -518,6 +552,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -540,6 +576,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -553,9 +591,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >AssocD</a
 		      > * <a href=""
 		      >Y</a
-		      > = <a href="" id="v:AssocY" class="def"
+		      > = <a id="v:AssocY" class="def"
 		      >AssocY</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -574,6 +614,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -587,11 +629,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >Bat</a
 		      > * <a href=""
 		      >Y</a
-		      > = <a href="" id="v:BatY" class="def"
+		      > = <a id="v:BatY" class="def"
 		      >BatY</a
 		      > <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -610,6 +654,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -626,6 +672,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      > a = a</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -638,8 +686,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Z" class="def"
+	    > <a id="t:Z" class="def"
 	    >Z</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -651,7 +701,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:ZA" class="def"
+		><a id="v:ZA" class="def"
 		  >ZA</a
 		  ></td
 		><td class="doc empty"
@@ -659,7 +709,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="" id="v:ZB" class="def"
+		><a id="v:ZB" class="def"
 		  >ZB</a
 		  ></td
 		><td class="doc empty"
@@ -685,7 +735,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >where</span
 		      ><ul class="inst"
 		      ><li class="inst"
-			><a href="" id="v:BatZ1" class="def"
+			><a id="v:BatZ1" class="def"
 			  >BatZ1</a
 			  > ::  <a href=""
 			  >Z</a
@@ -697,17 +747,17 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >ZA</a
 			  ></li
 			><li class="inst"
-			><a href="" id="v:BatZ2" class="def"
+			><a id="v:BatZ2" class="def"
 			  >BatZ2</a
 			  > :: { <ul class="subs"
 			  ><li
-			    ><a href="" id="v:batx" class="def"
+			    ><a id="v:batx" class="def"
 			      >batx</a
 			      > :: <a href=""
 			      >X</a
 			      ></li
 			    ><li
-			    ><a href="" id="v:baty" class="def"
+			    ><a id="v:baty" class="def"
 			      >baty</a
 			      > :: <a href=""
 			      >Y</a
@@ -722,6 +772,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  ></li
 			></ul
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -736,9 +788,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Test" class="def"
+	    > <a id="t:Test" class="def"
 	    >Test</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Doc for: class Test a</p
@@ -758,6 +812,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -780,6 +836,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -800,9 +858,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
-	    > a :: k</p
+	    > a :: k <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Doc for: type family Foo a</p
@@ -824,6 +884,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -842,6 +904,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -856,9 +920,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
-	    > <a href="" id="t:Bat" class="def"
+	    > <a id="t:Bat" class="def"
 	    >Bat</a
-	    > a :: *</p
+	    > a :: * <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Doc for: data family Bat a</p
@@ -881,7 +947,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >where</span
 		      ><ul class="inst"
 		      ><li class="inst"
-			><a href="" id="v:BatZ1" class="def"
+			><a id="v:BatZ1" class="def"
 			  >BatZ1</a
 			  > ::  <a href=""
 			  >Z</a
@@ -893,17 +959,17 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >ZA</a
 			  ></li
 			><li class="inst"
-			><a href="" id="v:BatZ2" class="def"
+			><a id="v:BatZ2" class="def"
 			  >BatZ2</a
 			  > :: { <ul class="subs"
 			  ><li
-			    ><a href="" id="v:batx" class="def"
+			    ><a id="v:batx" class="def"
 			      >batx</a
 			      > :: <a href=""
 			      >X</a
 			      ></li
 			    ><li
-			    ><a href="" id="v:baty" class="def"
+			    ><a id="v:baty" class="def"
 			      >baty</a
 			      > :: <a href=""
 			      >Y</a
@@ -918,6 +984,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  ></li
 			></ul
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -933,11 +1001,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >Bat</a
 		      > * <a href=""
 		      >Y</a
-		      > = <a href="" id="v:BatY" class="def"
+		      > = <a id="v:BatY" class="def"
 		      >BatY</a
 		      > <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -955,23 +1025,23 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      >X</a
 		      > <ul class="inst"
 		      ><li class="inst"
-			>= <a href="" id="v:BatX" class="def"
+			>= <a id="v:BatX" class="def"
 			  >BatX</a
 			  > <a href=""
 			  >X</a
 			  ></li
 			><li class="inst"
-			>| <a href="" id="v:BatXX" class="def"
+			>| <a id="v:BatXX" class="def"
 			  >BatXX</a
 			  > { <ul class="subs"
 			  ><li
-			    ><a href="" id="v:aaa" class="def"
+			    ><a id="v:aaa" class="def"
 			      >aaa</a
 			      > :: <a href=""
 			      >X</a
 			      ></li
 			    ><li
-			    ><a href="" id="v:bbb" class="def"
+			    ><a id="v:bbb" class="def"
 			      >bbb</a
 			      > :: <a href=""
 			      >Y</a
@@ -980,6 +1050,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  > }</li
 			></ul
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -994,9 +1066,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="" id="t:Assoc" class="def"
+	    > <a id="t:Assoc" class="def"
 	    >Assoc</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Doc for: class Assoc a</p
@@ -1007,9 +1081,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	    ><p class="src"
 	    ><span class="keyword"
 	      >data</span
-	      > <a href="" id="t:AssocD" class="def"
+	      > <a id="t:AssocD" class="def"
 	      >AssocD</a
-	      > a :: *</p
+	      > a :: * <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >Doc for: data AssocD a</p
@@ -1017,9 +1093,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	    ><p class="src"
 	    ><span class="keyword"
 	      >type</span
-	      > <a href="" id="t:AssocT" class="def"
+	      > <a id="t:AssocT" class="def"
 	      >AssocT</a
-	      > a :: *</p
+	      > a :: * <a href="" class="selflink"
+	      >#</a
+	      ></p
 	    ><div class="doc"
 	    ><p
 	      >Doc for: type AssocT a</p
@@ -1040,6 +1118,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -1059,7 +1139,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocD</a
 			  > (<a href=""
 			  >Y</a
-			  > :: k)</p
+			  > :: k) <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><span class="keyword"
 			  >type</span
@@ -1067,7 +1149,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocT</a
 			  > (<a href=""
 			  >Y</a
-			  > :: k) :: *</p
+			  > :: k) :: * <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -1082,6 +1166,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -1101,7 +1187,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocD</a
 			  > (<a href=""
 			  >X</a
-			  > :: k)</p
+			  > :: k) <a href="" class="selflink"
+			  >#</a
+			  ></p
 			><p class="src"
 			><span class="keyword"
 			  >type</span
@@ -1109,7 +1197,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 			  >AssocT</a
 			  > (<a href=""
 			  >X</a
-			  > :: k) :: *</p
+			  > :: k) :: * <a href="" class="selflink"
+			  >#</a
+			  ></p
 			></div
 		      ></div
 		    ></td
@@ -1122,9 +1212,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > <a href="" id="t:Bar" class="def"
+	    > <a id="t:Bar" class="def"
 	    >Bar</a
-	    > b</p
+	    > b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Doc for: type family Bar b</p
@@ -1162,9 +1254,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > a <a href="" id="t:-60--62-" class="def"
+	    > a <a id="t:-60--62-" class="def"
 	    >&lt;&gt;</a
-	    > b :: k</p
+	    > b :: k <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs instances"
 	  ><p id="control.i:-60--62-" class="caption collapser" onclick="toggleSection('i:-60--62-')"
 	    >Instances</p
@@ -1180,6 +1274,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > * <a href=""
 		      >Y</a
 		      > a = a</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -1196,6 +1292,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > a = <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -1216,6 +1314,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > = <a href=""
 		      >X</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td
@@ -1228,9 +1328,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > a <a href="" id="t:-62--60-" class="def"
+	    > a <a id="t:-62--60-" class="def"
 	    >&gt;&lt;</a
-	    > b</p
+	    > b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs instances"
 	  ><p id="control.i:-62--60-" class="caption collapser" onclick="toggleSection('i:-62--60-')"
 	    >Instances</p
@@ -1250,6 +1352,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies.html");};
 		      > <a href=""
 		      >XXX</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -72,8 +72,10 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:W" class="def"
+	    > <a id="t:W" class="def"
 	    >W</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
@@ -93,9 +95,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 		      >Bar</a
 		      > <a href=""
 		      >W</a
-		      > = <a href="" id="v:BarX" class="def"
+		      > = <a id="v:BarX" class="def"
 		      >BarX</a
 		      > Z</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -112,6 +116,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 		      > <a href=""
 		      >W</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -126,9 +132,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > <a href="" id="t:Foo" class="def"
+	    > <a id="t:Foo" class="def"
 	    >Foo</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Exported type family</p
@@ -148,6 +156,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 		      > <a href=""
 		      >W</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -166,6 +176,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 		      > = <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -180,9 +192,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
-	    > <a href="" id="t:Bar" class="def"
+	    > <a id="t:Bar" class="def"
 	    >Bar</a
-	    > a</p
+	    > a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Exported data family</p
@@ -201,9 +215,11 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 		      >Bar</a
 		      > <a href=""
 		      >W</a
-		      > = <a href="" id="v:BarX" class="def"
+		      > = <a id="v:BarX" class="def"
 		      >BarX</a
 		      > Z</span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc"
 		  ><p
@@ -220,6 +236,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeFamilies2.html");}
 		      > <a href=""
 		      >Y</a
 		      ></span
+		    > <a href="" class="selflink"
+		    >#</a
 		    ></td
 		  ><td class="doc empty"
 		  >&nbsp;</td

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -48,40 +48,48 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeOperators.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > a <a href="" id="t::-45-:" class="def"
+	    > a <a id="t::-45-:" class="def"
 	    >:-:</a
-	    > b</p
+	    > b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > (a <a href="" id="t::-43-:" class="def"
+	    > (a <a id="t::-43-:" class="def"
 	    >:+:</a
-	    > b) c</p
+	    > b) c <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > <a href="" id="t:Op" class="def"
+	    > <a id="t:Op" class="def"
 	    >Op</a
-	    > a b</p
+	    > a b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
 	    >newtype</span
-	    > <a href="" id="t:O" class="def"
+	    > <a id="t:O" class="def"
 	    >O</a
-	    > g f a</p
+	    > g f a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ><div class="subs constructors"
 	  ><p class="caption"
 	    >Constructors</p
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="" id="v:O" class="def"
+		><a id="v:O" class="def"
 		  >O</a
 		  ></td
 		><td class="doc empty"
@@ -95,7 +103,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeOperators.html");}
 		    ><ul
 		    ><li
 		      ><dfn class="src"
-			><a href="" id="v:unO" class="def"
+			><a id="v:unO" class="def"
 			  >unO</a
 			  > :: g (f a)</dfn
 			><div class="doc empty"
@@ -112,33 +120,41 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeOperators.html");}
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > a <a href="" id="t:-60--61--62-" class="def"
+	    > a <a id="t:-60--61--62-" class="def"
 	    >&lt;=&gt;</a
-	    > b</p
+	    > b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:biO" class="def"
+	  ><a id="v:biO" class="def"
 	    >biO</a
 	    > :: (g <a href=""
 	    >`O`</a
-	    > f) a</p
+	    > f) a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:f" class="def"
+	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: (a ~ b) =&gt; a -&gt; b</p
+	    > :: (a ~ b) =&gt; a -&gt; b <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:g" class="def"
+	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: (a ~ b, b ~ c) =&gt; a -&gt; c</p
+	    > :: (a ~ b, b ~ c) =&gt; a -&gt; c <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:x" class="def"
+	  ><a id="v:x" class="def"
 	    >x</a
 	    > :: (a <a href=""
 	    >:-:</a
@@ -146,11 +162,13 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeOperators.html");}
 	    >&lt;=&gt;</a
 	    > (a <a href=""
 	    >`Op`</a
-	    > a) =&gt; a</p
+	    > a) =&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:y" class="def"
+	  ><a id="v:y" class="def"
 	    >y</a
 	    > :: (a <a href=""
 	    >&lt;=&gt;</a
@@ -158,7 +176,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_TypeOperators.html");}
 	    >`Op`</a
 	    > a) <a href=""
 	    >&lt;=&gt;</a
-	    > a) =&gt; a</p
+	    > a) =&gt; a <a href="" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	></div
       ></div

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -58,10 +58,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Unicode.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:x" class="def"
+	  ><a id="v:x" class="def"
 	    >x</a
 	    > :: <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -46,12 +46,14 @@ window.onload = function () {pageLoad();setSynopsis("mini_Visible.html");};
 	>Documentation</h1
 	><div class="top"
 	><p class="src"
-	  ><a href="" id="v:visible" class="def"
+	  ><a id="v:visible" class="def"
 	    >visible</a
 	    > :: <a href=""
 	    >Int</a
 	    > -&gt; <a href=""
 	    >Int</a
+	    > <a href="" class="selflink"
+	    >#</a
 	    ></p
 	  ></div
 	></div

--- a/html-test/ref/ocean.css
+++ b/html-test/ref/ocean.css
@@ -159,6 +159,8 @@ p.caption.expander {
 .instance.collapser, .instance.expander {
   margin-left: 0px;
   background-position: left center;
+  min-width: 9px;
+  min-height: 9px;
 }
 
 
@@ -379,21 +381,16 @@ div#style-menu-holder {
 #interface h5 + div.top {
  	margin-top: 1em;
 }
-#interface p.src .link {
+#interface .src .selflink,
+#interface .src .link {
   float: right;
   color: #919191;
-  border-left: 1px solid #919191;
   background: #f0f0f0;
   padding: 0 0.5em 0.2em;
-  margin: 0 -0.5em 0 0.5em;
+  margin: 0 -0.5em 0 0;
 }
-
-#interface td.src .link {
-  float: right;
-  color: #919191;
+#interface .src .selflink {
   border-left: 1px solid #919191;
-  background: #f0f0f0;
-  padding: 0 0.5em 0.2em;
   margin: 0 -0.5em 0 0.5em;
 }
 


### PR DESCRIPTION
Since pull request #407, the identifiers have been permalinked to themselves, but this makes it difficult to copy the identifier by double-clicking.  To work around this usability problem, the permalinks are now placed on the far right adjacent to "Source", indicated by "#".

Also, `namedAnchor` now uses `id` instead of `name` (which is obsolete).

![screenshot 2015-09-30 03 13 59](https://cloud.githubusercontent.com/assets/6571068/10186778/b0459bcc-6721-11e5-9634-8770b010a67c.png)
