### PR TITLE
Avoid errors on non UTF-8 Windows

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -48,6 +48,7 @@ import qualified Data.Set as Set
 import Distribution.Verbosity
 import System.Directory
 import System.FilePath
+import System.IO
 import Text.Printf
 
 import Digraph
@@ -56,6 +57,7 @@ import Exception
 import GHC hiding (verbosity)
 import HscTypes
 import FastString (unpackFS)
+import MonadUtils (liftIO)
 
 -- | Create 'Interface's and a link environment by typechecking the list of
 -- modules using the GHC API and processing the resulting syntax trees.
@@ -165,6 +167,7 @@ createIfaces verbosity flags instIfaceMap mods = do
 processModule :: Verbosity -> ModSummary -> [Flag] -> IfaceMap -> InstIfaceMap -> Ghc (Maybe Interface)
 processModule verbosity modsum flags modMap instIfaceMap = do
   out verbosity verbose $ "Checking module " ++ moduleString (ms_mod modsum) ++ "..."
+  liftIO $ hSetEncoding stderr utf8
   tm <- loadModule =<< typecheckModule =<< parseModule modsum
   if not $ isBootSummary modsum then do
     out verbosity verbose "Creating interface..."

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -43,6 +43,8 @@ import Control.DeepSeq (force)
 import Control.Exception (evaluate)
 import Control.Monad
 import Data.Traversable
+import Data.Function (on)
+import System.IO
 
 import qualified Packages
 import qualified Module

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -43,8 +43,6 @@ import Control.DeepSeq (force)
 import Control.Exception (evaluate)
 import Control.Monad
 import Data.Traversable
-import Data.Function (on)
-import System.IO
 
 import qualified Packages
 import qualified Module


### PR DESCRIPTION
Problem
====

haddock exits with errors like below:

`(1)`

```
haddock: internal error: <stderr>: hPutChar: invalid argument (invalid character)
```

`(2)`

```
haddock: internal error: Language\Haskell\HsColour\Anchors.hs: hGetContents: invalid argument (invalid byte sequence)
```

`(1)` is caused by printing [the "bullet" character](http://www.fileformat.info/info/unicode/char/2022/index.htm) onto stderr.
For example, this warning contains it:

```
Language\Haskell\HsColour\ANSI.hs:62:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘toEnum’
    • In the instance declaration for ‘Enum Highlight’
```

`(2)` is caused when the input file of `readFile` contains some Unicode characters.
In the case above, '⇒' is the cause.

Environment
----

OS: Windows 10
haddock: 2.17.3
GHC: 8.0.1

Solution
====

Add `hSetEncoding handle utf8` to avoid the errors.

Note
====

- I found the detailed causes by these changes for debugging:
    - https://github.com/haskell/haddock/commit/8f29edb6b02691c1cf4c479f6c6f3f922b35a55b
    - https://github.com/haskell/haddock/commit/1dd23bf2065a1e1f2c14d0f4abd847c906b4ecb4
- These errors happen even after executing `chcp 65001` on the console.
  According to the debug code, `hGetEncoding stderr` returns `CP932` regardless of the console encoding.