### PR TITLE
Make <code> text more readable in Ocean theme.

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -83,9 +83,12 @@ table {
 }
 
 pre, code, kbd, samp, tt, .src {
-	font-family:monospace;
-	*font-size:108%;
-	line-height: 124%;
+    font-family: monospace;
+    background-color: #f7f7f9;
+    border-radius: .25rem;
+    padding: .1rem .2rem;
+    *font-size: 108%;
+    line-height: 124%;
 }
 
 .links, .link {


### PR DESCRIPTION
Hi.

Depending on browser/fonts it can be hard to distinguish text in `<code></code>` blocks from regular text, and this makes the Haddock generated documentation harder to read, in my opinion. How about doing something like this instead? (Inspired by bootstrap.css...)

(I'm not a designer, so don't really know for sure if this is a good idea or not.)