### PR TITLE
Actually render infix type operators as infix

### DIFF
--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -440,8 +440,14 @@ synifyType _ (TyConApp tc tys)
       = noLoc $ HsIParamTy noExt (noLoc $ HsIPName x) (synifyType WithinType ty)
       -- and equalities
       | tc `hasKey` eqTyConKey
-      , [ty1, ty2] <- tys
+      , [ty1, ty2] <- vis_tys
       = noLoc $ HsEqTy noExt (synifyType WithinType ty1) (synifyType WithinType ty2)
+      -- and infix type operators
+      | isSymOcc (nameOccName (getName tc))
+      , [ty1, ty2] <- vis_tys
+      = noLoc $ HsOpTy noExt (synifyType WithinType ty1)
+                             (noLoc $ getName tc)
+                             (synifyType WithinType ty2)
       -- Most TyCons:
       | otherwise =
         foldl (\t1 t2 -> noLoc (HsAppTy noExt t1 t2))


### PR DESCRIPTION
(This is based off of the `ghc-head` branch.)

Currently, infix type operators are always rendered prefix:

![tildes-bad](https://user-images.githubusercontent.com/2364661/32750295-3b90a466-c890-11e7-8e34-091181a0edb8.png)

Note how `(~)`, `(~~)`, `(:~:)`, and `(:~~:)` are rendered prefix. This stinks. Let's render them infix! Doing so is actually quite simple.

After this patch, here's what that code looks like now:

![tildes-good](https://user-images.githubusercontent.com/2364661/32750330-50916c10-c890-11e7-8ed2-c0aa90021283.png)