### PR TITLE
Clickable anchors for headings

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -696,7 +696,8 @@ processDeclOneLiner True = Just
 processDeclOneLiner False = Just . divTopDecl . declElem
 
 groupHeading :: Int -> String -> Html -> Html
-groupHeading lev id0 = groupTag lev ! [identifier (groupId id0)]
+groupHeading lev id0 = linkedAnchor grpId . groupTag lev ! [identifier grpId]
+  where grpId = groupId id0
 
 groupTag :: Int -> Html -> Html
 groupTag lev

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -73,10 +73,12 @@
 	  ></details
 	></div
       ><div id="interface"
-      ><h1 id="g:1"
-	>Section1<a id="a:section1"
+      ><a href="#" id="g:1"
+	><h1
+	  >Section1<a id="a:section1"
+	    ></a
+	    ></h1
 	  ></a
-	  ></h1
 	><div class="top"
 	><p class="src"
 	  ><a id="v:test1" class="def"
@@ -87,10 +89,12 @@
 	    >#</a
 	    ></p
 	  ></div
-	><h1 id="g:2"
-	>Section2<a id="a:section2"
+	><a href="#" id="g:2"
+	><h1
+	  >Section2<a id="a:section2"
+	    ></a
+	    ></h1
 	  ></a
-	  ></h1
 	><div class="top"
 	><p class="src"
 	  ><a id="v:test2" class="def"

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -113,8 +113,10 @@
 	  ></details
 	></div
       ><div id="interface"
-      ><h1 id="g:1"
-	>Foo</h1
+      ><a href="#" id="g:1"
+	><h1
+	  >Foo</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:foo" class="def"
@@ -125,8 +127,10 @@
 	    >#</a
 	    ></p
 	  ></div
-	><h1 id="g:2"
-	>Bar</h1
+	><a href="#" id="g:2"
+	><h1
+	  >Bar</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:bar" class="def"
@@ -137,8 +141,10 @@
 	    >#</a
 	    ></p
 	  ></div
-	><h1 id="g:3"
-	>Baz</h1
+	><a href="#" id="g:3"
+	><h1
+	  >Baz</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:baz" class="def"
@@ -149,8 +155,10 @@
 	    >#</a
 	    ></p
 	  ></div
-	><h1 id="g:4"
-	>One</h1
+	><a href="#" id="g:4"
+	><h1
+	  >One</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:one" class="def"
@@ -167,8 +175,10 @@
 	      ></div
 	    ></div
 	  ></div
-	><h1 id="g:5"
-	>Two</h1
+	><a href="#" id="g:5"
+	><h1
+	  >Two</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:two" class="def"
@@ -185,8 +195,10 @@
 	      ></div
 	    ></div
 	  ></div
-	><h1 id="g:6"
-	>Three</h1
+	><a href="#" id="g:6"
+	><h1
+	  >Three</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:three" class="def"

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -79,8 +79,10 @@
 	  ></details
 	></div
       ><div id="interface"
-      ><h1 id="g:1"
-	>Re-exported from an other module</h1
+      ><a href="#" id="g:1"
+	><h1
+	  >Re-exported from an other module</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:foo" class="def"
@@ -103,8 +105,10 @@
 	    >some documentation for foo</p
 	    ></div
 	  ></div
-	><h1 id="g:2"
-	>Re-exported from an other package</h1
+	><a href="#" id="g:2"
+	><h1
+	  >Re-exported from an other package</h1
+	  ></a
 	><div class="doc"
 	><p
 	  >Not yet working, see <a href="#"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -132,10 +132,12 @@
 	  ></details
 	></div
       ><div id="interface"
-      ><h1 id="g:1"
-	>The <code
-	  >HashTable</code
-	  > type</h1
+      ><a href="#" id="g:1"
+	><h1
+	  >The <code
+	    >HashTable</code
+	    > type</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
@@ -161,10 +163,12 @@
 	      >.</p
 	    ></div
 	  ></div
-	><h2 id="g:2"
-	>Operations on <code
-	  >HashTable</code
-	  >s</h2
+	><a href="#" id="g:2"
+	><h2
+	  >Operations on <code
+	    >HashTable</code
+	    >s</h2
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:new" class="def"
@@ -234,10 +238,12 @@
 	      > otherwise.</p
 	    ></div
 	  ></div
