### PR TITLE
Fix #548 by rendering datatype kinds more carefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,7 @@ TAGS
 .cabal-sandbox
 .ghc.environment.*
 cabal.sandbox.config
+cabal.project.local
+cabal.project.local~
 
 .stack-work/

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -155,7 +155,7 @@ synifyTyCon _coax tc
                                                     -- algebraic data nor newtype:
                                       , dd_ctxt = noLoc []
                                       , dd_cType = Nothing
-                                      , dd_kindSig = Just (synifyKindSig (tyConKind tc))
+                                      , dd_kindSig = synifyDataTyConReturnKind tc
                                                -- we have their kind accurately:
                                       , dd_cons = []  -- No constructors
                                       , dd_derivs = noLoc [] }
@@ -210,7 +210,7 @@ synifyTyCon coax tc
                            -- CoAxioms, not their TyCons
     _ -> synifyName tc
   tyvars = synifyTyVars (tyConTyVars tc)
-  kindSig = Just (tyConKind tc)
+  kindSig = synifyDataTyConReturnKind tc
   -- The data constructors.
   --
   -- Any data-constructors not exported from the module that *defines* the
@@ -235,7 +235,7 @@ synifyTyCon coax tc
   defn = HsDataDefn { dd_ND      = alg_nd
                     , dd_ctxt    = alg_ctx
                     , dd_cType   = Nothing
-                    , dd_kindSig = fmap synifyKindSig kindSig
+                    , dd_kindSig = kindSig
                     , dd_cons    = cons
                     , dd_derivs  = alg_deriv }
  in case lefts consRaw of
@@ -244,6 +244,27 @@ synifyTyCon coax tc
                  , tcdDataDefn = defn
                  , tcdDataCusk = False, tcdFVs = placeHolderNamesTc }
   dataConErrs -> Left $ unlines dataConErrs
