### PR TITLE
Precise Haddock: Use Avails for export resolution

### DIFF
--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -118,12 +118,12 @@ attachToExportItem index expInfo iface ifaceMap instIfaceMap export =
   where
     attachFixities e@ExportDecl{ expItemDecl = L _ d
                                , expItemPats = patsyns
+                               , expItemSubDocs = subDocs
                                } = e { expItemFixities =
       nubByName fst $ expItemFixities e ++
       [ (n',f) | n <- getMainDeclBinder d
-              , Just subs <- [instLookup instSubMap n iface ifaceMap instIfaceMap <|> Just []]
-              , n' <- n : (subs ++ patsyn_names)
-              , Just f <- [instLookup instFixMap n' iface ifaceMap instIfaceMap]
+               , n' <- n : (map fst subDocs ++ patsyn_names)
+               , Just f <- [instLookup instFixMap n' iface ifaceMap instIfaceMap]
       ] }
       where
         patsyn_names = concatMap (getMainDeclBinder . fst) patsyns

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -98,7 +98,7 @@ createInterface tm flags modMap instIfaceMap = do
       Nothing -> do
         liftErrMsg $ tell [ "Warning: Renamed source is not available." ]
         return (emptyRnGroup, [], Nothing, Nothing)
-      x -> x
+      x -> return x
 
   opts0 <- liftErrMsg $ mkDocOpts (haddockOptions dflags) flags mdl
   let opts

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -655,9 +655,16 @@ mkExportItems
     lookupExport (_, avails) =
       concat <$> traverse availExport (nubAvails avails)
 
-    availExport avail =
-      availExportItem is_sig modMap thisMod semMod warnings exportedNames
-        maps fixMap splices instIfaceMap dflags avail
+    availExport avail
+      | availName avail `notElem` availNamesWithSelectors avail = do
+          exportItems <- for (availNamesWithSelectors avail)
+                             (availExportItem is_sig modMap thisMod semMod
+                               warnings exportedNames maps fixMap splices
+                               instIfaceMap dflags . Avail.avail)
+          return (concat exportItems)
+      | otherwise =
+          availExportItem is_sig modMap thisMod semMod warnings exportedNames
+            maps fixMap splices instIfaceMap dflags avail
 
 availExportItem :: Bool               -- is it a signature
                 -> IfaceMap

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -655,16 +655,9 @@ mkExportItems
     lookupExport (_, avails) =
       concat <$> traverse availExport (nubAvails avails)
 
-    availExport avail
-      | availName avail `notElem` availNamesWithSelectors avail = do
-          exportItems <- for (availNamesWithSelectors avail)
-                             (availExportItem is_sig modMap thisMod semMod
-                               warnings exportedNames maps fixMap splices
-                               instIfaceMap dflags . Avail.avail)
-          return (concat exportItems)
-      | otherwise =
-          availExportItem is_sig modMap thisMod semMod warnings exportedNames
-            maps fixMap splices instIfaceMap dflags avail
+    availExport avail =
+      availExportItem is_sig modMap thisMod semMod warnings exportedNames
+        maps fixMap splices instIfaceMap dflags avail
 
 availExportItem :: Bool               -- is it a signature
                 -> IfaceMap
@@ -680,11 +673,17 @@ availExportItem :: Bool               -- is it a signature
                 -> AvailInfo
                 -> ErrMsgGhc [ExportItem GhcRn]
 availExportItem is_sig modMap thisMod semMod warnings exportedNames
-  (docMap, argMap, declMap, instMap) fixMap splices instIfaceMap
-  dflags availInfo = do
-
-  pats <- findBundledPatterns availInfo
-  declWith availInfo pats
+  maps@(docMap, argMap, declMap, instMap) fixMap splices instIfaceMap
+  dflags availInfo
+  | availName availInfo `notElem` availNamesWithSelectors availInfo = do
+      exportItems <- for (availNamesWithSelectors availInfo)
+                         (availExportItem is_sig modMap thisMod semMod
+                           warnings exportedNames maps fixMap splices
+                           instIfaceMap dflags . Avail.avail)
+      return (concat exportItems)
+  | otherwise = do
+      pats <- findBundledPatterns availInfo
+      declWith availInfo pats
   where
     declWith :: AvailInfo
              -> [(HsDecl GhcRn, DocForDecl Name)]

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -100,10 +100,7 @@ createInterface tm flags modMap instIfaceMap = do
         return (emptyRnGroup, [], Nothing, Nothing)
       Just x -> return x
 
-  opts0 <- liftErrMsg $ mkDocOpts (haddockOptions dflags) flags mdl
-  let opts
-        | Flag_IgnoreAllExports `elem` flags = OptIgnoreExports : opts0
-        | otherwise = opts0
+  opts <- liftErrMsg $ mkDocOpts (haddockOptions dflags) flags mdl
 
   -- Process the top-level module header documentation.
   (!info, mbDoc) <- liftErrMsg $ processModuleHeader dflags gre safety mayDocHeader
@@ -320,10 +317,13 @@ mkDocOpts mbOpts flags mdl = do
   hm <- if Flag_HideModule (moduleString mdl) `elem` flags
         then return $ OptHide : opts
         else return opts
-  if Flag_ShowExtensions (moduleString mdl) `elem` flags
-    then return $ OptShowExtensions : hm
-    else return hm
-
+  ie <- if Flag_IgnoreAllExports `elem` flags
+        then return $ OptIgnoreExports : hm
+        else return hm
+  se <- if Flag_ShowExtensions (moduleString mdl) `elem` flags
+        then return $ OptShowExtensions : ie
+        else return ie
+  return se
 
 parseOption :: String -> ErrMsgM (Maybe DocOption)
 parseOption "hide"            = return (Just OptHide)

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -98,7 +98,7 @@ createInterface tm flags modMap instIfaceMap = do
       Nothing -> do
         liftErrMsg $ tell [ "Warning: Renamed source is not available." ]
         return (emptyRnGroup, [], Nothing, Nothing)
-      x -> return x
+      Just x -> return x
 
   opts0 <- liftErrMsg $ mkDocOpts (haddockOptions dflags) flags mdl
   let opts

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -116,7 +116,10 @@ createInterface tm flags modMap instIfaceMap = do
         | otherwise = exports0
 
       unrestrictedImportedMods
-        | Just (_, idecls, _, _) <- tm_renamed_source tm
+        -- calculation of unqualified module imports
+        -- is only necessary with an explicit export list
+        | Just _ <- exports
+        , Just (_, idecls, _, _) <- tm_renamed_source tm
         = unrestrictedModuleImports (map unLoc idecls)
         | otherwise = M.empty
 

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -116,8 +116,8 @@ createInterface tm flags modMap instIfaceMap = do
         | otherwise = exports0
 
       unrestrictedImportedMods
-        -- calculation of unqualified module imports
-        -- is only necessary with an explicit export list
+        -- module re-exports are only possible with
+        -- explicit export list
         | Just _ <- exports
         = unrestrictedModuleImports (map unLoc imports)
         | otherwise = M.empty

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -93,12 +93,12 @@ createInterface tm flags modMap instIfaceMap = do
 
   -- The renamed source should always be available to us, but it's best
   -- to be on the safe side.
-  (group_, mayExports, mayDocHeader) <-
+  (group_, imports, mayExports, mayDocHeader) <-
     case renamedSource tm of
       Nothing -> do
         liftErrMsg $ tell [ "Warning: Renamed source is not available." ]
-        return (emptyRnGroup, Nothing, Nothing)
-      Just (x, _, y, z) -> return (x, y, z)
+        return (emptyRnGroup, [], Nothing, Nothing)
+      x -> x
 
   opts0 <- liftErrMsg $ mkDocOpts (haddockOptions dflags) flags mdl
   let opts
@@ -119,8 +119,7 @@ createInterface tm flags modMap instIfaceMap = do
         -- calculation of unqualified module imports
         -- is only necessary with an explicit export list
         | Just _ <- exports
-        , Just (_, idecls, _, _) <- tm_renamed_source tm
-        = unrestrictedModuleImports (map unLoc idecls)
+        = unrestrictedModuleImports (map unLoc imports)
         | otherwise = M.empty
 
       fixMap = mkFixMap group_

--- a/haddock-api/src/Haddock/Interface/Json.hs
+++ b/haddock-api/src/Haddock/Interface/Json.hs
@@ -37,7 +37,6 @@ jsonInstalledInterface InstalledInterface{..} = jsonObject properties
       , ("exports"         , jsonArray (map jsonName instExports))
       , ("visible_exports" , jsonArray (map jsonName instVisibleExports))
       , ("options"         , jsonArray (map (jsonString . show) instOptions))
-      , ("sub_map"         , jsonMap nameStableString (jsonArray . map jsonName) instSubMap)
       , ("fix_map"         , jsonMap nameStableString jsonFixity instFixMap)
       ]
 

--- a/haddock-api/src/Haddock/Interface/Json.hs
+++ b/haddock-api/src/Haddock/Interface/Json.hs
@@ -38,7 +38,6 @@ jsonInstalledInterface InstalledInterface{..} = jsonObject properties
       , ("visible_exports" , jsonArray (map jsonName instVisibleExports))
       , ("options"         , jsonArray (map (jsonString . show) instOptions))
       , ("sub_map"         , jsonMap nameStableString (jsonArray . map jsonName) instSubMap)
-      , ("bundled_patsyns" , jsonMap nameStableString (jsonArray . map jsonName) instBundledPatSynMap)
       , ("fix_map"         , jsonMap nameStableString jsonFixity instFixMap)
       ]
 
@@ -106,4 +105,3 @@ jsonInt = JSInt
 
 jsonBool :: Bool -> JsonDoc
 jsonBool = JSBool
-

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -373,7 +373,7 @@ instance Binary InterfaceFile where
 
 instance Binary InstalledInterface where
   put_ bh (InstalledInterface modu is_sig info docMap argMap
-           exps visExps opts subMap fixMap) = do
+           exps visExps opts fixMap) = do
     put_ bh modu
     put_ bh is_sig
     put_ bh info
