### PR TITLE
Haddock changes for T10598

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -350,7 +350,8 @@ subordinates instMap decl = case decl of
                   , L _ n <- ns ]
         derivs  = [ (instName, [unL doc], M.empty)
                   | Just (L _ tys) <- [dd_derivs dd]
-                  , HsIB { hsib_body = L l (HsDocTy _ doc) } <- tys
+                  , HsIB { hsib_body = L l (HsDocTy _ doc) }
+                      <- map (dt_type . unLoc) tys
                   , Just instName <- [M.lookup l instMap] ]
 
 -- | Extract function argument docs from inside types.

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -508,9 +508,11 @@ renameInstD (DataFamInstD { dfid_inst = d }) = do
 
 renameDerivD :: DerivDecl Name -> RnM (DerivDecl DocName)
 renameDerivD (DerivDecl { deriv_type = ty
+                        , deriv_pragma = prag
                         , deriv_overlap_mode = omode }) = do
   ty' <- renameLSigType ty
   return (DerivDecl { deriv_type = ty'
+                    , deriv_pragma = prag
                     , deriv_overlap_mode = omode })
 
 renameClsInstD :: ClsInstDecl Name -> RnM (ClsInstDecl DocName)


### PR DESCRIPTION
This contains all of the necessary Haddock changes to go along with [Phab D2280](https://phabricator.haskell.org/D2280), which fixes [GHC Trac #10598](https://ghc.haskell.org/trac/ghc/ticket/10598).