### PR TITLE
Version bump to 2.17.4

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Changes in version 2.17.4
+
+ * Compatibility with GHC 8.0.2
+
 Changes in version 2.17.3
 
  * Remove framed view of the HTML documentation

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -1,5 +1,5 @@
 name:                 haddock-api
-version:              2.17.3
+version:              2.17.4
 synopsis:             A documentation-generation tool for Haskell libraries
 description:          Haddock is a documentation-generation tool for Haskell
                       libraries


### PR DESCRIPTION
See #587

There have been few changes on master since 2.17.3, mostly small documentation fixes though, so I think it's more appropriate to bump the version to 2.17.4. This commit is based on the last commit on master before master itself was bumped to GHC 8.2 (d2be5e88 – Bump for GHC 8.2, 2017-03-09). I tested building against nightly-2017-03-15 (GHC 8.0.2) and  lts-7.20 (GHC 8.0.1) and haddock-api compiles against both.

Please tag & upload to hackage. Thank you. 

---
```
Bartosz Nitka (1):
      Fix rendering of class methods for Eq and Ord

Ben Gamari (3):
      ocean: Ensure that synopsis fully covers other content
      ghc.mk: Don't attempt to install html/frames.html
      Haddock.Types: More precise version guard

Dominic Steinitz (4):
      Documentation for LaTeX markup.
      Fix spelling mistake.
      Camel case MathJax.
      Fix math typo and add link.

Omari Norman (1):
      Add $ as a special character

Sebastian Meric de Bellefon (3):
      publish haddock-test library
      Copyright holders shown on several lines. Fix #279
      do not create empty src directory

Simon Marlow (1):
      Disable NFData instances for GHC types when GHC >= 8.0.2

Tomas Carnecky (1):
      Version bump to 2.17.4
```