@@ -381,7 +381,6 @@ instance Binary InstalledInterface where
     put_ bh exps
     put_ bh visExps
     put_ bh opts
-    put_ bh subMap
     put_ bh fixMap
 
   get bh = do
@@ -392,10 +391,9 @@ instance Binary InstalledInterface where
     exps    <- get bh
     visExps <- get bh
     opts    <- get bh
-    subMap  <- get bh
     fixMap  <- get bh
     return (InstalledInterface modu is_sig info docMap argMap
-            exps visExps opts subMap fixMap)
+            exps visExps opts fixMap)
 
 
 instance Binary DocOption where

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -83,7 +83,7 @@ binaryInterfaceMagic = 0xD0Cface
 --
 binaryInterfaceVersion :: Word16
 #if (__GLASGOW_HASKELL__ >= 803) && (__GLASGOW_HASKELL__ < 805)
-binaryInterfaceVersion = 31
+binaryInterfaceVersion = 32
 
 binaryInterfaceVersionCompatibility :: [Word16]
 binaryInterfaceVersionCompatibility = [binaryInterfaceVersion]
@@ -373,7 +373,7 @@ instance Binary InterfaceFile where
 
 instance Binary InstalledInterface where
   put_ bh (InstalledInterface modu is_sig info docMap argMap
-           exps visExps opts subMap patSynMap fixMap) = do
+           exps visExps opts subMap fixMap) = do
     put_ bh modu
     put_ bh is_sig
     put_ bh info
