### PR TITLE
Lazy decoding of InstalledIntefaces

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -70,8 +70,7 @@ processModules
 processModules verbosity modules flags extIfaces = do
 
   out verbosity verbose "Creating interfaces..."
-  let instIfaceMap =  Map.fromList [ (instMod iface, iface) | ext <- extIfaces
-                                   , iface <- ifInstalledIfaces ext ]
+  let instIfaceMap = Map.unions (map ifInstalledIfaces extIfaces)
   interfaces <- createIfaces0 verbosity modules flags instIfaceMap
 
   let exportedNames =


### PR DESCRIPTION
Before we were decoding InstalledInterfaces from InterfaceFiles up
front. This patch enables lazy per-module deserialization of InstalledInterfaces.

Test failures expected, the haddock interfaces installed with ghc-8.2 do not comply to this new format yet.