-	><h1 id="g:3"
-	>The <code
-	  >Hash</code
-	  > class</h1
+	><a href="#" id="g:3"
+	><h1
+	  >The <code
+	    >Hash</code
+	    > class</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -630,10 +630,14 @@
 	  ></details
 	></div
       ><div id="interface"
-      ><h1 id="g:1"
-	>Type declarations</h1
-	><h2 id="g:2"
-	>Data types</h2
+      ><a href="#" id="g:1"
+	><h1
+	  >Type declarations</h1
+	  ></a
+	><a href="#" id="g:2"
+	><h2
+	  >Data types</h2
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
@@ -1168,8 +1172,10 @@
 	      ></table
 	    ></div
 	  ></div
-	><h2 id="g:3"
-	>Records</h2
+	><a href="#" id="g:3"
+	><h2
+	  >Records</h2
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
@@ -1449,8 +1455,10 @@
 	><p
 	  >test that we can export record selectors on their own:</p
 	  ></div
-	><h1 id="g:4"
-	>Class declarations</h1
+	><a href="#" id="g:4"
+	><h1
+	  >Class declarations</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
@@ -1741,8 +1749,10 @@
 	      > method</p
 	    ></div
 	  ></div
-	><h1 id="g:5"
-	>Function types</h1
+	><a href="#" id="g:5"
+	><h1
+	  >Function types</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:f" class="def"
@@ -1823,8 +1833,10 @@ using double quotes: <a href="#"
 	    >we can export foreign declarations too</p
 	    ></div
 	  ></div
-	><h1 id="g:6"
-	>Auxiliary stuff</h1
+	><a href="#" id="g:6"
+	><h1
+	  >Auxiliary stuff</h1
+	  ></a
 	><div class="doc"
 	><p
 	  >This is some documentation that is attached to a name ($aux1)
@@ -1916,8 +1928,10 @@ test2
 each line must begin with &gt; (which isn't significant unless it
 is at the beginning of the line).</pre
 	  ></div
-	><h1 id="g:7"
-	>A hidden module</h1
+	><a href="#" id="g:7"
+	><h1
+	  >A hidden module</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:hidden" class="def"
@@ -1930,8 +1944,10 @@ is at the beginning of the line).</pre
 	    >#</a
 	    ></p
 	  ></div
-	><h1 id="g:8"
-	>A visible module</h1
+	><a href="#" id="g:8"
+	><h1
+	  >A visible module</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  >module <a href="#"
@@ -1942,8 +1958,10 @@ is at the beginning of the line).</pre
 	><p
 	  >nested-style doc comments </p
 	  ></div
-	><h1 id="g:9"
-	>Existential / Universal types</h1
+	><a href="#" id="g:9"
+	><h1
+	  >Existential / Universal types</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><span class="keyword"
@@ -2002,8 +2020,10 @@ is at the beginning of the line).</pre
 	      ></table
 	    ></div
 	  ></div
-	><h1 id="g:10"
-	>Type signatures with argument docs</h1
+	><a href="#" id="g:10"
+	><h1
+	  >Type signatures with argument docs</h1
+	  ></a
 	><div class="top"
 	><p class="src"
 	  ><a id="v:k" class="def"
@@ -2224,10 +2244,14 @@ is at the beginning of the line).</pre
 	    >A foreign import with argument docs</p
 	    ></div
 	  ></div
-	><h1 id="g:11"
-	>A section</h1
-	><h2 id="g:12"
-	>A subsection</h2
+	><a href="#" id="g:11"
+	><h1
+	  >A section</h1
+	  ></a
+	><a href="#" id="g:12"
+	><h2
+	  >A subsection</h2
+	  ></a
 	><div class="doc"
 	><pre
 	  >a literal line</pre


### PR DESCRIPTION
See #579. This just adds an <a> tag around the heading, pointing to the heading itself. I didn't implement the second half of that feature request (more descriptive anchor names) because I actually prefer the short names - they are consistent with the other generated anchor names.

This is a tiny change, but it is something I've also wanted in the past.