### PR TITLE
Fix infinite loop when specializing instance heads

### DIFF
--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -1,0 +1,196 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >Bug679</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >None</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug679</p
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Bar" class="def"
+	    >Bar</a
+	    > a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs constructors"
+	  ><p class="caption"
+	    >Constructors</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a id="v:Bar" class="def"
+		  >Bar</a
+		  ></td
+		><td class="doc empty"
+		></td
+		></tr
+	      ></table
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:Bar" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Bar:Foo:1"
+		      ></span
+		      > <a href="#"
+		      >Foo</a
+		      > (<a href="#"
+		      >Bar</a
+		      > a)</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Bar:Foo:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >foo</a
+			  > :: <a href="#"
+			  >Bar</a
+			  > a -&gt; <a href="#"
+			  >Bar</a
+			  > a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >class</span
+	    > <a id="t:Foo" class="def"
+	    >Foo</a
+	    > a <span class="keyword"
+	    >where</span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    ><a href="#"
+	      >foo</a
+	      ></p
+	    ></div
+	  ><div class="subs methods"
+	  ><p class="caption"
+	    >Methods</p
+	    ><p class="src"
+	    ><a id="v:foo" class="def"
+	      >foo</a
+	      > :: a -&gt; a <a href="#" class="selflink"
+	      >#</a
+	      ></p
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:Foo" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:1"
+		      ></span
+		      > <a href="#"
+		      >Foo</a
+		      > (<a href="#"
+		      >Bar</a
+		      > a)</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:ic:Foo:Foo:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >foo</a
+			  > :: <a href="#"
+			  >Bar</a
+			  > a -&gt; <a href="#"
+			  >Bar</a
+			  > a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug679.hs
+++ b/html-test/src/Bug679.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Bug679 where
+
+import Language.Haskell.TH
+
+data Bar a = Bar
+
+$(do
+   a <- newName "a"
+   
+   let classN = mkName "Foo"
+   let methodN = mkName "foo"
+
+   methodTy <- [t| $(varT a) -> $(varT a) |]
+   let cla = ClassD [] classN [PlainTV a] [] [SigD methodN methodTy]
+ 
+   -- Note that we are /reusing/ the same type variable 'a' as in the class
+   instanceHead <- [t| $(conT classN) (Bar $(varT a)) |]
+   idCall <- [e| id |]
+   let ins = InstanceD Nothing [] instanceHead [FunD methodN [Clause [] (NormalB idCall) []]]
+    
+   pure [cla,ins])
+


### PR DESCRIPTION
The bug can only be triggered from TH, hence why it probably went un-noticed for so long. I'd like to include the following test-case in `html-test` but I'm not sure how to generate the reference HTML...

```haskell
{-# LANGUAGE TemplateHaskell #-}
{-# OPTIONS_GHC -ddump-splices #-}

module Foo where

import Language.Haskell.TH

data Bar a = Bar

$(do
   a <- newName "a"
   
   let classN = mkName "Foo"
   let methodN = mkName "foo"

   methodTy <- [t| $(varT a) -> $(varT a) |]
   let cla = ClassD [] classN [PlainTV a] [] [SigD methodN methodTy]

   -- Note we are reusing the 'a' variable from before
   instanceHead <- [t| $(conT classN) (Bar $(varT a)) |]
   idCall <- [e| id |]
   let ins = InstanceD Nothing [] instanceHead [FunD methodN [Clause [] (NormalB idCall) []]]
    
   pure [cla,ins])
```

I think this is causing #710 and #679. It so happens that `makeClassy` reuses type variables from class to instance, which runs specializing those instance heads into an infinite loop.

I'm not sure this is correct, but it seems to make the above _not_ loop, so it should at least be a step in the right direction...