### PR TITLE
Don't include names with empty subordinates in maps

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -317,13 +317,21 @@ mkMaps :: DynFlags
 mkMaps dflags gre instances decls =
   let
     (a, b, c, d) = unzip4 $ map mappings decls
-  in (f' $ map (nubByName fst) a , f b, f c, f d, instanceMap)
+  in ( f' (map (nubByName fst) a)
+     , f (filterMapping (not . M.null) b)
+     , f (filterMapping (not . null) c)
+     , f (filterMapping (not . null) d)
+     , instanceMap
+     )
   where
     f :: (Ord a, Monoid b) => [[(a, b)]] -> Map a b
     f = M.fromListWith (<>) . concat
 
     f' :: [[(Name, MDoc Name)]] -> Map Name (MDoc Name)
     f' = M.fromListWith metaDocAppend . concat
+
+    filterMapping :: (b -> Bool) ->  [[(a, b)]] -> [[(a, b)]]
+    filterMapping p = map (filter (p . snd))
 
     mappings :: (LHsDecl Name, [HsDocString])
              -> ( [(Name, MDoc Name)]


### PR DESCRIPTION
These are unecessary anyway and just blow up interface size. 

I *think* this might be related to #641. And I think this will lead to failed tests until https://github.com/haskell/haddock/pull/642 is merged. 

On a related note: I think currently the maps include subordinates and documentation for *any* declaration present in the source file not just for the exported ones. 