### PR TITLE
Add $ as a special character

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -501,7 +501,7 @@ Special characters
 ~~~~~~~~~~~~~~~~~~
 
 The following characters have special meanings in documentation
-comments: ``\\``, ``/``, ``'``, ``\```, ``"``, ``@``, ``<``. To insert a
+comments: ``\\``, ``/``, ``'``, ``\```, ``"``, ``@``, ``<``, ``$``. To insert a
 literal occurrence of one of these special characters, precede it with a
 backslash (``\\``).
 


### PR DESCRIPTION
If this character is not escaped, documentation built with Haddock
2.17.2 will fail.  This was not an issue with 2.16 series, which
causes builds to fail and there is nothing in the docs or error
message giving a clue about why builds that used to succeed now
don't.