### PR TITLE
Lookup fixities for reexports without subordinates

### DIFF
--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -18,6 +18,7 @@ import Haddock.Types
 import Haddock.Convert
 import Haddock.GhcUtils
 
+import Control.Applicative
 import Control.Arrow hiding ((<+>))
 import Data.List
 import Data.Ord (comparing)
@@ -113,7 +114,7 @@ attachToExportItem expInfo iface ifaceMap instIfaceMap export =
                                } = e { expItemFixities =
       nubByName fst $ expItemFixities e ++
       [ (n',f) | n <- getMainDeclBinder d
-              , Just subs <- [instLookup instSubMap n iface ifaceMap instIfaceMap]
+              , Just subs <- [instLookup instSubMap n iface ifaceMap instIfaceMap <|> Just []]
               , n' <- n : (subs ++ patsyn_names)
               , Just f <- [instLookup instFixMap n' iface ifaceMap instIfaceMap]
       ] }


### PR DESCRIPTION
This resolves #641: Reexported `a` in `Bar` doesn't have any subordinates (it is neither a class, type family nor a data declaration) so fixity lookup stops right there.

Solution: Return the empty list for declarations without subordinates now.
