### PR TITLE
Pass to GHC visible modules for instance filtering

### DIFF
--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -54,7 +54,7 @@ type ExportInfo = (ExportedNames, Modules)
 -- Also attaches fixities
 attachInstances :: ExportInfo -> [Interface] -> InstIfaceMap -> Ghc [Interface]
 attachInstances expInfo ifaces instIfaceMap = do
-  (_msgs, mb_index) <- getNameToInstancesIndex
+  (_msgs, mb_index) <- getNameToInstancesIndex (map ifaceMod ifaces)
   mapM (attach $ fromMaybe emptyNameEnv mb_index) ifaces
   where
     -- TODO: take an IfaceMap as input


### PR DESCRIPTION
The GHC-side `getNameToInstancesIndex` filters out incorrectly some
instances because it is not aware of what modules are visible. On the
Haddock side, we need to pass in the modules we are processing.

On the GHC side, we need to check against _those_ modules when checking
if an instance is visible.

Here is the GHC patch: https://phabricator.haskell.org/D4290