### PR TITLE
Make parser state a newtype

### DIFF
--- a/haddock-library/src/Documentation/Haddock/Parser/Monad.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser/Monad.hs
@@ -42,7 +42,7 @@ import           Data.Tuple
 
 import           Documentation.Haddock.Types (Version)
 
-data ParserState = ParserState {
+newtype ParserState = ParserState {
   parserStateSince :: Maybe Version
 } deriving (Eq, Show)
 


### PR DESCRIPTION
Previously, it was `data` wrapping a `Maybe`, which seems a bit
silly. Obviously, this can be changed back if anyone wants to add
more fields some day.