### PR TITLE
Fix #505

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -789,7 +789,10 @@ extractDecl name mdl decl
           [s0] -> let (n, tyvar_names) = (tcdName d, tyClDeclTyVars d)
                       L pos sig = addClassContext n tyvar_names s0
                   in L pos (SigD sig)
-          _ -> error "internal: extractDecl (ClassDecl)"
+          _ -> O.pprPanic "extractDecl" (O.text "Ambiguous decl for" O.<+> O.ppr name O.<+> O.text "in class:"
+                                         O.$$ O.nest 4 (O.ppr d)
+                                         O.$$ O.text "Matches:"
+                                         O.$$ O.nest 4 (O.ppr matches))
       TyClD d@DataDecl {} ->
         let (n, tyvar_tys) = (tcdName d, lHsQTyVarsToTypes (tyClDeclTyVars d))
         in SigD <$> extractRecSel name mdl n tyvar_tys (dd_cons (tcdDataDefn d))

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -783,8 +783,13 @@ extractDecl name mdl decl
   | otherwise  =
     case unLoc decl of
       TyClD d@ClassDecl {} ->
-        let matches = [ sig | sig <- tcdSigs d, name `elem` sigName sig,
-                        isTypeLSig sig ] -- TODO: document fixity
+        let matches = [ lsig
+                      | lsig <- tcdSigs d
+                      , ClassOpSig False _ _ <- pure $ unLoc lsig
+                        -- Note: exclude `default` declarations (see #505)
+                      , name `elem` sigName lsig
+                      ]
+            -- TODO: document fixity
         in case matches of
           [s0] -> let (n, tyvar_names) = (tcdName d, tyClDeclTyVars d)
                       L pos sig = addClassContext n tyvar_names s0

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -36,7 +36,6 @@ import Control.Arrow (second)
 import Control.DeepSeq
 import Control.Monad
 import Data.Function (on)
-import qualified Data.Foldable as F
 
 import qualified Packages
 import qualified Module
@@ -50,7 +49,7 @@ import TcRnTypes
 import FastString (concatFS)
 import BasicTypes ( StringLiteral(..) )
 import qualified Outputable as O
-import HsDecls ( gadtDeclDetails,getConDetails )
+import HsDecls ( getConDetails )
 
 -- | Use a 'TypecheckedModule' to produce an 'Interface'.
 -- To do this, we need access to already processed modules in the topological


### PR DESCRIPTION
We were inappropriately consider `default` declarations when looking for a normal class op.

Closes #505.