### PR TITLE
Add QuickJump version to meta.json

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -86,12 +86,12 @@ library
     Haddock.Backends.Xhtml.Decl
     Haddock.Backends.Xhtml.DocMarkup
     Haddock.Backends.Xhtml.Layout
+    Haddock.Backends.Xhtml.Meta
     Haddock.Backends.Xhtml.Names
     Haddock.Backends.Xhtml.Themes
     Haddock.Backends.Xhtml.Types
     Haddock.Backends.Xhtml.Utils
     Haddock.Backends.LaTeX
-    Haddock.Backends.Meta
     Haddock.Backends.HaddockDB
     Haddock.Backends.Hoogle
     Haddock.Backends.Hyperlinker

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -27,9 +27,9 @@ module Haddock (
 
 import Data.Version
 import Haddock.Backends.Xhtml
+import Haddock.Backends.Xhtml.Meta
 import Haddock.Backends.Xhtml.Themes (getThemes)
 import Haddock.Backends.LaTeX
-import Haddock.Backends.Meta
 import Haddock.Backends.Hoogle
 import Haddock.Backends.Hyperlinker
 import Haddock.Interface

--- a/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
@@ -1,4 +1,4 @@
-module Haddock.Backends.Meta where
+module Haddock.Backends.Xhtml.Meta where
 
 import Haddock.Utils.Json
 import Haddock.Version
@@ -6,6 +6,11 @@ import Haddock.Version
 import Data.ByteString.Builder (hPutBuilder)
 import System.FilePath ((</>))
 import System.IO (withFile, IOMode (WriteMode))
+
+-- | Everytime breaking changes to the Quckjump api
+-- happen this needs to be modified.
+quickjumpVersion :: Int
+quickjumpVersion = 1
 
 -- | Writes a json encoded file containing additional
 -- information about the generated documentation. This
@@ -15,7 +20,8 @@ writeHaddockMeta odir = do
   let
     meta_json :: Value
     meta_json = object [
-        "haddock_version" .= String projectVersion
+        "haddock_version"   .= String projectVersion
+      , "quickjump_version" .= quickjumpVersion
       ]
 
   withFile (odir </> "meta.json") WriteMode $ \h ->

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -120,12 +120,12 @@ executable haddock
       Haddock.Backends.Xhtml.Decl
       Haddock.Backends.Xhtml.DocMarkup
       Haddock.Backends.Xhtml.Layout
+      Haddock.Backends.Xhtml.Meta
       Haddock.Backends.Xhtml.Names
       Haddock.Backends.Xhtml.Themes
       Haddock.Backends.Xhtml.Types
       Haddock.Backends.Xhtml.Utils
       Haddock.Backends.LaTeX
-      Haddock.Backends.Meta
       Haddock.Backends.HaddockDB
       Haddock.Backends.Hoogle
       Haddock.Backends.Hyperlinker


### PR DESCRIPTION
This helps with versioning the hackage integration.