@@ -382,7 +382,6 @@ instance Binary InstalledInterface where
     put_ bh visExps
     put_ bh opts
     put_ bh subMap
-    put_ bh patSynMap
     put_ bh fixMap
 
   get bh = do
@@ -394,11 +393,9 @@ instance Binary InstalledInterface where
     visExps <- get bh
     opts    <- get bh
     subMap  <- get bh
-    patSynMap <- get bh
     fixMap  <- get bh
-
     return (InstalledInterface modu is_sig info docMap argMap
-            exps visExps opts subMap patSynMap fixMap)
+            exps visExps opts subMap fixMap)
 
 
 instance Binary DocOption where

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -101,9 +101,6 @@ data Interface = Interface
     -- names of subordinate declarations mapped to their parent declarations.
   , ifaceDeclMap         :: !(Map Name [LHsDecl GhcRn])
 
-    -- | Bundled pattern synonym declarations for specific types.
-  , ifaceBundledPatSynMap :: !(Map Name [Name])
-
     -- | Documentation of declarations originating from the module (including
     -- subordinates).
   , ifaceDocMap          :: !(DocMap Name)
@@ -186,8 +183,6 @@ data InstalledInterface = InstalledInterface
 
   , instSubMap           :: Map Name [Name]
 
-  , instBundledPatSynMap :: Map Name [Name]
-
   , instFixMap           :: Map Name Fixity
   }
 
@@ -204,7 +199,6 @@ toInstalledIface interface = InstalledInterface
   , instVisibleExports   = ifaceVisibleExports   interface
   , instOptions          = ifaceOptions          interface
   , instSubMap           = ifaceSubMap           interface
-  , instBundledPatSynMap = ifaceBundledPatSynMap interface
   , instFixMap           = ifaceFixMap           interface
   }
 

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -111,7 +111,6 @@ data Interface = Interface
   , ifaceRnDocMap        :: !(DocMap DocName)
   , ifaceRnArgMap        :: !(ArgMap DocName)
 
-  , ifaceSubMap          :: !(Map Name [Name])
   , ifaceFixMap          :: !(Map Name Fixity)
 
   , ifaceExportItems     :: ![ExportItem GhcRn]
@@ -181,8 +180,6 @@ data InstalledInterface = InstalledInterface
     -- | Haddock options for this module (prune, ignore-exports, etc).
   , instOptions          :: [DocOption]
 
-  , instSubMap           :: Map Name [Name]
-
   , instFixMap           :: Map Name Fixity
   }
 
@@ -198,7 +195,6 @@ toInstalledIface interface = InstalledInterface
   , instExports          = ifaceExports          interface
   , instVisibleExports   = ifaceVisibleExports   interface
   , instOptions          = ifaceOptions          interface
-  , instSubMap           = ifaceSubMap           interface
   , instFixMap           = ifaceFixMap           interface
   }
 


### PR DESCRIPTION
Since https://github.com/ghc/ghc/commit/7e5d4a0e8e673f79b93ff63c4a4d0cd2b71e3063 GHC holds the `Avails` for each export list entry. This patch makes use of these `Avails` so it doesn't have to calculate all the reexported names by itself. 

This resolves
- #121 
- #174 
- #225 
- #344 
- #584 
- #591 
