### PR TITLE
 Improve appearance and readability

### DIFF
--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -47,8 +47,8 @@ dd {
 }
 
 a { text-decoration: none; }
-a[href]:link {color: #9C5791;}
-a[href]:visited {color: #5E3558;}
+a[href]:link {color: #9E358F;}
+a[href]:visited {color: #805A75;}
 a[href]:hover { text-decoration:underline; }
 
 a[href].def:link, a[href].def:visited { color: rgba(69, 59, 97, 0.8); }
@@ -73,7 +73,7 @@ body.js-enabled .hide-when-js-enabled {
 
 @media only screen and (min-width: 1280px) {
   #content {
-    width: 62vw;
+    width: 70vw;
     max-width: 1450px;
   }
 
@@ -133,6 +133,14 @@ body.js-enabled .hide-when-js-enabled {
   The package name                                   Source . Contents . Index
 */
 @media only screen and (min-width: 1000px) {
+  #package-header {
+      text-align: left;
+      overflow: visible;
+      white-space: nowrap;
+      display: inline-table;
+      width: 100%;
+  }
+
   #package-header .caption {
     display: inline-block;
     margin: 3px 1em 2px 2em;

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -144,6 +144,7 @@ body.js-enabled .hide-when-js-enabled {
   #package-header .caption {
     display: inline-block;
     margin: 3px 1em 2px 2em;
+    float: left;
   }
 
   #package-header ul.links {

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -73,36 +73,55 @@ body.js-enabled .hide-when-js-enabled {
 
 @media only screen and (min-width: 1280px) {
   #content {
-    width: 65vw;
+    width: 62vw;
     max-width: 1450px;
   }
 
   #table-of-contents {
     position: fixed;
-    left: 10px;
     max-width: 10vw;
     top: 10.2em;
   }
+
+  #synopsis {
+    display: block;
+    position: fixed;
+    top: 5em;
+    max-width: 65vw;
+    /* Ensure that synopsis covers everything (including MathJAX markup) */
+    z-index: 1;
+  }
+
+  #synopsis, #table-of-contents {
+    left: 2em;
+  }
+
+  #synopsis .show {
+    border: 1px solid #5E5184;
+    padding: 0.7em;
+    max-height: 65vh;
+  }
+
 }
 
 @media only screen and (max-width: 1280px) {
   #content {
     width: 80vw;
   }
-}
-
-@media only screen and (max-width: 1000px) {
-  #content {
-    width: 93vw;
-  }
 
   #synopsis {
     display: block;
     padding: 0;
     position: relative;
-    margin: 4em 0;
+    margin: 0;
     border-bottom: 1px dashed #5E5184;
     width: 100%;
+  }
+}
+
+@media only screen and (max-width: 1000px) {
+  #content {
+    width: 93vw;
   }
 }
 
@@ -122,23 +141,6 @@ body.js-enabled .hide-when-js-enabled {
   #package-header ul.links {
     float: right;
     margin: 3px 2em 2px 1em;
-  }
-
-  #synopsis {
-    display: block;
-    position: fixed;
-    top: 5em;
-    left: 10px;
-    padding: 0.25em;
-    max-width: 65vw;
-    /* Ensure that synopsis covers everything (including MathJAX markup) */
-    z-index: 1;
-  }
-
-  #synopsis .show {
-    border: 1px solid #5E5184;
-    padding: 0.7em;
-    max-height: 65vh;
   }
 }
 
@@ -181,7 +183,7 @@ Display the package name on top of the menu links and center both elements:
  */
 
 body {
-  font: 400 16px/1.6 'Open Sans', sans-serif;
+  font: 400 15px/1.5 'Open Sans', sans-serif;
   *font-size:small; /* for IE */
   *font:x-small; /* for IE in quirks mode */
 }
@@ -199,8 +201,6 @@ table {
 
 pre, code, kbd, samp, tt, .src {
 	font-family:monospace;
-	*font-size:108%;
-	line-height: 1.54em;
 }
 
 .links, .link {
@@ -219,8 +219,8 @@ pre, code, kbd, samp, tt, .src {
 #package-header #page-menu a:link, #package-header #page-menu a:visited { color: white; }
 
 
-.info  {
-  font-size: 85%; /* 11pt */
+.info {
+  font-size: 90%;
 }
 
 
@@ -254,7 +254,7 @@ ul + p {
 ul.links {
   list-style: none;
   text-align: left;
-  font-size: 1em;
+  font-size: 0.95em;
 }
 
 ul.links li {
@@ -277,7 +277,7 @@ ul.links li a {
 
 .collapser:before, .expander:before {
   font-size: 1.2em;
-  color: #5E5184;
+  color: #9C5791;
   display: inline-block;
   padding-right: 7px;
 }
@@ -312,18 +312,22 @@ details[open] > summary {
 }
 
 pre {
-  padding: 1rem;
-  margin: 0px;
+  padding: 0.5rem 1rem;
+  margin: 1em 0 0 0;
   background-color: #f7f7f7;
   overflow: auto;
 }
 
+pre + p {
+  margin-top: 1em;
+}
+
 pre + pre {
-  margin-top: 0.4em;
+  margin-top: 0.5em;
 }
 
 .src {
-  background: #f0f0f0;
+  background: #f4f4f4;
   padding: 0.2em 0.5em;
 }
 
@@ -372,7 +376,7 @@ table.info {
   border: 1px solid #ddd;
   color: rgb(78,98,114);
   background-color: #fff;
-  max-width: 40%;
+  max-width: 60%;
   border-spacing: 0;
   position: relative;
   top: -0.78em;
@@ -430,7 +434,7 @@ div#style-menu-holder {
   position: absolute;
   width: 100%;
   height: 3em;
-  margin-top: 3em;
+  margin-top: 6em;
 }
 
 /* @end */
@@ -445,7 +449,8 @@ div#style-menu-holder {
 #table-of-contents {
   background:  #f7f7f7;
   padding: 1em;
-  margin: 1em 0 2em 0;
+  margin: 0;
+  margin-top: 1em;
 }
 
 #table-of-contents .caption {
@@ -457,7 +462,7 @@ div#style-menu-holder {
   list-style: none;
   margin: 0;
   margin-top: 10px;
-  font-size: 95%;
+  font-size: 14px;
 }
 
 #table-of-contents ul ul {
@@ -503,11 +508,17 @@ div#style-menu-holder {
   margin-left: 0;
 }
 
+#interface td.src {
+  white-space: nowrap;
+}
+
 /* @end */
 
 /* @group Main Content */
 
-#interface div.top + div.top { margin-top: 0.6em; }
+#interface div.top + div.top {
+  margin-top: 3em;
+}
 
 #interface p + div.top,
 #interface h1 + div.top,
@@ -520,14 +531,13 @@ div#style-menu-holder {
 #interface .src .selflink,
 #interface .src .link {
   float: right;
-  color: #919191;
-  background: #f0f0f0;
-  padding: 0 0.5em 0.2em;
-  margin: 0 -0.5em 0 0;
+  color: #888;
+  padding: 0 7px;
   -moz-user-select: none;
+  font-weight: bold;
+  line-height: 30px;
 }
 #interface .src .selflink {
-  border-left: 1px solid #919191;
   margin: 0 -0.5em 0 0.5em;
 }
 
