### PR TITLE
Haddock: Fix broken lazy IO in prologue reading

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -540,9 +540,10 @@ getPrologue :: DynFlags -> [Flag] -> IO (Maybe (MDoc RdrName))
 getPrologue dflags flags =
   case [filename | Flag_Prologue filename <- flags ] of
     [] -> return Nothing
-    [filename] -> withFile filename ReadMode $ \h -> do
+    [filename] -> do
+      h <- openFile filename ReadMode
       hSetEncoding h utf8
-      str <- hGetContents h
+      str <- hGetContents h -- semi-closes the handle
       return . Just $! parseParas dflags str
     _ -> throwE "multiple -p/--prologue options"
 


### PR DESCRIPTION
We previously used withFile in conjunction with hGetContents. The list returned
by the latter wasn't completely forced by the time we left the withFile block,
meaning that we would try to read from a closed handle.