### PR TITLE
Improve Syb code

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Ast.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Ast.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
-
+{-# LANGUAGE TypeApplications #-}
 
 module Haddock.Backends.Hyperlinker.Ast (enrich) where
 
 
-import Haddock.Syb
+import qualified Haddock.Syb as Syb
 import Haddock.Backends.Hyperlinker.Types
 
 import qualified GHC
@@ -16,6 +16,9 @@ import Control.Applicative
 import Data.Data
 import Data.Maybe
 
+everythingImportantInRenamedSource :: (Alternative f, Data x)
+  => (forall a. Data a => a -> f r) -> x -> f r
+everythingImportantInRenamedSource f = Syb.everythingButType @GHC.Name (<|>) f
 
 -- | Add more detailed information to token stream using GHC API.
 enrich :: GHC.RenamedSource -> [Token] -> [RichToken]
@@ -53,7 +56,7 @@ enrichToken _ _ = Nothing
 -- | Obtain details map for variables ("normally" used identifiers).
 variables :: GHC.RenamedSource -> DetailsMap
 variables =
-    everything (<|>) (var `combine` rec)
+    everythingImportantInRenamedSource (var `Syb.combine` rec)
   where
     var term = case cast term of
         (Just (GHC.L sspan (GHC.HsVar name))) ->
@@ -68,8 +71,7 @@ variables =
 
 -- | Obtain details map for types.
 types :: GHC.RenamedSource -> DetailsMap
-types =
-    everything (<|>) ty
+types = everythingImportantInRenamedSource ty
   where
     ty term = case cast term of
         (Just (GHC.L sspan (GHC.HsTyVar _ name))) ->
@@ -81,9 +83,10 @@ types =
 -- That includes both identifiers bound by pattern matching or declared using
 -- ordinary assignment (in top-level declarations, let-expressions and where
 -- clauses).
+
 binds :: GHC.RenamedSource -> DetailsMap
-binds =
-    everything (<|>) (fun `combine` pat `combine` tvar)
+binds = everythingImportantInRenamedSource
+      (fun `Syb.combine` pat `Syb.combine` tvar)
   where
     fun term = case cast term of
         (Just (GHC.FunBind (GHC.L sspan name) _ _ _ _ :: GHC.HsBind GHC.Name)) ->
@@ -93,7 +96,7 @@ binds =
         (Just (GHC.L sspan (GHC.VarPat name))) ->
             pure (sspan, RtkBind (GHC.unLoc name))
         (Just (GHC.L _ (GHC.ConPatIn (GHC.L sspan name) recs))) ->
-            [(sspan, RtkVar name)] ++ everything (<|>) rec recs
+            [(sspan, RtkVar name)] ++ Syb.everything (<|>) rec recs
         (Just (GHC.L _ (GHC.AsPat (GHC.L sspan name) _))) ->
             pure (sspan, RtkBind name)
         _ -> empty
@@ -112,8 +115,8 @@ binds =
 decls :: GHC.RenamedSource -> DetailsMap
 decls (group, _, _, _) = concatMap ($ group)
     [ concat . map typ . concat . map GHC.group_tyclds . GHC.hs_tyclds
-    , everything (<|>) fun . GHC.hs_valds
-    , everything (<|>) (con `combine` ins)
+    , everythingImportantInRenamedSource fun . GHC.hs_valds
+    , everythingImportantInRenamedSource (con `Syb.combine` ins)
     ]
   where
     typ (GHC.L _ t) = case t of
@@ -127,7 +130,8 @@ decls (group, _, _, _) = concatMap ($ group)
         _ -> empty
     con term = case cast term of
         (Just cdcl) ->
-            map decl (GHC.getConNames cdcl) ++ everything (<|>) fld cdcl
+            map decl (GHC.getConNames cdcl)
+              ++ everythingImportantInRenamedSource fld cdcl
         Nothing -> empty
     ins term = case cast term of
         (Just (GHC.DataFamInstD inst)) -> pure . tyref $ GHC.dfid_tycon inst
@@ -149,7 +153,7 @@ decls (group, _, _, _) = concatMap ($ group)
 -- import lists.
 imports :: GHC.RenamedSource -> DetailsMap
 imports src@(_, imps, _, _) =
-    everything (<|>) ie src ++ mapMaybe (imp . GHC.unLoc) imps
+    everythingImportantInRenamedSource ie src ++ mapMaybe (imp . GHC.unLoc) imps
   where
     ie term = case cast term of
         (Just (GHC.IEVar v)) -> pure $ var $ GHC.ieLWrappedName v

--- a/haddock-api/src/Haddock/Syb.hs
+++ b/haddock-api/src/Haddock/Syb.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE Rank2Types #-}
-
-
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Haddock.Syb
-    ( everything, everythingWithState, everywhere
+    ( everything, everythingBut, everythingButType, everythingWithState
+    , everywhere, everywhereBut, everywhereButType
     , mkT
     , combine
     ) where
@@ -10,16 +12,40 @@ module Haddock.Syb
 
 import Data.Data
 import Control.Applicative
+import Data.Maybe
 
+-- | Returns true if a /= t.
+-- requires AllowAmbiguousTypes
+is_not_t :: forall t a. (Typeable t, Typeable a) => a -> Bool
+is_not_t s = isNothing (cast s :: Maybe t)
 
 -- | Perform a query on each level of a tree.
 --
 -- This is stolen directly from SYB package and copied here to not introduce
 -- additional dependencies.
-everything :: (r -> r -> r) -> (forall a. Data a => a -> r)
-           -> (forall a. Data a => a -> r)
+everything :: (r -> r -> r)
+  -> (forall a. Data a => a -> r)
+  -> (forall a. Data a => a -> r)
 everything k f x = foldl k (f x) (gmapQ (everything k f) x)
 
+-- | Variation of "everything" with an added stop condition
+-- Just like 'everything', this is stolen from SYB package.
+everythingBut :: (r -> r -> r)
+  -> (forall a. Data a => a -> (r, Bool))
+  -> (forall a. Data a => a -> r)
+everythingBut k f x = let (v, stop) = f x
+                      in if stop
+                           then v
+                           else foldl k v (gmapQ (everythingBut k f) x)
+
+
+-- | Variation of "everything" that does not recurse into children of type t
+-- requires AllowAmbiguousTypes
+everythingButType :: forall t r. Typeable t
+  => (r -> r -> r)
+  -> (forall a. Data a => a -> r)
+  -> (forall a. Data a => a -> r)
+everythingButType (<>) f = everythingBut (<>) $ (,) <$> f <*> is_not_t @t
 
 -- | Perform a query with state on each level of a tree.
 --
@@ -39,6 +65,23 @@ everythingWithState s k f x =
 -- Just like 'everything', this is stolen from SYB package.
 everywhere :: (forall a. Data a => a -> a) -> (forall a. Data a => a -> a)
 everywhere f = f . gmapT (everywhere f)
+
+
+-- | Variation on everywhere with an extra stop condition
+-- Just like 'everything', this is stolen from SYB package.
+everywhereBut :: (forall a. Data a => a -> Bool)
+  -> (forall a. Data a => a -> a)
+  -> (forall a. Data a => a -> a)
+everywhereBut q f x
+    | q x       = x
+    | otherwise = f (gmapT (everywhereBut q f) x)
+
+-- | Variation of "everywhere" that does not recurse into children of type t
+-- requires AllowAmbiguousTypes
+everywhereButType :: forall t x. (Typeable t, Data x)
+  => (x -> x)
+  -> (forall a. Data a => a -> a)
+everywhereButType f = everywhereBut (is_not_t @t) (mkT f)
 
 -- | Create generic transformation.
 --


### PR DESCRIPTION
Specialize.hs and Ast.hs are modified to have their Syb code not recurse into
Name or Id in HsSyn types.

Specialize.hs is refactored to have fewer calls to gmapT and gmapQ

I have verified that the output doc directories are identical.

per/haddock.* test results on HEAD with this patch are:
=====> haddock.base(normal) 1 of 3 [0, 0, 0]
bytes allocated value is too low:
(If this is because you have improved GHC, please
update the test so that GHC doesn't regress again)
Expected haddock.base(normal) bytes allocated: 25592972912 +/-5%
Lower bound haddock.base(normal) bytes allocated: 24313324266
Upper bound haddock.base(normal) bytes allocated: 26872621558
Actual haddock.base(normal) bytes allocated: 14909947832
Deviation haddock.base(normal) bytes allocated: -41.7 %
*** unexpected stat test failure for haddock.base(normal)
=====> haddock.Cabal(normal) 2 of 3 [0, 0, 0]
bytes allocated value is too low:
(If this is because you have improved GHC, please
update the test so that GHC doesn't regress again)
Expected haddock.Cabal(normal) bytes allocated: 18865432648 +/-5%
Lower bound haddock.Cabal(normal) bytes allocated: 17922161015
Upper bound haddock.Cabal(normal) bytes allocated: 19808704281
Actual haddock.Cabal(normal) bytes allocated: 12583254632
Deviation haddock.Cabal(normal) bytes allocated: -33.3 %
*** unexpected stat test failure for haddock.Cabal(normal)
=====> haddock.compiler(normal) 3 of 3 [0, 0, 0]
bytes allocated value is too low:
(If this is because you have improved GHC, please
update the test so that GHC doesn't regress again)
Expected haddock.compiler(normal) bytes allocated: 55777283352 +/-10%
Lower bound haddock.compiler(normal) bytes allocated: 50199555016
Upper bound haddock.compiler(normal) bytes allocated: 61355011688
Actual haddock.compiler(normal) bytes allocated: 50051828168
Deviation haddock.compiler(normal) bytes allocated: -10.3 %
*** unexpected stat test failure for haddock.compiler(normal)