+
+-- In this module, every TyCon being considered has come from an interface
+-- file. This means that when considering a data type constructor such as:
+--
+--   data Foo (w :: *) (m :: * -> *) (a :: *)
+--
+-- Then its tyConKind will be (* -> (* -> *) -> * -> *). But beware! We are
+-- also rendering the type variables of Foo, so if we synify the tyConKind of
+-- Foo in full, we will end up displaying this in Haddock:
+--
+--   data Foo (w :: *) (m :: * -> *) (a :: *)
+--     :: * -> (* -> *) -> * -> *
+--
+-- Which is entirely wrong (#548). We only want to display the *return* kind,
+-- which this function obtains.
+synifyDataTyConReturnKind :: TyCon -> Maybe (LHsKind Name)
+synifyDataTyConReturnKind tc
+  = case splitFunTys (tyConKind tc) of
+      (_, ret_kind)
+        | isLiftedTypeKind ret_kind -> Nothing -- Don't bother displaying :: *
+        | otherwise                 -> Just (synifyKindSig ret_kind)
 
 synifyInjectivityAnn :: Maybe Name -> [TyVar] -> Injectivity
                      -> Maybe (LInjectivityAnn Name)

--- a/html-test/ref/Bug548.html
+++ b/html-test/ref/Bug548.html
@@ -1,0 +1,600 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >Bug548</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug548</p
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >newtype</span
+	    > <a id="t:WrappedArrow" class="def"
+	    >WrappedArrow</a
+	    > (a :: <a href="#"
+	    >*</a
+	    > -&gt; <a href="#"
+	    >*</a
+	    > -&gt; <a href="#"
+	    >*</a
+	    >) b c <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs constructors"
+	  ><p class="caption"
+	    >Constructors</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a id="v:WrapArrow" class="def"
+		  >WrapArrow</a
+		  ></td
+		><td class="doc empty"
+		></td
+		></tr
+	      ><tr
+	      ><td colspan="2"
+		><div class="subs fields"
+		  ><p class="caption"
+		    >Fields</p
+		    ><ul
+		    ><li
+		      ><dfn class="src"
+			><a id="v:unwrapArrow" class="def"
+			  >unwrapArrow</a
+			  > :: a b c</dfn
+			><div class="doc empty"
+			></div
+			></li
+		      ></ul
+		    ></div
+		  ></td
+		></tr
+	      ></table
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:WrappedArrow" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Generic1:1"
+		      ></span
+		      > <a href="#"
+		      >Generic1</a
+		      > <a href="#"
+		      >*</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b)</span
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Generic1:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href="#"
+			  >Rep1</a
+			  > (<a href="#"
+			  >WrappedArrow</a
+			  > a b) (f :: <a href="#"
+			  >WrappedArrow</a
+			  > a b -&gt; <a href="#"
+			  >*</a
+			  >) :: k -&gt; <a href="#"
+			  >*</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >from1</a
+			  > :: f a0 -&gt; <a href="#"
+			  >Rep1</a
+			  > (<a href="#"
+			  >WrappedArrow</a
+			  > a b) f a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >to1</a
+			  > :: <a href="#"
+			  >Rep1</a
+			  > (<a href="#"
+			  >WrappedArrow</a
+			  > a b) f a0 -&gt; f a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Functor:2"
+		      ></span
+		      > <a href="#"
+		      >Arrow</a
+		      > a =&gt; <a href="#"
+		      >Functor</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: 2.1</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Functor:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >fmap</a
+			  > :: (a0 -&gt; b0) -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;$)</a
+			  > :: a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Applicative:3"
+		      ></span
+		      > <a href="#"
+		      >Arrow</a
+		      > a =&gt; <a href="#"
+		      >Applicative</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: 2.1</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Applicative:3"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >pure</a
+			  > :: a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;*&gt;)</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b (a0 -&gt; b0) -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >liftA2</a
+			  > :: (a0 -&gt; b0 -&gt; c) -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b c <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(*&gt;)</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;*)</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b b0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Alternative:4"
+		      ></span
+		      > (<a href="#"
+		      >ArrowZero</a
+		      > a, <a href="#"
+		      >ArrowPlus</a
+		      > a) =&gt; <a href="#"
+		      >Alternative</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: 2.1</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Alternative:4"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >empty</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;|&gt;)</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >some</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b [a0] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >many</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b a0 -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b [a0] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Generic:5"
+		      ></span
+		      > <a href="#"
+		      >Generic</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b c)</span
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Generic:5"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href="#"
+			  >Rep</a
+			  > (<a href="#"
+			  >WrappedArrow</a
+			  > a b c) :: <a href="#"
+			  >*</a
+			  > -&gt; <a href="#"
+			  >*</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >from</a
+			  > :: <a href="#"
+			  >WrappedArrow</a
+			  > a b c -&gt; <a href="#"
+			  >Rep</a
+			  > (<a href="#"
+			  >WrappedArrow</a
+			  > a b c) x <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >to</a
+			  > :: <a href="#"
+			  >Rep</a
+			  > (<a href="#"
+			  >WrappedArrow</a
+			  > a b c) x -&gt; <a href="#"
+			  >WrappedArrow</a
+			  > a b c <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Rep1:6"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#"
+		      >Rep1</a
+		      > <a href="#"
+		      >*</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b)</span
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Rep1:6"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#"
+			>Rep1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>WrappedArrow</a
+			> a b) = <a href="#"
+			>D1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>MetaData</a
+			> &quot;WrappedArrow&quot; &quot;Control.Applicative&quot; &quot;base&quot; <a href="#"
+			>True</a
+			>) (<a href="#"
+			>C1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>MetaCons</a
+			> &quot;WrapArrow&quot; <a href="#"
+			>PrefixI</a
+			> <a href="#"
+			>True</a
+			>) (<a href="#"
+			>S1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>MetaSel</a
+			> (<a href="#"
+			>Just</a
+			> <a href="#"
+			>Symbol</a
+			> &quot;unwrapArrow&quot;) <a href="#"
+			>NoSourceUnpackedness</a
+			> <a href="#"
+			>NoSourceStrictness</a
+			> <a href="#"
+			>DecidedLazy</a
+			>) (<a href="#"
+			>Rec1</a
+			> <a href="#"
+			>*</a
+			> (a b))))</div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Rep:7"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#"
+		      >Rep</a
+		      > (<a href="#"
+		      >WrappedArrow</a
+		      > a b c)</span
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:WrappedArrow:Rep:7"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#"
+			>Rep</a
+			> (<a href="#"
+			>WrappedArrow</a
+			> a b c) = <a href="#"
+			>D1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>MetaData</a
+			> &quot;WrappedArrow&quot; &quot;Control.Applicative&quot; &quot;base&quot; <a href="#"
+			>True</a
+			>) (<a href="#"
+			>C1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>MetaCons</a
+			> &quot;WrapArrow&quot; <a href="#"
+			>PrefixI</a
+			> <a href="#"
+			>True</a
+			>) (<a href="#"
+			>S1</a
+			> <a href="#"
+			>*</a
+			> (<a href="#"
+			>MetaSel</a
+			> (<a href="#"
+			>Just</a
+			> <a href="#"
+			>Symbol</a
+			> &quot;unwrapArrow&quot;) <a href="#"
+			>NoSourceUnpackedness</a
+			> <a href="#"
+			>NoSourceStrictness</a
+			> <a href="#"
+			>DecidedLazy</a
+			>) (<a href="#"
+			>Rec0</a
+			> <a href="#"
+			>*</a
+			> (a b c))))</div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug548.hs
+++ b/html-test/src/Bug548.hs
@@ -1,0 +1,3 @@
+module Bug548 (WrappedArrow(..)) where
+
+import Control.Applicative


### PR DESCRIPTION
Before, any data type that was loaded from an interface file (i.e., any data type that passes through `Haddock.Convert`) was displaying utterly wrong kind information, leading to #548. For example, one can see this effect on [the `mtl` Haddocks](http://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-State-Strict.html#t:StateT) on Hackage:

![mtl-bad](https://user-images.githubusercontent.com/2364661/32746485-c4fc4dd4-c883-11e7-9de1-40b211b81a07.png)

Yuck! That return kind is utterly bogus, given that it also displays the type variables of `StateT`.

The simplest fix (adopted here) is to only display the _return_ kind. Moreover, since we're dealing with data types here, I opt not to display the return kind if it's `*` (since that is what it will be by default anyways).

After this change, here is what `StateT` looks like now:

![mtl-good](https://user-images.githubusercontent.com/2364661/32746549-05373404-c884-11e7-8b28-d2b349b8e92f.png)

(Haddock also now appears to render the kind signature of `m`. I wasn't responsible for making that happen, but it's fortunate that Haddock does this, as it's important to ensure that the same kind information is still presented to the user.)