@@ -608,6 +618,20 @@ div#style-menu-holder {
   margin: 0;
 }
 
+.subs .subs .caption {
+  margin-top: 16px !important;
+  margin-bottom: 0px !important;
+}
+
+.subs .subs .caption + .src {
+  margin: 0px;
+  margin-top: 8px;
+}
+
+.subs .subs .src + .src {
+  margin-top: 8px;
+}
+
 /* Render short-style data instances */
 .inst ul {
   height: 100%;
@@ -626,7 +650,9 @@ div#style-menu-holder {
 }
 
 .top p.src {
-  border-top: 1px solid #ccc;
+  border-bottom: 3px solid #e5e5e5;
+  line-height: 2rem;
+  margin-bottom: 1em;
 }
 
 .warning {

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -37,8 +37,8 @@ dd {
 }
 
 a { text-decoration: none; }
-a[href]:link { color: rgb(196,69,29); }
-a[href]:visited { color: rgb(171,105,84); }
+a[href]:link {color: #9C5791;}
+a[href]:visited {color: #5E3558;}
 a[href]:hover { text-decoration:underline; }
 
 a[href].def:link, a[href].def:visited { color: rgba(69, 59, 97, 0.8); }
@@ -57,45 +57,68 @@ body.js-enabled .hide-when-js-enabled {
 
 /* @group responsive */
 
-@media only screen and (min-width: 950px) {
-  #page-header {
-    text-align: left;
-    text-align: left;
-  }
+#package-header .caption {
+  margin: 0px 1em 0 2em;
+}
 
+@media only screen and (min-width: 1280px) {
   #content {
     width: 60vw;
+    max-width: 1450px;
+    min-width: 830px;
   }
+}
 
-  #package-header .caption {
-    margin: 0 0 0 20vw;
+@media only screen and (max-width: 1280px) {
+  #content {
+    width: 75vw;
   }
-
-  ul.links {
-    margin: 0px 20vw 0 0;
-  }
-
 }
 
 @media only screen and (max-width: 950px) {
-  #page-header {
-    text-align: center;
-  }
-
   #content {
-    width: 80vw;
-  }
-
-  #package-header .caption {
-    margin: 0 0 0 10vw;
-  }
-
-  ul.links {
-    margin: 0px 10vw 0 0;
+    width: 88vw;
   }
 }
 
-@media only screen and (max-width: 500px) {
+
+/* menu for wider screens
+
+  Display the package name at the left and the menu links at the right,
+  inline with each other:
+  The package name                                   Source . Contents . Index
+*/
+@media only screen and (min-width: 1000px) {
+  #package-header .caption {
+    display: inline-block;
+    margin: 3px 1em 2px 2em;
+  }
+
+  #package-header ul.links {
+    float: right;
+    margin: 3px 2em 2px 1em;
+  }
+}
+
+/* menu for smaller screens
+
+Display the package name on top of the menu links and center both elements:
+                  The package name
+              Source . Contents . Index
+*/
+@media only screen and (max-width: 1000px) {
+  #package-header .caption {
+    display: block;
+    margin: 4px 0;
+    text-align: center;
+  }
+
+  #package-header ul.links {
+    float: none;
+    text-align: center;
+    margin: 0.6em 0 0 0;
+  }
+
   #module-header table.info {
     float: none;
     top: 0;
@@ -107,6 +130,7 @@ body.js-enabled .hide-when-js-enabled {
 
 /* @end */
 
+
 /* @group Fonts & Sizes */
 
 /* Basic technique & IE workarounds from YUI 3
@@ -115,7 +139,7 @@ body.js-enabled .hide-when-js-enabled {
  */
 
 body {
-  font: 300 13px/1.85 "Merriweather Sans", sans-serif;
+  font: 400 16px/1.6 'Open Sans', sans-serif;
   *font-size:small; /* for IE */
   *font:x-small; /* for IE in quirks mode */
 }
@@ -150,16 +174,15 @@ pre, code, kbd, samp, tt, .src {
 }
 
 #module-header .caption sup {
-  font-size: 70%;
+  font-size: 80%;
   font-weight: normal;
 }
 
+#package-header #page-menu a:link, #package-header #page-menu a:visited { color: white; }
+
+
 .info  {
   font-size: 85%; /* 11pt */
-}
-
-#table-of-contents, #synopsis  {
-  /* font-size: 85%; /* 11pt */
 }
 
 
