### PR TITLE
Allow user defined signatures for pattern synonyms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Changes in version 2.18.0
 
+ * Support user defined signatures on pattern synonyms
+
  * Synopsis is working again (#599)
 
 ## Changes in version 2.17.4

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -92,6 +92,10 @@ filterSigNames p (ClassOpSig is_default ns ty) =
   case filter (p . unLoc) ns of
     []       -> Nothing
     filtered -> Just (ClassOpSig is_default filtered ty)
+filterSigNames p (PatSynSig ns ty) =
+  case filter (p . unLoc) ns of
+    []       -> Nothing
+    filtered -> Just (PatSynSig filtered ty)
 filterSigNames _ _                           = Nothing
 
 ifTrueJust :: Bool -> name -> Maybe name
@@ -114,6 +118,7 @@ sigNameNoLoc _                         = []
 isUserLSig :: LSig name -> Bool
 isUserLSig (L _(TypeSig {}))    = True
 isUserLSig (L _(ClassOpSig {})) = True
+isUserLSig (L _(PatSynSig {}))  = True
 isUserLSig _                    = False
 
 

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -842,6 +842,7 @@ fullModuleContents dflags warnings gre (docMap, argMap, subMap, declMap, instMap
     expandSig :: Sig name -> [Sig name]
     expandSig (TypeSig names t)      = [ TypeSig [n] t      | n <- names ]
     expandSig (ClassOpSig b names t) = [ ClassOpSig b [n] t | n <- names ]
+    expandSig (PatSynSig names t)    = [ PatSynSig [n] t    | n <- names ]
     expandSig x                      = [x]
 
     mkExportItem :: LHsDecl Name -> ErrMsgGhc (Maybe (ExportItem Name))

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -118,6 +118,16 @@ window.onload = function () {pageLoad();};
 	    > k a (b :: k). <a href="#"
 	    >(&gt;&lt;)</a
 	    > k a b</li
+	  ><li class="src short"
+	  ><span class="keyword"
+	    >pattern</span
+	    > <a href="#"
+	    >PatWithExplicitSig</a
+	    > :: <a href="#"
+	    >Eq</a
+	    > somex =&gt; somex -&gt; <a href="#"
+	    >FooType</a
+	    > somex</li
 	  ></ul
 	></div
       ><div id="interface"
@@ -277,6 +287,25 @@ window.onload = function () {pageLoad();};
 		>Empty</a
 		></code
 	      ></p
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >pattern</span
+	    > <a id="v:PatWithExplicitSig" class="def"
+	    >PatWithExplicitSig</a
+	    > :: <a href="#"
+	    >Eq</a
+	    > somex =&gt; somex -&gt; <a href="#"
+	    >FooType</a
+	    > somex <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >Earlier ghc versions didn't allow explicit signatures
+ on pattern synonyms.</p
 	    ></div
 	  ></div
 	></div

--- a/html-test/src/PatternSyns.hs
+++ b/html-test/src/PatternSyns.hs
@@ -20,3 +20,8 @@ data (a :: *) >< b = Empty
 
 -- | Pattern for 'Empty'
 pattern E = Empty
+
+-- | Earlier ghc versions didn't allow explicit signatures
+-- on pattern synonyms.
+pattern PatWithExplicitSig :: Eq somex => somex -> FooType somex
+pattern PatWithExplicitSig x = FooCtor x


### PR DESCRIPTION
Along my way with #627 I found that haddock currently doesn't allow user defined signatures for pattern synonyms!