### PR TITLE
ocean: Ensure that synopsis fully covers other content

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -333,6 +333,8 @@ div#style-menu-holder {
   top: 10%;
   padding: 0;
   max-width: 75%;
+  /* Ensure that synopsis covers everything (including MathJAX markup) */
+  z-index: 1;
 }
 
 #synopsis .caption {


### PR DESCRIPTION
Previously MathJax content was being rendered on top of the synopsis due
to ambiguous z-ordering. Here we explicitly give the synopsis block a
higher z-index to ensure it is rendered on top. Fixes #531.