### PR TITLE
Build instructions: haddock-library and -api first!

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Clone the repository:
 
 and then proceed using your favourite build tool.
 
+Note: before building `haddock`, you need to build the subprojects
+`haddock-library` and `haddock-api`, in this order!
+
 #### Using [`cabal new-build`](http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html)
 
 ```bash


### PR DESCRIPTION
Ah, it actually cost me more than an hour to build haddock, since the build procedure in README.md was misleading.  (I blamed it on wrong ghc, wrong cabal etc.)

This addition to the build instructions would have helped me a lot!