### PR TITLE
Highlight link target

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -609,4 +609,8 @@ div#style-menu-holder {
   float: right;
 }
 
+:target {
+  background-color: #ffff00;
+}
+
 /* @end */


### PR DESCRIPTION
Sometimes when linking into a short module or to a symbol somewhere near the bottom of the HTML, there is confusion about which symbol is actually being linked to. My recent case was a question from a colleague about [`fromJust`](https://hackage.haskell.org/package/base-4.9.1.0/docs/Data-Maybe.html#v:fromJust) which, because of my screen size, appeared to be about [`isJust`](https://hackage.haskell.org/package/base-4.9.1.0/docs/Data-Maybe.html#v:isJust).

This tiny addition to the CSS would have solved my confusion, I think.