### PR TITLE
Copyright holders shown on several lines. Fix #279

### DIFF
--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -34,12 +34,12 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug280.html");};
     ><div id="module-header"
       ><table class="info"
 	><tr
-	  ><th
+	  ><th valign="top"
 	    >Copyright</th
 	    ><td
-	    >Foo,
-           Bar,
-           Baz</td
+	    >Foo<br
+         />Bar<br
+         />Baz</td
 	    ></tr
 	  ><tr
 	  ><th

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -33,7 +33,7 @@ window.onload = function () {pageLoad();setSynopsis(&quot;mini_Test.html&quot;);
     ><div id="module-header"
       ><table class="info"
 	><tr
-	  ><th
+	  ><th valign="top"
 	    >Copyright</th
 	    ><td
 	    >(c) Simon Marlow 2002</td


### PR DESCRIPTION
This changes the copyright holders display in the module pages.