@@ -169,10 +192,10 @@ pre, code, kbd, samp, tt, .src {
 
 .caption, h1, h2, h3, h4, h5, h6, summary {
   font-weight: bold;
-  color: rgb(78,98,114);
-  color: rgb(142, 80, 132);
+  color: #5E5184;
   margin: 2em 0 1em 0;
 }
+
 
 * + h1, * + h2, * + h3, * + h4, * + h5, * + h6 {
   margin-top: 2em;
@@ -190,15 +213,10 @@ ul + p {
   margin-top: 2em;
 }
 
-ul.links, #package-header p.caption {
-  padding-top: 3px;
-}
-
 ul.links {
   list-style: none;
   text-align: left;
-  float: right;
-  font-size: 13px;
+  font-size: 1em;
 }
 
 ul.links li {
@@ -258,7 +276,7 @@ details[open] > summary {
 pre {
   padding: 17px;
   margin: 1em 0 2em 0;
-  background-color: rgba(0, 0, 0, .025);
+  background-color: rgba(0, 0, 0, .033);
   overflow: auto;
   border-bottom: 0.25em solid white;
   /* white border adds some space below the box to compensate
@@ -291,22 +309,21 @@ pre {
   background: rgb(94, 81, 132);
   border-bottom: 5px solid rgba(69, 59, 97, 0.5);
   color: #ddd;
-  padding: 8px 0;
+  padding: 0.6em 0 0.2em 0;
   position: relative;
   text-align: left;
   margin: 0 auto;
+  overflow: hidden;
 }
 
 #package-header .caption {
-  background: url(hslogo-16.png) no-repeat 0em;
   color: white;
-  font-weight: normal;
   font-style: normal;
-  padding-left: 35px;
+  font-size: 1.1rem;
+  font-weight: bold;
 }
 
 #module-header .caption {
-  color: rgb(94, 81, 132);
   font-weight: bold;
   border-bottom: 1px solid #ddd;
 }
@@ -414,11 +431,12 @@ div#style-menu-holder {
 #synopsis {
   display: block;
   position: fixed;
-  right: 0;
   height: 80%;
-  top: 10%;
+  top: 9vh;
+  right: 10px;
   padding: 0;
   max-width: 75%;
+  z-index: 1;
   /* Ensure that synopsis covers everything (including MathJAX markup) */
   z-index: 1;
 }

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -274,14 +274,14 @@ details[open] > summary {
 }
 
 pre {
-  padding: 17px;
-  margin: 1em 0 2em 0;
+  padding: 1rem;
+  margin: 0px;
   background-color: rgba(0, 0, 0, .033);
   overflow: auto;
-  border-bottom: 0.25em solid white;
-  /* white border adds some space below the box to compensate
-     for visual extra space that paragraphs have between baseline
-     and the bounding box */
+}
+
+pre + pre {
+  margin-top: 0.4em;
 }
 
 .src {
@@ -319,7 +319,7 @@ pre {
 #package-header .caption {
   color: white;
   font-style: normal;
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: bold;
 }
 

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -11,10 +11,20 @@ html {
 
 body {
   background: #fefefe;
-  color: rgba(69, 59, 97, 0.95);
+  color: #221D30;
   text-align: left;
   min-height: 100%;
   position: relative;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-feature-settings: "kern" 1;
+  -moz-font-feature-settings: "kern" 1;
+  -o-font-feature-settings: "kern" 1;
+  font-feature-settings: "kern" 1;
+  font-kerning: normal;
+}
+
+#content a {
+  overflow-wrap: break-word;
 }
 
 p {
@@ -63,21 +73,36 @@ body.js-enabled .hide-when-js-enabled {
 
 @media only screen and (min-width: 1280px) {
   #content {
-    width: 60vw;
+    width: 65vw;
     max-width: 1450px;
-    min-width: 830px;
+  }
+
+  #table-of-contents {
+    position: fixed;
+    left: 10px;
+    max-width: 10vw;
+    top: 10.2em;
   }
 }
 
 @media only screen and (max-width: 1280px) {
   #content {
-    width: 75vw;
+    width: 80vw;
   }
 }
 
-@media only screen and (max-width: 950px) {
+@media only screen and (max-width: 1000px) {
   #content {
-    width: 88vw;
+    width: 93vw;
+  }
+
+  #synopsis {
+    display: block;
+    padding: 0;
+    position: relative;
+    margin: 4em 0;
+    border-bottom: 1px dashed #5E5184;
+    width: 100%;
   }
 }
 
@@ -97,6 +122,22 @@ body.js-enabled .hide-when-js-enabled {
   #package-header ul.links {
     float: right;
     margin: 3px 2em 2px 1em;
+  }
+
+  #synopsis {
+    display: block;
+    position: fixed;
+    top: 5em;
+    left: 10px;
+    padding: 0.25em;
+    max-width: 65vw;
+    /* Ensure that synopsis covers everything (including MathJAX markup) */
+    z-index: 1;
+  }
+
+  #synopsis .show {
+    border: 1px solid #5E5184;
+    padding: 0.7em;
   }
 }
 
@@ -149,10 +190,6 @@ h2 { font-size: 131%;   /* 17pt */ }
 h3 { font-size: 116%;   /* 15pt */ }
 h4 { font-size: 100%;   /* 13pt */ }
 h5 { font-size: 100%;   /* 13pt */ }
-
-select, input, button, textarea {
-	font:99% sans-serif;
-}
 
 table {
 	font-size:inherit;
@@ -238,17 +275,17 @@ ul.links li a {
 .clear { clear: both; }
 
 .collapser:before, .expander:before {
-  font-size: 0.9em;
+  font-size: 1.2em;
   color: #5E5184;
   display: inline-block;
   padding-right: 7px;
 }
 
 .collapser:before {
-  content: '-'
+  content: '⊗';
 }
 .expander:before {
-  content: "+";
+  content: "⊕";
 }
 
 .collapser, .expander {
@@ -276,7 +313,7 @@ details[open] > summary {
 pre {
   padding: 1rem;
   margin: 0px;
-  background-color: rgba(0, 0, 0, .033);
+  background-color: #f7f7f7;
   overflow: auto;
 }
 
@@ -342,7 +379,8 @@ table.info {
 }
 
 .info th {
-	padding: 0 1em 0 0;
+  padding: 0 1em 0 0;
+  text-align: right;
 }
 
 div#style-menu-holder {
@@ -398,14 +436,15 @@ div#style-menu-holder {
 
 /* @group Front Matter */
 
+#synopsis .caption,
+#table-of-contents .caption {
+  font-size: 1rem;
+}
+
 #table-of-contents {
-  float: right;
-  clear: right;
-  background: #faf9dc;
-  border: 1px solid #d8d7ad;
-  padding: 0.5em 1em;
-  max-width: 20em;
-  margin: 0.5em 0 1em 1em;
+  background:  #f7f7f7;
+  padding: 1em;
+  margin: 1em 0 2em 0;
 }
 
 #table-of-contents .caption {
@@ -426,19 +465,6 @@ div#style-menu-holder {
 
 #description .caption {
   display: none;
-}
-
-#synopsis {
-  display: block;
-  position: fixed;
-  height: 80%;
-  top: 9vh;
-  right: 10px;
-  padding: 0;
-  max-width: 75%;
-  z-index: 1;
-  /* Ensure that synopsis covers everything (including MathJAX markup) */
-  z-index: 1;
 }
 
 #synopsis summary {
@@ -470,7 +496,7 @@ div#style-menu-holder {
 
 #synopsis ul,
 #synopsis ul li.src {
-  background-color: #faf9dc;
+  background-color: #f7f7f7;
   white-space: nowrap;
   list-style: none;
   margin-left: 0;
@@ -480,7 +506,9 @@ div#style-menu-holder {
 
 /* @group Main Content */
 
-#interface div.top { margin: 2em 0; }
+#interface div.top + div.top { margin-top: 0.6em; }
+
+#interface p + div.top,
 #interface h1 + div.top,
 #interface h2 + div.top,
 #interface h3 + div.top,
