### PR TITLE
Add autogen-modules

### DIFF
--- a/haddock.cabal
+++ b/haddock.cabal
@@ -146,6 +146,10 @@ executable haddock
       Haddock.Convert
       
       Paths_haddock
+
+    autogen-modules:
+      Paths_haddock
+
   else
     -- in order for haddock's advertised version number to have proper meaning,
     -- we pin down to a single haddock-api version.


### PR DESCRIPTION
> Packages using 'cabal-version: >= 1.25' and the autogenerated module Paths_* must include it also on the 'autogen-modules' field besides 'exposed-modules' and 'other-modules'. This specifies that the module does not come with the package and is generated on setup. Modules built with a custom Setup.hs script also go here to ensure that commands like sdist don't fail.