### PR TITLE
Collapse type/data family instances by default

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -594,20 +594,25 @@ ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) =
             , [subInstDetails iid ats sigs]
             )
           where
-            iid = instanceId origin no orphan ihd
             sigs = ppInstanceSigs links splice unicode qual clsiSigs
             ats = ppInstanceAssocTys links splice unicode qual clsiAssocTys
         TypeInst rhs ->
-            (ptype, mdoc, [])
+            ( subInstHead iid ptype
+            , mdoc
+            , [subFamInstDetails iid prhs]
+            )
           where
-            ptype = keyword "type" <+> typ <+> prhs
+            ptype = keyword "type" <+> typ
             prhs = maybe noHtml (\t -> equals <+> ppType unicode qual t) rhs
         DataInst dd ->
-            (pdata, mdoc, [])
+            ( subInstHead iid pdata
+            , mdoc
+            , [subFamInstDetails iid pdecl])
           where
-            pdata = keyword "data" <+> typ <+> pdecl
+            pdata = keyword "data" <+> typ
             pdecl = ppShortDataDecl False True dd unicode qual
   where
+    iid = instanceId origin no orphan ihd
     typ = ppAppNameTypes ihdClsName ihdKinds ihdTypes unicode qual
 
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -603,14 +603,15 @@ ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) =
             )
           where
             ptype = keyword "type" <+> typ
-            prhs = maybe noHtml (\t -> equals <+> ppType unicode qual t) rhs
+            prhs = ptype <+> maybe noHtml
+                                   (\t -> equals <+> ppType unicode qual t) rhs
         DataInst dd ->
             ( subInstHead iid pdata
             , mdoc
             , [subFamInstDetails iid pdecl])
           where
             pdata = keyword "data" <+> typ
-            pdecl = ppShortDataDecl False True dd unicode qual
+            pdecl = pdata <+> ppShortDataDecl False True dd unicode qual
   where
     iid = instanceId origin no orphan ihd
     typ = ppAppNameTypes ihdClsName ihdKinds ihdTypes unicode qual

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -231,7 +231,7 @@ subFamInstDetails :: String -- ^ Instance unique id (for anchor generation)
                   -> Html   -- ^ Type or data family instance
                   -> Html
 subFamInstDetails iid fi =
-    subInstSection iid << declElem fi
+    subInstSection iid << thediv ! [theclass "src"] << fi
 
 subInstSection :: String -- ^ Instance unique id (for anchor generation)
                -> Html

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -31,7 +31,8 @@ module Haddock.Backends.Xhtml.Layout (
   subConstructors,
   subEquations,
   subFields,
-  subInstances, subOrphanInstances, subInstHead, subInstDetails,
+  subInstances, subOrphanInstances,
+  subInstHead, subInstDetails, subFamInstDetails,
   subMethods,
   subMinimal,
 
@@ -178,7 +179,6 @@ subAssociatedTypes = divSubDecls "associated-types" "Associated Types" . subBloc
 subConstructors :: Qualification -> [SubDecl] -> Html
 subConstructors qual = divSubDecls "constructors" "Constructors" . subTable qual
 
-
 subFields :: Qualification -> [SubDecl] -> Html
 subFields qual = divSubDecls "fields" "Fields" . subDlist qual
 
@@ -225,10 +225,18 @@ subInstDetails :: String -- ^ Instance unique id (for anchor generation)
                -> [Html] -- ^ Method contents (pretty-printed signatures)
                -> Html
 subInstDetails iid ats mets =
-    section << (subAssociatedTypes ats <+> subMethods mets)
-  where
-    section = thediv ! collapseSection (instAnchorId iid) False "inst-details"
+    subInstSection iid << (subAssociatedTypes ats <+> subMethods mets)
 
+subFamInstDetails :: String -- ^ Instance unique id (for anchor generation)
+                  -> Html   -- ^ Type or data family instance
+                  -> Html
+subFamInstDetails iid fi =
+    subInstSection iid << declElem fi
+
+subInstSection :: String -- ^ Instance unique id (for anchor generation)
+               -> Html
+               -> Html
+subInstSection iid = thediv ! collapseSection (instAnchorId iid) False "inst-details"
 
 instAnchorId :: String -> String
 instAnchorId iid = makeAnchorId $ "i:" ++ iid


### PR DESCRIPTION
Fixes #474. Here is what this code:

```haskell
{-# LANGUAGE DeriveGeneric #-}
{-# LANGUAGE GADTs #-}
{-# LANGUAGE TypeFamilies #-}
module Example where

import GHC.Generics

data Letter = A | B | C deriving Generic

type family TFam a
type instance TFam a = Int

data family DFam a b
data instance DFam Int b
  = DFam1 { dfam1 :: Int }
  | DFam2 { dfam2 :: Int }
data instance DFam Char b where
    DFam3 :: { dfam3 :: Char } -> DFam Char Char
    DFam4 :: { dfam4 :: Char } -> DFam Char Char
```

now renders as, with some family instances expanded to show how they are rendered:

![haddock-after](https://cloud.githubusercontent.com/assets/2364661/12996423/9c6ecb6e-d0fd-11e5-93c0-d521258254aa.png)
