### PR TITLE
Remove anything related to obsolete frames mode

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -327,10 +327,6 @@ div#style-menu-holder {
 }
 
 #synopsis {
-  display: none;
-}
-
-.no-frame #synopsis {
   display: block;
   position: fixed;
   right: 0;

--- a/haddock-api/resources/html/haddock-util.js
+++ b/haddock-api/resources/html/haddock-util.js
@@ -1,7 +1,7 @@
 // Haddock JavaScript utilities
 
 var rspace = /\s\s+/g,
-	  rtrim = /^\s+|\s+$/g;
+    rtrim = /^\s+|\s+$/g;
 
 function spaced(s) { return (" " + s + " ").replace(rspace, " "); }
 function trim(s)   { return s.replace(rtrim, ""); }
@@ -107,136 +107,6 @@ function getCookie(name) {
     }
   }
   return null;
-}
-
-
-
-var max_results = 75; // 50 is not enough to search for map in the base libraries
-var shown_range = null;
-var last_search = null;
-
-function quick_search()
-{
-    perform_search(false);
-}
-
-function full_search()
-{
-    perform_search(true);
-}
-
-
-function perform_search(full)
-{
-    var text = document.getElementById("searchbox").value.toLowerCase();
-    if (text == last_search && !full) return;
-    last_search = text;
-
-    var table = document.getElementById("indexlist");
-    var status = document.getElementById("searchmsg");
-    var children = table.firstChild.childNodes;
-
-    // first figure out the first node with the prefix
-    var first = bisect(-1);
-    var last = (first == -1 ? -1 : bisect(1));
-
-    if (first == -1)
-    {
-        table.className = "";
-        status.innerHTML = "No results found, displaying all";
-    }
-    else if (first == 0 && last == children.length - 1)
-    {
-        table.className = "";
-        status.innerHTML = "";
-    }
-    else if (last - first >= max_results && !full)
-    {
-        table.className = "";
-        status.innerHTML = "More than " + max_results + ", press Search to display";
-    }
-    else
-    {
-        // decide what you need to clear/show
-        if (shown_range)
-            setclass(shown_range[0], shown_range[1], "indexrow");
-        setclass(first, last, "indexshow");
-        shown_range = [first, last];
-        table.className = "indexsearch";
-        status.innerHTML = "";
-    }
-
-
-    function setclass(first, last, status)
-    {
-        for (var i = first; i <= last; i++)
-        {
-            children[i].className = status;
-        }
-    }
-
-
-    // do a binary search, treating 0 as ...
-    // return either -1 (no 0's found) or location of most far match
-    function bisect(dir)
-    {
-        var first = 0, finish = children.length - 1;
-        var mid, success = false;
-
-        while (finish - first > 3)
-        {
-            mid = Math.floor((finish + first) / 2);
-
-            var i = checkitem(mid);
-            if (i == 0) i = dir;
-            if (i == -1)
-                finish = mid;
-            else
-                first = mid;
-        }
-        var a = (dir == 1 ? first : finish);
-        var b = (dir == 1 ? finish : first);
-        for (var i = b; i != a - dir; i -= dir)
-        {
-            if (checkitem(i) == 0) return i;
-        }
-        return -1;
-    }
-
-
-    // from an index, decide what the result is
-    // 0 = match, -1 is lower, 1 is higher
-    function checkitem(i)
-    {
-        var s = getitem(i).toLowerCase().substr(0, text.length);
-        if (s == text) return 0;
-        else return (s > text ? -1 : 1);
-    }
-
-
-    // from an index, get its string
-    // this abstracts over alternates
-    function getitem(i)
-    {
-        for ( ; i >= 0; i--)
-        {
-            var s = children[i].firstChild.firstChild.data;
-            if (s.indexOf(' ') == -1)
-                return s;
-        }
-        return ""; // should never be reached
-    }
-}
-
-function setSynopsis(filename) {
-    if (parent.window.synopsis && parent.window.synopsis.location) {
-        if (parent.window.synopsis.location.replace) {
-            // In Firefox this avoids adding the change to the history.
-            parent.window.synopsis.location.replace(filename);
-        } else {
-            parent.window.synopsis.location = filename;
-        }
-    }
 }
 
 function addMenuItem(html) {

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -108,8 +108,8 @@ copyHtmlBits odir libdir themes = do
   return ()
 
 
-headHtml :: String -> Maybe String -> Themes -> Maybe String -> Html
-headHtml docTitle miniPage themes mathjax_url =
+headHtml :: String -> Themes -> Maybe String -> Html
+headHtml docTitle themes mathjax_url =
   header << [
     meta ! [httpequiv "Content-Type", content "text/html; charset=UTF-8"],
     thetitle << docTitle,
@@ -118,14 +118,11 @@ headHtml docTitle miniPage themes mathjax_url =
     script ! [src mjUrl, thetype "text/javascript"] << noHtml,
     script ! [thetype "text/javascript"]
         -- NB: Within XHTML, the content of script tags needs to be
-        -- a <![CDATA[ section. Will break if the miniPage name could
-        -- have "]]>" in it!
-      << primHtml (
-          "//<![CDATA[\nwindow.onload = function () {pageLoad();"
-          ++ setSynopsis ++ "};\n//]]>\n")
+        -- a <![CDATA[ section.
+      << primHtml
+          "//<![CDATA[\nwindow.onload = function () {pageLoad();};\n//]]>\n"
     ]
   where
-    setSynopsis = maybe "" (\p -> "setSynopsis(\"" ++ p ++ "\");") miniPage
     mjUrl = maybe "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" id mathjax_url
 
 
@@ -271,7 +268,7 @@ ppHtmlContents dflags odir doctitle _maybe_package
          | iface <- ifaces
          , instIsSig iface]
       html =
-        headHtml doctitle Nothing themes mathjax_url +++
+        headHtml doctitle themes mathjax_url +++
         bodyHtml doctitle Nothing
           maybe_source_url maybe_wiki_url
           Nothing maybe_index_url << [
@@ -372,7 +369,7 @@ ppHtmlIndex odir doctitle _maybe_package themes
 
   where
     indexPage showLetters ch items =
-      headHtml (doctitle ++ " (" ++ indexName ch ++ ")") Nothing themes maybe_mathjax_url +++
+      headHtml (doctitle ++ " (" ++ indexName ch ++ ")") themes maybe_mathjax_url +++
       bodyHtml doctitle Nothing
         maybe_source_url maybe_wiki_url
         maybe_contents_url Nothing << [
@@ -494,7 +491,7 @@ ppHtmlModule odir doctitle themes
         = toHtml mdl_str
       real_qual = makeModuleQual qual aliases mdl
       html =
-        headHtml mdl_str_annot (Just $ "mini_" ++ moduleHtmlFile mdl) themes maybe_mathjax_url +++
+        headHtml mdl_str_annot themes maybe_mathjax_url +++
         bodyHtml doctitle (Just iface)
           maybe_source_url maybe_wiki_url
           maybe_contents_url maybe_index_url << [
@@ -504,23 +501,9 @@ ppHtmlModule odir doctitle themes
 
   createDirectoryIfMissing True odir
   writeFile (joinPath [odir, moduleHtmlFile mdl]) (renderToString debug html)
-  ppHtmlModuleMiniSynopsis odir doctitle themes maybe_mathjax_url iface unicode real_qual debug
 
 signatureDocURL :: String
 signatureDocURL = "https://wiki.haskell.org/Module_signature"
-
-ppHtmlModuleMiniSynopsis :: FilePath -> String -> Themes
-  -> Maybe String -> Interface -> Bool -> Qualification -> Bool -> IO ()
-ppHtmlModuleMiniSynopsis odir _doctitle themes maybe_mathjax_url iface unicode qual debug = do
-  let mdl = ifaceMod iface
-      html =
-        headHtml (moduleString mdl) Nothing themes maybe_mathjax_url +++
-        miniBody <<
-          (divModuleHeader << sectionName << moduleString mdl +++
-           miniSynopsis mdl iface unicode qual)
-  createDirectoryIfMissing True odir
-  writeFile (joinPath [odir, "mini_" ++ moduleHtmlFile mdl]) (renderToString debug html)
-
 
 ifaceToHtml :: SourceURLs -> WikiURLs -> Interface -> Bool -> Qualification -> Html
 ifaceToHtml maybe_source_url maybe_wiki_url iface unicode qual
@@ -571,43 +554,6 @@ ifaceToHtml maybe_source_url maybe_wiki_url iface unicode qual
 
     linksInfo = (maybe_source_url, maybe_wiki_url)
 
-
-miniSynopsis :: Module -> Interface -> Bool -> Qualification -> Html
-miniSynopsis mdl iface unicode qual =
-    divInterface << concatMap (processForMiniSynopsis mdl unicode qual) exports
-  where
-    exports = numberSectionHeadings (ifaceRnExportItems iface)
-
-
-processForMiniSynopsis :: Module -> Bool -> Qualification -> ExportItem DocName
-                       -> [Html]
-processForMiniSynopsis mdl unicode qual ExportDecl { expItemDecl = L _loc decl0 } =
-  ((divTopDecl <<).(declElem <<)) <$> case decl0 of
-    TyClD d -> let b = ppTyClBinderWithVarsMini mdl d in case d of
-        (FamDecl decl)    -> [ppTyFamHeader True False decl unicode qual]
-        (DataDecl{})   -> [keyword "data" <+> b]
-        (SynDecl{})    -> [keyword "type" <+> b]
-        (ClassDecl {}) -> [keyword "class" <+> b]
-    SigD (TypeSig lnames _) ->
-      map (ppNameMini Prefix mdl . nameOccName . getName . unLoc) lnames
-    _ -> []
-processForMiniSynopsis _ _ qual (ExportGroup lvl _id txt) =
-  [groupTag lvl << docToHtml Nothing qual (mkMeta txt)]
-processForMiniSynopsis _ _ _ _ = []
-
-
-ppNameMini :: Notation -> Module -> OccName -> Html
-ppNameMini notation mdl nm =
-    anchor ! [ href (moduleNameUrl mdl nm)
-             , target mainFrameName ]
-      << ppBinder' notation nm
-
-
-ppTyClBinderWithVarsMini :: Module -> TyClDecl DocName -> Html
-ppTyClBinderWithVarsMini mdl decl =
-  let n = tcdName decl
-      ns = tyvarNames $ tcdTyVars decl -- it's safe to use tcdTyVars, see code above
-  in ppTypeApp n [] ns (\is_infix -> ppNameMini is_infix mdl . nameOccName . getName) ppTyName
 
 ppModuleContents :: Qualification
                  -> [ExportItem DocName]

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_A.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/B.html
+++ b/html-test/ref/B.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_B.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bold.html
+++ b/html-test/ref/Bold.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bold.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug1.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug195.html
+++ b/html-test/ref/Bug195.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug195.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug2.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug201.html
+++ b/html-test/ref/Bug201.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug201.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug253.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug26.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
@@ -10,9 +9,9 @@
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
     ></script
     ><script type="text/javascript"
-    >//<![CDATA[
-window.onload = function () {pageLoad();setSynopsis("mini_Bug280.html");};
-//]]>
+    >//
+window.onload = function () {pageLoad();};
+//
 </script
     ></head
   ><body
@@ -28,7 +27,7 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug280.html");};
 	  ></li
 	></ul
       ><p class="caption empty"
-      >&nbsp;</p
+      ></p
       ></div
     ><div id="content"
     ><div id="module-header"
@@ -38,8 +37,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug280.html");};
 	    >Copyright</th
 	    ><td
 	    >Foo<br
-         />Bar<br
-         />Baz</td
+	       />Bar<br
+	       />Baz</td
 	    ></tr
 	  ><tr
 	  ><th
@@ -55,9 +54,9 @@ window.onload = function () {pageLoad();setSynopsis("mini_Bug280.html");};
       ><p class="caption"
 	>Description</p
 	><div class="doc"
-		><p
-		>The module description</p
-		></div
+	><p
+	  >The module description</p
+	  ></div
 	></div
       ><div id="interface"
       ><h1

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug294.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug298.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug3.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug308.html
+++ b/html-test/ref/Bug308.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug308.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug308CrossModule.html
+++ b/html-test/ref/Bug308CrossModule.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug308CrossModule.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug310.html
+++ b/html-test/ref/Bug310.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug310.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug313.html
+++ b/html-test/ref/Bug313.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug313.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug335.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug387.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug4.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug6.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug7.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug8.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bug85.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_BugDeprecated.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_BugExportHeadings.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Bugs.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedClass.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedData.html
+++ b/html-test/ref/DeprecatedData.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedData.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedFunction.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedFunction2.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedFunction3.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedModule.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedModule2.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedNewtype.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedReExport.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedRecord.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedTypeFamily.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_DeprecatedTypeSynonym.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Examples.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Extensions.html
+++ b/html-test/ref/Extensions.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Extensions.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_FunArgs.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_GADTRecords.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Hash.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_HiddenInstances.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_HiddenInstancesB.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Hyperlinks.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/IgnoreExports.html
+++ b/html-test/ref/IgnoreExports.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_IgnoreExports.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_ImplicitParams.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Instances.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Math.html
+++ b/html-test/ref/Math.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Math.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Minimal.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_ModuleWithWarning.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/NamedDoc.html
+++ b/html-test/ref/NamedDoc.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_NamedDoc.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Nesting.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_NoLayout.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/NonGreedy.html
+++ b/html-test/ref/NonGreedy.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_NonGreedy.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Operators.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/OrphanInstances.html
+++ b/html-test/ref/OrphanInstances.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_OrphanInstances.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_OrphanInstancesClass.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/OrphanInstancesType.html
+++ b/html-test/ref/OrphanInstancesType.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_OrphanInstancesType.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_PatternSyns.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/PromotedTypes.html
+++ b/html-test/ref/PromotedTypes.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_PromotedTypes.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Properties.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/PruneWithWarning.html
+++ b/html-test/ref/PruneWithWarning.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_PruneWithWarning.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_QuasiExpr.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_QuasiQuote.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_SpuriousSuperclassConstraints.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/TH.html
+++ b/html-test/ref/TH.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_TH.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/TH2.html
+++ b/html-test/ref/TH2.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_TH2.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Test.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Threaded.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Threaded_TH.html
+++ b/html-test/ref/Threaded_TH.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Threaded_TH.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Ticket112.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Ticket61.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Ticket75.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_TitledPicture.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_TypeFamilies.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_TypeFamilies2.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_TypeOperators.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Unicode.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -10,7 +10,7 @@
     ></script
     ><script type="text/javascript"
     >//
-window.onload = function () {pageLoad();setSynopsis(&quot;mini_Visible.html&quot;);};
+window.onload = function () {pageLoad();};
 //
 </script
     ></head

--- a/html-test/ref/haddock-util.js
+++ b/html-test/ref/haddock-util.js
@@ -1,7 +1,7 @@
 // Haddock JavaScript utilities
 
 var rspace = /\s\s+/g,
-	  rtrim = /^\s+|\s+$/g;
+    rtrim = /^\s+|\s+$/g;
 
 function spaced(s) { return (" " + s + " ").replace(rspace, " "); }
 function trim(s)   { return s.replace(rtrim, ""); }
@@ -107,136 +107,6 @@ function getCookie(name) {
     }
   }
   return null;
-}
-
-
-
-var max_results = 75; // 50 is not enough to search for map in the base libraries
-var shown_range = null;
-var last_search = null;
-
-function quick_search()
-{
-    perform_search(false);
-}
-
-function full_search()
-{
-    perform_search(true);
-}
-
-
-function perform_search(full)
-{
-    var text = document.getElementById("searchbox").value.toLowerCase();
-    if (text == last_search && !full) return;
-    last_search = text;
-
-    var table = document.getElementById("indexlist");
-    var status = document.getElementById("searchmsg");
-    var children = table.firstChild.childNodes;
-
-    // first figure out the first node with the prefix
-    var first = bisect(-1);
-    var last = (first == -1 ? -1 : bisect(1));
-
-    if (first == -1)
-    {
-        table.className = "";
-        status.innerHTML = "No results found, displaying all";
-    }
-    else if (first == 0 && last == children.length - 1)
-    {
-        table.className = "";
-        status.innerHTML = "";
-    }
-    else if (last - first >= max_results && !full)
-    {
-        table.className = "";
-        status.innerHTML = "More than " + max_results + ", press Search to display";
-    }
-    else
-    {
-        // decide what you need to clear/show
-        if (shown_range)
-            setclass(shown_range[0], shown_range[1], "indexrow");
-        setclass(first, last, "indexshow");
-        shown_range = [first, last];
-        table.className = "indexsearch";
-        status.innerHTML = "";
-    }
-
-
-    function setclass(first, last, status)
-    {
-        for (var i = first; i <= last; i++)
-        {
-            children[i].className = status;
-        }
-    }
-
-
-    // do a binary search, treating 0 as ...
-    // return either -1 (no 0's found) or location of most far match
-    function bisect(dir)
-    {
-        var first = 0, finish = children.length - 1;
-        var mid, success = false;
-
-        while (finish - first > 3)
-        {
-            mid = Math.floor((finish + first) / 2);
-
-            var i = checkitem(mid);
-            if (i == 0) i = dir;
-            if (i == -1)
-                finish = mid;
-            else
-                first = mid;
-        }
-        var a = (dir == 1 ? first : finish);
-        var b = (dir == 1 ? finish : first);
-        for (var i = b; i != a - dir; i -= dir)
-        {
-            if (checkitem(i) == 0) return i;
-        }
-        return -1;
-    }
-
-
-    // from an index, decide what the result is
-    // 0 = match, -1 is lower, 1 is higher
-    function checkitem(i)
-    {
-        var s = getitem(i).toLowerCase().substr(0, text.length);
-        if (s == text) return 0;
-        else return (s > text ? -1 : 1);
-    }
-
-
-    // from an index, get its string
-    // this abstracts over alternates
-    function getitem(i)
-    {
-        for ( ; i >= 0; i--)
-        {
-            var s = children[i].firstChild.firstChild.data;
-            if (s.indexOf(' ') == -1)
-                return s;
-        }
-        return ""; // should never be reached
-    }
-}
-
-function setSynopsis(filename) {
-    if (parent.window.synopsis && parent.window.synopsis.location) {
-        if (parent.window.synopsis.location.replace) {
-            // In Firefox this avoids adding the change to the history.
-            parent.window.synopsis.location.replace(filename);
-        } else {
-            parent.window.synopsis.location = filename;
-        }
-    }
 }
 
 function addMenuItem(html) {


### PR DESCRIPTION
This is a proper fix for #599. Synopsis would only show if it is
contained in a `.no-frame` block which is a remain prior #514.

Also removes some obsolete javascript for searching a haddock page(?). 