### PR TITLE
Write meta.json when generating html output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
  * to be released
 
+ * Haddock now writes additional information about the documentation to `meta.json`
+
  * Fix renaming of type variables after specializing instance method signatures (#613)
 
  * Move markup related data types to haddock-library

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -89,6 +89,7 @@ library
     Haddock.Backends.Xhtml.Types
     Haddock.Backends.Xhtml.Utils
     Haddock.Backends.LaTeX
+    Haddock.Backends.Meta
     Haddock.Backends.HaddockDB
     Haddock.Backends.Hoogle
     Haddock.Backends.Hyperlinker

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -29,6 +29,7 @@ import Data.Version
 import Haddock.Backends.Xhtml
 import Haddock.Backends.Xhtml.Themes (getThemes)
 import Haddock.Backends.LaTeX
+import Haddock.Backends.Meta
 import Haddock.Backends.Hoogle
 import Haddock.Backends.Hyperlinker
 import Haddock.Interface
@@ -319,6 +320,7 @@ render dflags flags qual ifaces installedIfaces extSrcMap = do
                 opt_contents_url opt_index_url unicode qual
                 pretty
     copyHtmlBits odir libDir themes
+    writeHaddockMeta odir
 
   -- TODO: we throw away Meta for both Hoogle and LaTeX right now,
   -- might want to fix that if/when these two get some work on them
@@ -445,9 +447,9 @@ getHaddockLibDir flags =
             exists <- doesDirectoryExist p
             pure $ if exists then Just p else Nothing
 
-      dirs <- mapM check res_dirs  
+      dirs <- mapM check res_dirs
       case [p | Just p <- dirs] of
-        (p : _) -> return p 
+        (p : _) -> return p
         _       -> die "Haddock's resource directory does not exist!\n"
 #endif
     fs -> return (last fs)

--- a/haddock-api/src/Haddock/Backends/Meta.hs
+++ b/haddock-api/src/Haddock/Backends/Meta.hs
@@ -1,0 +1,22 @@
+module Haddock.Backends.Meta where
+
+import Haddock.Utils.Json
+import Haddock.Version
+
+import Data.ByteString.Builder (hPutBuilder)
+import System.FilePath ((</>))
+import System.IO (withFile, IOMode (WriteMode))
+
+-- | Writes a json encoded file containing additional
+-- information about the generated documentation. This
+-- is useful for external tools (e.g. hackage).
+writeHaddockMeta :: FilePath -> IO ()
+writeHaddockMeta odir = do
+  let
+    meta_json :: Value
+    meta_json = object [
+        "haddock_version" .= String projectVersion
+      ]
+
+  withFile (odir </> "meta.json") WriteMode $ \h ->
+    hPutBuilder h (encodeToBuilder meta_json)

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -125,6 +125,7 @@ executable haddock
       Haddock.Backends.Xhtml.Types
       Haddock.Backends.Xhtml.Utils
       Haddock.Backends.LaTeX
+      Haddock.Backends.Meta
       Haddock.Backends.HaddockDB
       Haddock.Backends.Hoogle
       Haddock.Backends.Hyperlinker


### PR DESCRIPTION
@hvr For the QuickNav feature I need to teach hackage which javascript files it has to look for in a doc tarball. As I am planning some long term changes in this area I thought it might make sense to introduce a `meta.json`. With this information hackage can decide which javascripts it needs.