### PR TITLE
Prevent GHC API from doing optimization passes.

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -398,7 +398,7 @@ withGhc' libDir flags ghcActs = runGhc (Just libDir) $ do
     ghcMode   = CompManager,
     ghcLink   = NoLink
     }
-  let dynflags'' = gopt_unset dynflags' Opt_SplitObjs
+  let dynflags'' = updOptLevel 0 $ gopt_unset dynflags' Opt_SplitObjs
   defaultCleanupHandler dynflags'' $ do
       -- ignore the following return-value, which is a list of packages
       -- that may need to be re-linked: Haddock doesn't do any


### PR DESCRIPTION
Currently GHC HEAD's Haddock segfaults on Windows 64-bit when generating documentation for `language-c-quote-0.11.7.1` package. I believe, this is related to GHC bytecode generation/linking issues (I consistently see access violation on executable data at virtual addresses above 4GB mark). Btw, GHC segfaults too, but after repeated run, when it hasn't recompile all files, but only part of them, it succeeds.

I've examined what flags `cabal` supplies to Haddock and was surprised seeing `--optghc=-O` there. When I've rerun Haddock manually with no `--optghc=-O` flag, it succeeded. Moreover, it (obviously) was much faster.

Thus this patch makes Haddock working on Windows 64-bit for some complicated cases and also have a nice side-effect making Haddock much faster on other platforms.