### PR TITLE
Handle leading-tick syntax for promoted data-kind constructors.

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
@@ -33,7 +33,9 @@ chunk str
     | "{-" `isPrefixOf` str = chunk' $ chunkComment 0 str
     | otherwise = case lex str of
         (tok:_) -> chunk' tok
-        [] -> [str]
+        [] -> case str of
+            ('\'' : rest) -> "\'" : chunk rest
+            _ -> [str]
   where
     chunk' (c, rest) = c:(chunk rest)
 


### PR DESCRIPTION
Fixes issue #593.