### PR TITLE
Make per-argument docs for class methods work again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 ## Changes in version 2.18.0
 
- * Support user defined signatures on pattern synonyms
-
  * Synopsis is working again (#599)
+
+ * Per-argument documentation on class methods working again (#647)
+
+ * Support user defined signatures on pattern synonyms
 
  * Support for bundled pattern synonyms (#494, #551, #626)
 

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -429,8 +429,9 @@ typeDocs :: HsDecl Name -> Map Int HsDocString
 typeDocs d =
   let docs = go 0 in
   case d of
-    SigD (TypeSig _ ty)   -> docs (unLoc (hsSigWcType ty))
-    SigD (PatSynSig _ ty) -> docs (unLoc (hsSigType ty))
+    SigD (TypeSig _ ty)      -> docs (unLoc (hsSigWcType ty))
+    SigD (ClassOpSig _ _ ty) -> docs (unLoc (hsSigType ty))
+    SigD (PatSynSig _ ty)    -> docs (unLoc (hsSigType ty))
     ForD (ForeignImport _ ty _ _)   -> docs (unLoc (hsSigType ty))
     TyClD (SynDecl { tcdRhs = ty }) -> docs (unLoc ty)
     _ -> M.empty

--- a/html-test/ref/Bug647.html
+++ b/html-test/ref/Bug647.html
@@ -1,0 +1,114 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >Bug647</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><script src="haddock-util.js" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ><script type="text/javascript"
+    >//
+window.onload = function () {pageLoad();};
+//
+</script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug647</p
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >class</span
+	    > <a id="t:Bug647" class="def"
+	    >Bug647</a
+	    > a <span class="keyword"
+	    >where</span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    ><a href="#"
+	      >f</a
+	      ></p
+	    ></div
+	  ><div class="subs methods"
+	  ><p class="caption"
+	    >Methods</p
+	    ><p class="src"
+	    ><a id="v:f" class="def"
+	      >f</a
+	      > <a href="#" class="selflink"
+	      >#</a
+	      ></p
+	    ><div class="subs arguments"
+	    ><p class="caption"
+	      >Arguments</p
+	      ><table
+	      ><tr
+		><td class="src"
+		  >:: a</td
+		  ><td class="doc"
+		  ><p
+		    >doc for arg1</p
+		    ></td
+		  ></tr
+		><tr
+		><td class="src"
+		  >-&gt; a</td
+		  ><td class="doc"
+		  ><p
+		    >doc for arg2</p
+		    ></td
+		  ></tr
+		><tr
+		><td class="src"
+		  >-&gt; a</td
+		  ><td class="doc"
+		  ><p
+		    >doc for arg3</p
+		    ></td
+		  ></tr
+		></table
+	      ></div
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug647.hs
+++ b/html-test/src/Bug647.hs
@@ -1,0 +1,7 @@
+module Bug647 where
+
+class Bug647 a where
+	f :: String -- ^ Docs for arg1
+	  -> Int    -- ^ Docs for arg2
+	  -> Int    -- ^ Docs for arg3
+	  -> a

--- a/html-test/src/Bug647.hs
+++ b/html-test/src/Bug647.hs
@@ -1,7 +1,6 @@
 module Bug647 where
 
 class Bug647 a where
-	f :: String -- ^ Docs for arg1
-	  -> Int    -- ^ Docs for arg2
-	  -> Int    -- ^ Docs for arg3
-	  -> a
+	f :: a -- ^ doc for arg1
+	  -> a -- ^ doc for arg2
+	  -> a -- ^ doc for arg3


### PR DESCRIPTION
This fixes #647. I am not sure why this stopped working somewhere between 2.16 and 2.17. git blame suggests the function didn't cover `ClassOpSig` for ages.
