### PR TITLE
addresses #727. ppTyFam and declNames are now safe.

### DIFF
--- a/latex-test/ref/Simple/main.tex
+++ b/latex-test/ref/Simple/main.tex
@@ -1,5 +1,6 @@
 \documentclass{book}
 \usepackage{haddock}
+
 \begin{document}
 \begin{titlepage}
 \begin{haddocktitle}


### PR DESCRIPTION
While not *the* ideal solution and rather a quick patch, at least it dumps LaTeX files without errors. These files can further be fed to a stream editor for further fixes and tweaks. 

N.B.: I have successfully used this build (+sed/perl scripts) to generate one chapter of a user manual. PM if interested in the result. I am willing to look further into the matter and contribute in order to get rid of the scripts. 