### PR TITLE
Fix #303. Hide footer when printing

### DIFF
--- a/haddock-api/resources/html/Classic.theme/xhaddock.css
+++ b/haddock-api/resources/html/Classic.theme/xhaddock.css
@@ -116,6 +116,10 @@ ul.links li {
   cursor: pointer;
 }
 
+@media print {
+  #footer { display: none; }
+}
+
 #package-header {
 	color: #ffffff;
 	padding: 5px 5px 5px 31px;

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -183,6 +183,9 @@ pre {
 .keyword { font-weight: normal; }
 .def { font-weight: bold; }
 
+@media print {
+  #footer { display: none; }
+}
 
 /* @end */
 

--- a/html-test/ref/ocean.css
+++ b/html-test/ref/ocean.css
@@ -183,6 +183,9 @@ pre {
 .keyword { font-weight: normal; }
 .def { font-weight: bold; }
 
+@media print {
+  #footer { display: none; }
+}
 
 /* @end */
 


### PR DESCRIPTION
The "Produced by Haddock" footer was overlapping the page's body when printing.
This patch hides the footer with a css media rule.