### PR TITLE
Drop Paths_haddock from ghc.mk

### DIFF
--- a/ghc.mk
+++ b/ghc.mk
@@ -33,8 +33,6 @@ $(INPLACE_LIB)/latex:
 
 endif
 
-utils/haddock_dist_MODULES += Paths_haddock
-
 utils/haddock_dist_DATA_FILES += html/quick-jump.min.js
 utils/haddock_dist_DATA_FILES += html/quick-jump.css
 utils/haddock_dist_DATA_FILES += html/haddock-bundle.min.js


### PR DESCRIPTION
With #705 and #706, the custom addition should not be necessary any more.