### PR TITLE
More general type for nameCacheFromGhc.

### DIFF
--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -156,7 +156,7 @@ writeInterfaceFile filename iface = do
 type NameCacheAccessor m = (m NameCache, NameCache -> m ())
 
 
-nameCacheFromGhc :: NameCacheAccessor Ghc
+nameCacheFromGhc :: forall m. (GhcMonad m, MonadIO m) => NameCacheAccessor m
 nameCacheFromGhc = ( read_from_session , write_to_session )
   where
     read_from_session = do


### PR DESCRIPTION
More general type for  nameCacheFromGhc.

Example of where I'd use it: https://github.com/carlohamalainen/ghc-mod/blob/ghc-imported-from-merge/Language/Haskell/GhcMod/HaddockLookup.hs#L443-L455
