### PR TITLE
Don't enable compilation for template haskell

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -110,11 +110,7 @@ createIfaces0 verbosity modules flags instIfaceMap =
   -- resulting ModSummaries.
   (if useTempDir then withTempOutputDir else id) $ do
     modGraph <- depAnalysis
-    if needsTemplateHaskell modGraph then do
-      modGraph' <- enableCompilation modGraph
-      createIfaces verbosity flags instIfaceMap modGraph'
-    else
-      createIfaces verbosity flags instIfaceMap modGraph
+    createIfaces verbosity flags instIfaceMap modGraph
 
   where
     useTempDir :: Bool
@@ -135,17 +131,6 @@ createIfaces0 verbosity modules flags instIfaceMap =
       targets <- mapM (\f -> guessTarget f Nothing) modules
       setTargets targets
       depanal [] False
-
-
-    enableCompilation :: ModuleGraph -> Ghc ModuleGraph
-    enableCompilation modGraph = do
-      let enableComp d = let platform = targetPlatform d
-                         in d { hscTarget = defaultObjectTarget platform }
-      modifySessionDynFlags enableComp
-      -- We need to update the DynFlags of the ModSummaries as well.
-      let upd m = m { ms_hspp_opts = enableComp (ms_hspp_opts m) }
-      let modGraph' = map upd modGraph
-      return modGraph'
 
 
 createIfaces :: Verbosity -> [Flag] -> InstIfaceMap -> ModuleGraph -> Ghc [Interface]


### PR DESCRIPTION
This is no longer necessary after
ghc commit [53c78be0aab76a3107c4dacbb1d177afacdd37fa](https://github.com/ghc/ghc/commit/53c78be0aab76a3107c4dacbb1d177afacdd37fa)