### PR TITLE
Fix #249 (ish)

### DIFF
--- a/haddock-api/resources/html/Classic.theme/xhaddock.css
+++ b/haddock-api/resources/html/Classic.theme/xhaddock.css
@@ -285,6 +285,7 @@ div.top h5 {
 	padding: 0 8px 2px 5px;
 	margin-right: -3px;
 	background-color: #f0f0f0;
+	-moz-user-select: none;
 }
 
 div.subs {

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -394,6 +394,7 @@ div#style-menu-holder {
   background: #f0f0f0;
   padding: 0 0.5em 0.2em;
   margin: 0 -0.5em 0 0;
+  -moz-user-select: none;
 }
 #interface .src .selflink {
   border-left: 1px solid #919191;


### PR DESCRIPTION
Hi, I tried reproducing the double-click issue in #249 and it doesn't seem to happen with modern browsers anymore; Source is only selected upon triple-clicking in the latest Firefox but not in Chrome or Edge. This will stop that, so I'd suggest either this change or just closing the issue.