### PR TITLE
Adding more exports to Documentation.Haddock

### DIFF
--- a/haddock-api/src/Documentation/Haddock.hs
+++ b/haddock-api/src/Documentation/Haddock.hs
@@ -34,6 +34,7 @@ module Documentation.Haddock (
 
   -- * Documentation comments
   Doc,
+  MDoc,
   DocH(..),
   Example(..),
   Hyperlink(..),

--- a/haddock-api/src/Documentation/Haddock.hs
+++ b/haddock-api/src/Documentation/Haddock.hs
@@ -16,6 +16,7 @@ module Documentation.Haddock (
   -- * Interface
   Interface(..),
   InstalledInterface(..),
+  toInstalledIface,
   createInterfaces,
   processModules,
 


### PR DESCRIPTION
Pull request related to issue #580.

Exports `MDoc` and `toInstalledIface` to allow external tools to process the documentation.