### PR TITLE
Delete references to the splitter

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -398,13 +398,12 @@ withGhc' libDir flags ghcActs = runGhc (Just libDir) $ do
     ghcMode   = CompManager,
     ghcLink   = NoLink
     }
-  let dynflags'' = gopt_unset dynflags' Opt_SplitObjs
-  defaultCleanupHandler dynflags'' $ do
+  defaultCleanupHandler dynflags' $ do
       -- ignore the following return-value, which is a list of packages
       -- that may need to be re-linked: Haddock doesn't do any
       -- dynamic or static linking at all!
-      _ <- setSessionDynFlags dynflags''
-      ghcActs dynflags''
+      _ <- setSessionDynFlags dynflags'
+      ghcActs dynflags'
   where
     parseGhcFlags :: MonadIO m => DynFlags -> m DynFlags
     parseGhcFlags dynflags = do


### PR DESCRIPTION
`-split-objs` [is dying].  When it goes, Haddock fails to compile, because it references a non-existent flag.

[is dying]: https://phabricator.haskell.org/D2768