### PR TITLE
Haddock: support splitted include paths.

### DIFF
--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -28,6 +28,7 @@ import Module
 import HscTypes
 import GHC
 import Class
+import DynFlags
 
 
 moduleString :: Module -> String
@@ -282,7 +283,8 @@ minimalDef n = do
 setObjectDir, setHiDir, setStubDir, setOutputDir :: String -> DynFlags -> DynFlags
 setObjectDir  f d = d{ objectDir  = Just f}
 setHiDir      f d = d{ hiDir      = Just f}
-setStubDir    f d = d{ stubDir    = Just f, includePaths = f : includePaths d }
+setStubDir    f d = d{ stubDir    = Just f
+                     , includePaths = addGlobalInclude (includePaths d) [f] }
   -- -stubdir D adds an implicit -I D, so that gcc can find the _stub.h file
   -- \#included from the .hc file when compiling with -fvia-C.
 setOutputDir  f = setObjectDir f . setHiDir f . setStubDir f


### PR DESCRIPTION
GHC will be splitting the include paths in DynFlags up to have better control over how to add include paths.