### PR TITLE
Fix #280. Parsing of module header

### DIFF
--- a/haddock-api/src/Haddock/Interface/ParseModuleHeader.hs
+++ b/haddock-api/src/Haddock/Interface/ParseModuleHeader.hs
@@ -76,7 +76,7 @@ parseKey :: String -> String -> Maybe (String,String)
 parseKey key toParse0 =
    do
       let
-         (spaces0,toParse1) = extractLeadingSpaces toParse0
+         (spaces0,toParse1) = extractLeadingSpaces (dropWhile (`elem` ['\r', '\n']) toParse0)
 
          indentation = spaces0
       afterKey0 <- extractPrefix key toParse1

--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >Bug280</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><script src="haddock-util.js" type="text/javascript"
+    ></script
+    ><script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ><script type="text/javascript"
+    >//<![CDATA[
+window.onload = function () {pageLoad();setSynopsis("mini_Bug280.html");};
+//]]>
+</script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      >&nbsp;</p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Copyright</th
+	    ><td
+	    >Foo,
+           Bar,
+           Baz</td
+	    ></tr
+	  ><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug280</p
+	></div
+      ><div id="description"
+      ><p class="caption"
+	>Description</p
+	><div class="doc"
+		><p
+		>The module description</p
+		></div
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><a id="v:x" class="def"
+	    >x</a
+	    > :: [<a href="#"
+	    >Char</a
+	    >] <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug280.hs
+++ b/html-test/src/Bug280.hs
@@ -1,0 +1,11 @@
+{-|
+Copyright: Foo,
+           Bar,
+           Baz
+
+The module description
+-}
+-- The module header can start with newlines. They are not taken into account for the indentation level
+module Bug280 where
+
+x = ""


### PR DESCRIPTION
The initial newlines were counted as indentation spaces, thus disturbing the parsing of next lines