### PR TITLE
Fix Binary instance for InstalledInterface

### DIFF
--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -378,8 +378,6 @@ instance Binary InstalledInterface where
     put_ bh is_sig
     put_ bh info
     lazyPut bh (docMap, argMap)
-    put_ bh docMap
-    put_ bh argMap
     put_ bh exps
     put_ bh visExps
     put_ bh opts


### PR DESCRIPTION
(#610) introduced lazy decoding for docs from InstalledInterface but
forgot to remove the original calls to get and put_