@@ -598,11 +626,6 @@ div#style-menu-holder {
 
 .top p.src {
   border-top: 1px solid #ccc;
-}
-
-.subs, .doc {
-  /* use this selector for one level of indent */
-  padding-left: 2em;
 }
 
 .warning {
@@ -726,7 +749,19 @@ div#style-menu-holder {
 }
 
 :target {
-  background-color: #ffff00;
+  background: -webkit-linear-gradient(top, transparent 0%, transparent 65%, #fbf36d 60%, #fbf36d 100%);
+  background: -moz-linear-gradient(top, transparent 0%, transparent 65%, #fbf36d 60%, #fbf36d 100%);
+  background: -o-linear-gradient(top, transparent 0%, transparent 65%, #fbf36d 60%, #fbf36d 100%);
+  background: -ms-linear-gradient(top, transparent 0%, transparent 65%, #fbf36d 60%, #fbf36d 100%);
+  background: linear-gradient(to bottom, transparent 0%, transparent 65%, #fbf36d 60%, #fbf36d 100%);
+}
+
+:target:hover {
+  background: -webkit-linear-gradient(top, transparent 0%, transparent 0%, #fbf36d 0%, #fbf36d 100%);
+  background: -moz-linear-gradient(top, transparent 0%, transparent 0%, #fbf36d 0%, #fbf36d 100%);
+  background: -o-linear-gradient(top, transparent 0%, transparent 0%, #fbf36d 0%, #fbf36d 100%);
+  background: -ms-linear-gradient(top, transparent 0%, transparent 0%, #fbf36d 0%, #fbf36d 100%);
+  background: linear-gradient(to bottom, transparent 0%, transparent 0%, #fbf36d 0%, #fbf36d 100%);
 }
 
 /* @end */

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -142,8 +142,7 @@ ul.links {
   text-align: left;
   float: right;
   display: inline-table;
-  margin: 0 0 0 1em;
-  margin-right: 22vw;
+  margin: 0 22vw 0 1em;
 }
 
 ul.links li {

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -73,7 +73,7 @@ body.js-enabled .hide-when-js-enabled {
 
 @media only screen and (min-width: 1280px) {
   #content {
-    width: 70vw;
+    width: 63vw;
     max-width: 1450px;
   }
 
@@ -104,7 +104,7 @@ body.js-enabled .hide-when-js-enabled {
 
 }
 
-@media only screen and (max-width: 1280px) {
+@media only screen and (max-width: 1279px) {
   #content {
     width: 80vw;
   }
@@ -119,7 +119,7 @@ body.js-enabled .hide-when-js-enabled {
   }
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 999px) {
   #content {
     width: 93vw;
   }
@@ -158,7 +158,7 @@ Display the package name on top of the menu links and center both elements:
                   The package name
               Source . Contents . Index
 */
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 999px) {
   #package-header .caption {
     display: block;
     margin: 4px 0;

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -138,6 +138,7 @@ body.js-enabled .hide-when-js-enabled {
   #synopsis .show {
     border: 1px solid #5E5184;
     padding: 0.7em;
+    max-height: 65vh;
   }
 }
 

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -54,6 +54,59 @@ body.js-enabled .hide-when-js-enabled {
 
 /* @end */
 
+
+/* @group responsive */
+
+@media only screen and (min-width: 950px) {
+  #page-header {
+    text-align: left;
+    text-align: left;
+  }
+
+  #content {
+    width: 60vw;
+  }
+
+  #package-header .caption {
+    margin: 0 0 0 20vw;
+  }
+
+  ul.links {
+    margin: 0px 20vw 0 0;
+  }
+
+}
+
+@media only screen and (max-width: 950px) {
+  #page-header {
+    text-align: center;
+  }
+
+  #content {
+    width: 80vw;
+  }
+
+  #package-header .caption {
+    margin: 0 0 0 10vw;
+  }
+
+  ul.links {
+    margin: 0px 10vw 0 0;
+  }
+}
+
+@media only screen and (max-width: 500px) {
+  #module-header table.info {
+    float: none;
+    top: 0;
+    margin: 0 auto;
+    overflow: hidden;
+    max-width: 80vw;
+  }
+}
+
+/* @end */
+
 /* @group Fonts & Sizes */
 
 /* Basic technique & IE workarounds from YUI 3
@@ -137,12 +190,15 @@ ul + p {
   margin-top: 2em;
 }
 
+ul.links, #package-header p.caption {
+  padding-top: 3px;
+}
+
 ul.links {
   list-style: none;
   text-align: left;
   float: right;
-  display: inline-table;
-  margin: 0 22vw 0 1em;
+  font-size: 13px;
 }
 
 ul.links li {
@@ -227,16 +283,15 @@ pre {
 /* @group Page Structure */
 
 #content {
-  margin: 0 auto;
+  margin: 3em auto 0 auto;
   padding: 0;
-  width: 55vw;
 }
 
 #package-header {
   background: rgb(94, 81, 132);
   border-bottom: 5px solid rgba(69, 59, 97, 0.5);
   color: #ddd;
-  padding: 0.6em 0 0.2em 0;
+  padding: 8px 0;
   position: relative;
   text-align: left;
   margin: 0 auto;
@@ -245,14 +300,10 @@ pre {
 #package-header .caption {
   background: url(hslogo-16.png) no-repeat 0em;
   color: white;
-  margin: 0;
-  margin-left: 22.5vw;
   font-weight: normal;
   font-style: normal;
-  padding-left: 2em;
+  padding-left: 35px;
 }
-
-#package-header a:link, #package-header a:visited { color: white; }
 
 #module-header .caption {
   color: rgb(94, 81, 132);

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -10,8 +10,8 @@ html {
 }
 
 body {
-  background: white;
-  color: black;
+  background: #fefefe;
+  color: rgba(69, 59, 97, 0.95);
   text-align: left;
   min-height: 100%;
   position: relative;
@@ -41,7 +41,7 @@ a[href]:link { color: rgb(196,69,29); }
 a[href]:visited { color: rgb(171,105,84); }
 a[href]:hover { text-decoration:underline; }
 
-a[href].def:link, a[href].def:visited { color: black; }
+a[href].def:link, a[href].def:visited { color: rgba(69, 59, 97, 0.8); }
 a[href].def:hover { color: rgb(78, 98, 114); }
 
 /* @end */
@@ -62,9 +62,9 @@ body.js-enabled .hide-when-js-enabled {
  */
 
 body {
-	font:13px/1.4 sans-serif;
-	*font-size:small; /* for IE */
-	*font:x-small; /* for IE in quirks mode */
+  font: 300 13px/1.85 "Merriweather Sans", sans-serif;
+  *font-size:small; /* for IE */
+  *font:x-small; /* for IE in quirks mode */
 }
 
 h1 { font-size: 146.5%; /* 19pt */ }
@@ -85,7 +85,7 @@ table {
 pre, code, kbd, samp, tt, .src {
 	font-family:monospace;
 	*font-size:108%;
-	line-height: 124%;
+	line-height: 1.54em;
 }
 
 .links, .link {
@@ -117,7 +117,8 @@ pre, code, kbd, samp, tt, .src {
 .caption, h1, h2, h3, h4, h5, h6, summary {
   font-weight: bold;
   color: rgb(78,98,114);
-  margin: 0.8em 0 0.4em;
+  color: rgb(142, 80, 132);
+  margin: 2em 0 1em 0;
 }
 
 * + h1, * + h2, * + h3, * + h4, * + h5, * + h6 {
@@ -128,19 +129,31 @@ h1 + h2, h2 + h3, h3 + h4, h4 + h5, h5 + h6 {
   margin-top: inherit;
 }
 
+p + ul {
+  margin-top: 1em;
+}
+
+ul + p {
+  margin-top: 2em;
+}
+
 ul.links {
   list-style: none;
   text-align: left;
   float: right;
   display: inline-table;
   margin: 0 0 0 1em;
+  margin-right: 22vw;
 }
 
 ul.links li {
   display: inline;
-  border-left: 1px solid #d5d5d5;
   white-space: nowrap;
   padding: 0;
+}
+
+ul.links li + li:before {
+  content: '\00B7';
 }
 
 ul.links li a {
@@ -188,9 +201,9 @@ details[open] > summary {
 }
 
 pre {
-  padding: 0.25em;
-  margin: 0.8em 0;
-  background: rgb(229,237,244);
+  padding: 17px;
+  margin: 1em 0 2em 0;
+  background-color: rgba(0, 0, 0, .025);
   overflow: auto;
   border-bottom: 0.25em solid white;
   /* white border adds some space below the box to compensate
@@ -216,32 +229,34 @@ pre {
 
 #content {
   margin: 0 auto;
-  padding: 0 2em 6em;
+  padding: 0;
+  width: 55vw;
 }
 
 #package-header {
-  background: rgb(41,56,69);
-  border-top: 5px solid rgb(78,98,114);
+  background: rgb(94, 81, 132);
+  border-bottom: 5px solid rgba(69, 59, 97, 0.5);
   color: #ddd;
-  padding: 0.2em;
+  padding: 0.6em 0 0.2em 0;
   position: relative;
   text-align: left;
+  margin: 0 auto;
 }
 
 #package-header .caption {
   background: url(hslogo-16.png) no-repeat 0em;
   color: white;
-  margin: 0 2em;
+  margin: 0;
+  margin-left: 22.5vw;
   font-weight: normal;
   font-style: normal;
   padding-left: 2em;
 }
 
 #package-header a:link, #package-header a:visited { color: white; }
-#package-header a:hover { background: rgb(78,98,114); }
 
 #module-header .caption {
-  color: rgb(78,98,114);
+  color: rgb(94, 81, 132);
   font-weight: bold;
   border-bottom: 1px solid #ddd;
 }
@@ -255,7 +270,7 @@ table.info {
   max-width: 40%;
   border-spacing: 0;
   position: relative;
-  top: -0.5em;
+  top: -0.78em;
   margin: 0 0 0 2em;
 }
 
@@ -307,9 +322,9 @@ div#style-menu-holder {
   color: #666;
   text-align: center;
   position: absolute;
-  bottom: 0;
   width: 100%;
   height: 3em;
+  margin-top: 3em;
 }
 
 /* @end */
@@ -327,13 +342,15 @@ div#style-menu-holder {
 }
 
 #table-of-contents .caption {
-  text-align: center;
+  text-align: left;
   margin: 0;
 }
 
 #table-of-contents ul {
   list-style: none;
   margin: 0;
+  margin-top: 10px;
+  font-size: 95%;
 }
 
 #table-of-contents ul ul {

--- a/haddock-api/resources/html/Ocean.std-theme/ocean.css
+++ b/haddock-api/resources/html/Ocean.std-theme/ocean.css
@@ -237,22 +237,22 @@ ul.links li a {
 .show { display: inherit; }
 .clear { clear: both; }
 
-.collapser {
-  background-image: url(minus.gif);
-  background-repeat: no-repeat;
+.collapser:before, .expander:before {
+  font-size: 0.9em;
+  color: #5E5184;
+  display: inline-block;
+  padding-right: 7px;
 }
-.expander {
-  background-image: url(plus.gif);
-  background-repeat: no-repeat;
+
+.collapser:before {
+  content: '-'
 }
+.expander:before {
+  content: "+";
+}
+
 .collapser, .expander {
-  padding-left: 14px;
-  margin-left: -14px;
   cursor: pointer;
-}
-p.caption.collapser,
-p.caption.expander {
-  background-position: 0 0.4em;
 }
 
 .instance.collapser, .instance.expander {
@@ -306,7 +306,7 @@ pre {
 }
 
 #package-header {
-  background: rgb(94, 81, 132);
+  background: #5E5184;
   border-bottom: 5px solid rgba(69, 59, 97, 0.5);
   color: #ddd;
   padding: 0.6em 0 0.2em 0;

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -123,13 +123,14 @@ headHtml docTitle themes mathjax_url =
     meta ! [httpequiv "Content-Type", content "text/html; charset=UTF-8"],
     thetitle << docTitle,
     styleSheet themes,
+    thelink ! [ rel "stylesheet", thetype "text/css", href fontUrl] << noHtml,
     thelink ! [ rel "stylesheet", thetype "text/css", href quickJumpCssFile] << noHtml,
     script ! [src haddockJsFile, emptyAttr "async", thetype "text/javascript"] << noHtml,
     script ! [src mjUrl, thetype "text/javascript"] << noHtml
     ]
   where
+    fontUrl = "https://fonts.googleapis.com/css?family=Merriweather+Sans:300,300i,400,700"
     mjUrl = maybe "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" id mathjax_url
-
 
 srcButton :: SourceURLs -> Maybe Interface -> Maybe Html
 srcButton (Just src_base_url, _, _, _) Nothing =

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -32,7 +32,7 @@ import Haddock.Types
 import Haddock.Version
 import Haddock.Utils
 import Haddock.Utils.Json
-import Text.XHtml hiding ( name, title, p, quote )
+import Text.XHtml hiding ( title, p, quote )
 import Haddock.GhcUtils
 
 import Control.Monad         ( when, unless )
@@ -120,7 +120,8 @@ copyHtmlBits odir libdir themes withQuickjump = do
 headHtml :: String -> Themes -> Maybe String -> Html
 headHtml docTitle themes mathjax_url =
   header << [
-    meta ! [httpequiv "Content-Type", content "text/html; charset=UTF-8"],
+    meta ! [ httpequiv "Content-Type", content "text/html; charset=UTF-8"],
+    meta ! [ name "viewport", content "width=device-width, initial-scale=1"],
     thetitle << docTitle,
     styleSheet themes,
     thelink ! [ rel "stylesheet", thetype "text/css", href quickJumpCssFile] << noHtml,

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -177,13 +177,13 @@ bodyHtml doctitle iface
            pageContent =
   body << [
     divPackageHeader << [
+      nonEmptySectionName << doctitle,
       unordList (catMaybes [
         srcButton maybe_source_url iface,
         wikiButton maybe_wiki_url (ifaceMod <$> iface),
         contentsButton maybe_contents_url,
         indexButton maybe_index_url])
-            ! [theclass "links", identifier "page-menu"],
-      nonEmptySectionName << doctitle
+            ! [theclass "links", identifier "page-menu"]
       ],
     divContent << pageContent,
     divFooter << paragraph << (

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -123,8 +123,8 @@ headHtml docTitle themes mathjax_url =
     meta ! [httpequiv "Content-Type", content "text/html; charset=UTF-8"],
     thetitle << docTitle,
     styleSheet themes,
-    thelink ! [ rel "stylesheet", thetype "text/css", href fontUrl] << noHtml,
     thelink ! [ rel "stylesheet", thetype "text/css", href quickJumpCssFile] << noHtml,
+    thelink ! [ rel "stylesheet", thetype "text/css", href fontUrl] << noHtml,
     script ! [src haddockJsFile, emptyAttr "async", thetype "text/javascript"] << noHtml,
     script ! [src mjUrl, thetype "text/javascript"] << noHtml
     ]

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -129,8 +129,8 @@ headHtml docTitle themes mathjax_url =
     script ! [src mjUrl, thetype "text/javascript"] << noHtml
     ]
   where
-    fontUrl = "https://fonts.googleapis.com/css?family=Merriweather+Sans:300,300i,400,700"
-    mjUrl = maybe "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" id mathjax_url
+    fontUrl = "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700"
+    mjUrl = fromMaybe "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" mathjax_url
 
 srcButton :: SourceURLs -> Maybe Interface -> Maybe Html
 srcButton (Just src_base_url, _, _, _) Nothing =

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -74,8 +74,8 @@ sectionName = paragraph ! [theclass "caption"]
 -- If it would have otherwise been empty, then give it the class ".empty".
 nonEmptySectionName :: Html -> Html
 nonEmptySectionName c
-  | isNoHtml c = paragraph ! [theclass "caption empty"] $ spaceHtml
-  | otherwise  = paragraph ! [theclass "caption"]       $ c
+  | isNoHtml c = thediv ! [theclass "caption empty"] $ spaceHtml
+  | otherwise  = thediv ! [theclass "caption"]       $ c
 
 
 divPackageHeader, divContent, divModuleHeader, divFooter,

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >A</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -5,6 +5,7 @@
     >A</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/B.html
+++ b/html-test/ref/B.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/B.html
+++ b/html-test/ref/B.html
@@ -5,6 +5,7 @@
     >B</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/B.html
+++ b/html-test/ref/B.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >B</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bold.html
+++ b/html-test/ref/Bold.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bold.html
+++ b/html-test/ref/Bold.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bold</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bold.html
+++ b/html-test/ref/Bold.html
@@ -5,6 +5,7 @@
     >Bold</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -5,6 +5,7 @@
     >Bug1</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug1</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug195.html
+++ b/html-test/ref/Bug195.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug195.html
+++ b/html-test/ref/Bug195.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug195</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug195.html
+++ b/html-test/ref/Bug195.html
@@ -5,6 +5,7 @@
     >Bug195</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -5,6 +5,7 @@
     >Bug2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug201.html
+++ b/html-test/ref/Bug201.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug201</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug201.html
+++ b/html-test/ref/Bug201.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug201.html
+++ b/html-test/ref/Bug201.html
@@ -5,6 +5,7 @@
     >Bug201</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug253</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -5,6 +5,7 @@
     >Bug253</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -5,6 +5,7 @@
     >Bug26</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug26</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug280</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -5,6 +5,7 @@
     >Bug280</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug294</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -5,6 +5,7 @@
     >Bug294</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug298</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -5,6 +5,7 @@
     >Bug298</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug3</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -5,6 +5,7 @@
     >Bug3</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug308.html
+++ b/html-test/ref/Bug308.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug308.html
+++ b/html-test/ref/Bug308.html
@@ -5,6 +5,7 @@
     >Bug308</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug308.html
+++ b/html-test/ref/Bug308.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug308</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug308CrossModule.html
+++ b/html-test/ref/Bug308CrossModule.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug308CrossModule.html
+++ b/html-test/ref/Bug308CrossModule.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug308CrossModule</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug308CrossModule.html
+++ b/html-test/ref/Bug308CrossModule.html
@@ -5,6 +5,7 @@
     >Bug308CrossModule</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug310.html
+++ b/html-test/ref/Bug310.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug310.html
+++ b/html-test/ref/Bug310.html
@@ -5,6 +5,7 @@
     >Bug310</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug310.html
+++ b/html-test/ref/Bug310.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug310</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug313.html
+++ b/html-test/ref/Bug313.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug313.html
+++ b/html-test/ref/Bug313.html
@@ -5,6 +5,7 @@
     >Bug313</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug313.html
+++ b/html-test/ref/Bug313.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug313</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug335</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -5,6 +5,7 @@
     >Bug335</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -5,6 +5,7 @@
     >Bug387</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug387</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug4</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -5,6 +5,7 @@
     >Bug4</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug546.html
+++ b/html-test/ref/Bug546.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug546.html
+++ b/html-test/ref/Bug546.html
@@ -5,6 +5,7 @@
     >Bug546</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug546.html
+++ b/html-test/ref/Bug546.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug546</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug548.html
+++ b/html-test/ref/Bug548.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug548.html
+++ b/html-test/ref/Bug548.html
@@ -5,6 +5,7 @@
     >Bug548</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug548.html
+++ b/html-test/ref/Bug548.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug548</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug6</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -5,6 +5,7 @@
     >Bug6</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug613.html
+++ b/html-test/ref/Bug613.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug613.html
+++ b/html-test/ref/Bug613.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug613</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug613.html
+++ b/html-test/ref/Bug613.html
@@ -5,6 +5,7 @@
     >Bug613</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug647.html
+++ b/html-test/ref/Bug647.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug647.html
+++ b/html-test/ref/Bug647.html
@@ -5,6 +5,7 @@
     >Bug647</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug647.html
+++ b/html-test/ref/Bug647.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug647</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug679</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -5,6 +5,7 @@
     >Bug679</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
@@ -12,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -22,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug7</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -5,6 +5,7 @@
     >Bug7</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug8</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -5,6 +5,7 @@
     >Bug8</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bug85</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -5,6 +5,7 @@
     >Bug85</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >BugDeprecated</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -5,6 +5,7 @@
     >BugDeprecated</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >BugExportHeadings</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -5,6 +5,7 @@
     >BugExportHeadings</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Bugs</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -5,6 +5,7 @@
     >Bugs</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/BundledPatterns.html
+++ b/html-test/ref/BundledPatterns.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/BundledPatterns.html
+++ b/html-test/ref/BundledPatterns.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >BundledPatterns</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/BundledPatterns.html
+++ b/html-test/ref/BundledPatterns.html
@@ -5,6 +5,7 @@
     >BundledPatterns</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/BundledPatterns2.html
+++ b/html-test/ref/BundledPatterns2.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/BundledPatterns2.html
+++ b/html-test/ref/BundledPatterns2.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >BundledPatterns2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/BundledPatterns2.html
+++ b/html-test/ref/BundledPatterns2.html
@@ -5,6 +5,7 @@
     >BundledPatterns2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/ConstructorPatternExport.html
+++ b/html-test/ref/ConstructorPatternExport.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >ConstructorPatternExport</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/ConstructorPatternExport.html
+++ b/html-test/ref/ConstructorPatternExport.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/ConstructorPatternExport.html
+++ b/html-test/ref/ConstructorPatternExport.html
@@ -5,6 +5,7 @@
     >ConstructorPatternExport</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/CrossPackageDocs.html
+++ b/html-test/ref/CrossPackageDocs.html
@@ -15,6 +15,8 @@ window.onload = function () {pageLoad();setSynopsis("mini_CrossPackageDocs.html"
     ></head
   ><body
   ><div id="package-header"
+    ><div class="caption empty"
+    >&nbsp;</div
     ><ul class="links" id="page-menu"
       ><li
 	><a href=""
@@ -25,8 +27,6 @@ window.onload = function () {pageLoad();setSynopsis("mini_CrossPackageDocs.html"
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      >&nbsp;</p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -5,6 +5,7 @@
     >DeprecatedClass</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedClass</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedData.html
+++ b/html-test/ref/DeprecatedData.html
@@ -5,6 +5,7 @@
     >DeprecatedData</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedData.html
+++ b/html-test/ref/DeprecatedData.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedData.html
+++ b/html-test/ref/DeprecatedData.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedData</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -5,6 +5,7 @@
     >DeprecatedFunction</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedFunction</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -5,6 +5,7 @@
     >DeprecatedFunction2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedFunction2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedFunction3</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -5,6 +5,7 @@
     >DeprecatedFunction3</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedModule</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -5,6 +5,7 @@
     >DeprecatedModule</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -5,6 +5,7 @@
     >DeprecatedModule2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedModule2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -5,6 +5,7 @@
     >DeprecatedNewtype</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedNewtype</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -5,6 +5,7 @@
     >DeprecatedReExport</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedReExport</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -5,6 +5,7 @@
     >DeprecatedRecord</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedRecord</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedTypeFamily</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -5,6 +5,7 @@
     >DeprecatedTypeFamily</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -5,6 +5,7 @@
     >DeprecatedTypeSynonym</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DeprecatedTypeSynonym</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/DuplicateRecordFields.html
+++ b/html-test/ref/DuplicateRecordFields.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/DuplicateRecordFields.html
+++ b/html-test/ref/DuplicateRecordFields.html
@@ -5,6 +5,7 @@
     >DuplicateRecordFields</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/DuplicateRecordFields.html
+++ b/html-test/ref/DuplicateRecordFields.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >DuplicateRecordFields</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -5,6 +5,7 @@
     >Examples</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Examples</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Extensions.html
+++ b/html-test/ref/Extensions.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Extensions.html
+++ b/html-test/ref/Extensions.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Extensions</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Extensions.html
+++ b/html-test/ref/Extensions.html
@@ -5,6 +5,7 @@
     >Extensions</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -5,6 +5,7 @@
     >FunArgs</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >FunArgs</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -5,6 +5,7 @@
     >GADTRecords</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >GADTRecords</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Hash</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -5,6 +5,7 @@
     >Hash</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -5,6 +5,7 @@
     >HiddenInstances</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >HiddenInstances</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >HiddenInstancesB</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -5,6 +5,7 @@
     >HiddenInstancesB</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -5,6 +5,7 @@
     >Hyperlinks</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Hyperlinks</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/IgnoreExports.html
+++ b/html-test/ref/IgnoreExports.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/IgnoreExports.html
+++ b/html-test/ref/IgnoreExports.html
@@ -5,6 +5,7 @@
     >IgnoreExports</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/IgnoreExports.html
+++ b/html-test/ref/IgnoreExports.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >IgnoreExports</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >ImplicitParams</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -5,6 +5,7 @@
     >ImplicitParams</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Instances</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -5,6 +5,7 @@
     >Instances</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Math.html
+++ b/html-test/ref/Math.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Math.html
+++ b/html-test/ref/Math.html
@@ -5,6 +5,7 @@
     >Math</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Math.html
+++ b/html-test/ref/Math.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Math</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -5,6 +5,7 @@
     >Minimal</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Minimal</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >ModuleWithWarning</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -5,6 +5,7 @@
     >ModuleWithWarning</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/NamedDoc.html
+++ b/html-test/ref/NamedDoc.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/NamedDoc.html
+++ b/html-test/ref/NamedDoc.html
@@ -5,6 +5,7 @@
     >NamedDoc</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/NamedDoc.html
+++ b/html-test/ref/NamedDoc.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >NamedDoc</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -5,6 +5,7 @@
     >Nesting</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Nesting.html
+++ b/html-test/ref/Nesting.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Nesting</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >NoLayout</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -5,6 +5,7 @@
     >NoLayout</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/NonGreedy.html
+++ b/html-test/ref/NonGreedy.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/NonGreedy.html
+++ b/html-test/ref/NonGreedy.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >NonGreedy</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/NonGreedy.html
+++ b/html-test/ref/NonGreedy.html
@@ -5,6 +5,7 @@
     >NonGreedy</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Operators</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -5,6 +5,7 @@
     >Operators</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/OrphanInstances.html
+++ b/html-test/ref/OrphanInstances.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/OrphanInstances.html
+++ b/html-test/ref/OrphanInstances.html
@@ -5,6 +5,7 @@
     >OrphanInstances</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/OrphanInstances.html
+++ b/html-test/ref/OrphanInstances.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >OrphanInstances</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >OrphanInstancesClass</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -5,6 +5,7 @@
     >OrphanInstancesClass</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/OrphanInstancesType.html
+++ b/html-test/ref/OrphanInstancesType.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/OrphanInstancesType.html
+++ b/html-test/ref/OrphanInstancesType.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >OrphanInstancesType</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/OrphanInstancesType.html
+++ b/html-test/ref/OrphanInstancesType.html
@@ -5,6 +5,7 @@
     >OrphanInstancesType</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/PR643.html
+++ b/html-test/ref/PR643.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/PR643.html
+++ b/html-test/ref/PR643.html
@@ -5,6 +5,7 @@
     >PR643</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/PR643.html
+++ b/html-test/ref/PR643.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >PR643</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/PR643_1.html
+++ b/html-test/ref/PR643_1.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/PR643_1.html
+++ b/html-test/ref/PR643_1.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >PR643_1</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/PR643_1.html
+++ b/html-test/ref/PR643_1.html
@@ -5,6 +5,7 @@
     >PR643_1</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -5,6 +5,7 @@
     >PatternSyns</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >PatternSyns</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/PromotedTypes.html
+++ b/html-test/ref/PromotedTypes.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/PromotedTypes.html
+++ b/html-test/ref/PromotedTypes.html
@@ -5,6 +5,7 @@
     >PromotedTypes</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/PromotedTypes.html
+++ b/html-test/ref/PromotedTypes.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >PromotedTypes</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -5,6 +5,7 @@
     >Properties</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Properties</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/PruneWithWarning.html
+++ b/html-test/ref/PruneWithWarning.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/PruneWithWarning.html
+++ b/html-test/ref/PruneWithWarning.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >PruneWithWarning</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/PruneWithWarning.html
+++ b/html-test/ref/PruneWithWarning.html
@@ -5,6 +5,7 @@
     >PruneWithWarning</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -5,6 +5,7 @@
     >QuasiExpr</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >QuasiExpr</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >QuasiQuote</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -5,6 +5,7 @@
     >QuasiQuote</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >SpuriousSuperclassConstraints</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -5,6 +5,7 @@
     >SpuriousSuperclassConstraints</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TH.html
+++ b/html-test/ref/TH.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >TH</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/TH.html
+++ b/html-test/ref/TH.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/TH.html
+++ b/html-test/ref/TH.html
@@ -5,6 +5,7 @@
     >TH</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TH2.html
+++ b/html-test/ref/TH2.html
@@ -5,6 +5,7 @@
     >TH2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TH2.html
+++ b/html-test/ref/TH2.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/TH2.html
+++ b/html-test/ref/TH2.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >TH2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Table.html
+++ b/html-test/ref/Table.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Table</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Table.html
+++ b/html-test/ref/Table.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Table.html
+++ b/html-test/ref/Table.html
@@ -5,6 +5,7 @@
     >Table</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Test</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -5,6 +5,7 @@
     >Test</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -5,6 +5,7 @@
     >Threaded</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Threaded</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Threaded_TH.html
+++ b/html-test/ref/Threaded_TH.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Threaded_TH.html
+++ b/html-test/ref/Threaded_TH.html
@@ -5,6 +5,7 @@
     >Threaded_TH</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Threaded_TH.html
+++ b/html-test/ref/Threaded_TH.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Threaded_TH</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -5,6 +5,7 @@
     >Ticket112</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Ticket112</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -5,6 +5,7 @@
     >Ticket61</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Ticket61</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Ticket75</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -5,6 +5,7 @@
     >Ticket75</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -5,6 +5,7 @@
     >TitledPicture</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >TitledPicture</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >TypeFamilies</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -5,6 +5,7 @@
     >TypeFamilies</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -5,6 +5,7 @@
     >TypeFamilies2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >TypeFamilies2</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -5,6 +5,7 @@
     >TypeOperators</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >TypeOperators</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -5,6 +5,7 @@
     >Unicode</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Unicode</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -13,7 +13,9 @@
     ></head
   ><body
   ><div id="package-header"
-    ><ul class="links" id="page-menu"
+    ><div class="caption empty"
+      ></div
+      ><ul class="links" id="page-menu"
       ><li
 	><a href="#"
 	  >Contents</a
@@ -23,8 +25,6 @@
 	  >Index</a
 	  ></li
 	></ul
-      ><p class="caption empty"
-      ></p
       ></div
     ><div id="content"
     ><div id="module-header"

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -5,6 +5,7 @@
     >Visible</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
      /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 ><head
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
      /><title
     >Visible</title
     ><link href="#" rel="stylesheet" type="text/css" title="Ocean"


### PR DESCRIPTION
## Motive

I work with haddock and hackage almost daily, both at work and at home, and the current theme is unfriendly. I find it very hard to read content with such a wide `#content`, and spacing is not great either. 

Furthermore, I'd say many Haskell developers would appreciate the presense of the latest Haskell's logo (purple) colors in these docs. 

## Changes

- use latest Haskell's logo colors
- decrease #content width to improve readability
- use, custom nicer font: [Merriweather Sans](https://fonts.google.com/specimen/Merriweather+Sans)
- improve sizes and distances

## Preview

**EDIT 04-02-2018**: See https://github.com/haskell/haddock/pull/721#issuecomment-362934997

<br>
Using: https://hackage.haskell.org/package/lens-tutorial-1.0.3/docs/Control-Lens-Tutorial.html

**Before:**

<img width="1280" alt="before" src="https://user-images.githubusercontent.com/7075260/34361086-6befd534-ea67-11e7-887c-02a8f70272a1.png">


**After:**
<img width="1280" alt="after" src="https://user-images.githubusercontent.com/7075260/34361092-78decd2c-ea67-11e7-93ec-65346b10b792.png">

<img width="337" alt="haddock-after-tablet-standing" src="https://user-images.githubusercontent.com/7075260/34388512-4bf1db88-eb34-11e7-9416-cbd156a0d693.png">

<img width="597" alt="haddock-after-tablet-laying" src="https://user-images.githubusercontent.com/7075260/34388521-52fa1300-eb34-11e7-9dc4-075971ac9ff5.png">

<img width="256" alt="haddock-after-iphone7" src="https://user-images.githubusercontent.com/7075260/34388530-634dcfd0-eb34-11e7-9c3b-e86733df5300.png">
