### PR TITLE
Latex type families

### DIFF
--- a/html-test/ref/TypeFamilies3.html
+++ b/html-test/ref/TypeFamilies3.html
@@ -1,0 +1,356 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >TypeFamilies3</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>TypeFamilies3</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><span class="keyword"
+	      >type family</span
+	      > <a href="#"
+	      >Foo</a
+	      > a <span class="keyword"
+	      >where ...</span
+	      ></li
+	    ><li class="src short"
+	    ><span class="keyword"
+	      >type family</span
+	      > <a href="#"
+	      >Bar</a
+	      > a</li
+	    ><li class="src short"
+	    ><span class="keyword"
+	      >data family</span
+	      > <a href="#"
+	      >Baz</a
+	      > a</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >type family</span
+	    > <a id="t:Foo" class="def"
+	    >Foo</a
+	    > a <span class="keyword"
+	    >where ...</span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >A closed type family</p
+	    ></div
+	  ><div class="subs equations"
+	  ><p class="caption"
+	    >Equations</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a href="#" title="TypeFamilies3"
+		  >Foo</a
+		  > () = <a href="#" title="Data.Int"
+		  >Int</a
+		  ></td
+		><td class="doc empty"
+		></td
+		></tr
+	      ><tr
+	      ><td class="src"
+		><a href="#" title="TypeFamilies3"
+		  >Foo</a
+		  > _ = ()</td
+		><td class="doc empty"
+		></td
+		></tr
+	      ></table
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >type family</span
+	    > <a id="t:Bar" class="def"
+	    >Bar</a
+	    > a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >An open family</p
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:Bar" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Bar:Bar:1"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="TypeFamilies3"
+		      >Bar</a
+		      > <a href="#" title="Data.Int"
+		      >Int</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Bar:Bar:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies3</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="TypeFamilies3"
+			>Bar</a
+			> <a href="#" title="Data.Int"
+			>Int</a
+			> = ()</div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Bar:Bar:2"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="TypeFamilies3"
+		      >Bar</a
+		      > ()</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Bar:Bar:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies3</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="TypeFamilies3"
+			>Bar</a
+			> () = <a href="#" title="Data.Int"
+			>Int</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data family</span
+	    > <a id="t:Baz" class="def"
+	    >Baz</a
+	    > a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >A data family</p
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:Baz" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Baz:Baz:1"
+		      ></span
+		      > <span class="keyword"
+		      >newtype</span
+		      > <a href="#" title="TypeFamilies3"
+		      >Baz</a
+		      > <a href="#" title="Prelude"
+		      >Double</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Baz:Baz:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies3</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>newtype</span
+			> <a href="#" title="TypeFamilies3"
+			>Baz</a
+			> <a href="#" title="Prelude"
+			>Double</a
+			> = <a id="v:Baz3" class="def"
+			>Baz3</a
+			> <a href="#" title="Prelude"
+			>Float</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Baz:Baz:2"
+		      ></span
+		      > <span class="keyword"
+		      >data</span
+		      > <a href="#" title="TypeFamilies3"
+		      >Baz</a
+		      > <a href="#" title="Data.Int"
+		      >Int</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Baz:Baz:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies3</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>data</span
+			> <a href="#" title="TypeFamilies3"
+			>Baz</a
+			> <a href="#" title="Data.Int"
+			>Int</a
+			> = <a id="v:Baz2" class="def"
+			>Baz2</a
+			> <a href="#" title="Data.Bool"
+			>Bool</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Baz:Baz:3"
+		      ></span
+		      > <span class="keyword"
+		      >data</span
+		      > <a href="#" title="TypeFamilies3"
+		      >Baz</a
+		      > ()</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Baz:Baz:3"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies3</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>data</span
+			> <a href="#" title="TypeFamilies3"
+			>Baz</a
+			> () = <a id="v:Baz1" class="def"
+			>Baz1</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/TypeFamilies3.hs
+++ b/html-test/src/TypeFamilies3.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module TypeFamilies3 where
+
+-- | A closed type family
+type family Foo a where
+  Foo () = Int
+  Foo _ = ()
+
+-- | An open family
+type family Bar a
+
+type instance Bar Int = ()
+type instance Bar () = Int
+
+-- | A data family
+data family Baz a
+
+data instance Baz () = Baz1
+data instance Baz Int = Baz2 Bool
+newtype instance Baz Double = Baz3 Float

--- a/latex-test/ref/TypeFamilies3/TypeFamilies3.tex
+++ b/latex-test/ref/TypeFamilies3/TypeFamilies3.tex
@@ -1,0 +1,44 @@
+\haddockmoduleheading{TypeFamilies3}
+\label{module:TypeFamilies3}
+\haddockbeginheader
+{\haddockverb\begin{verbatim}
+module TypeFamilies3 (
+    Foo,  Bar,  Baz(Baz3, Baz2, Baz1)
+  ) where\end{verbatim}}
+\haddockendheader
+
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+type\ family\ Foo\ a\ where
+\end{tabular}]\haddockbegindoc
+\haddockbeginargs
+\haddockdecltt{Foo () = Int} \\
+\haddockdecltt{Foo \_ = ()} \\
+\end{tabulary}\par
+A closed type family\par
+
+\end{haddockdesc}
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+type\ family\ Bar\ a
+\end{tabular}]\haddockbegindoc
+An open family\par
+
+\end{haddockdesc}
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+type\ instance\ Bar\ Int\ =\ ()\\type\ instance\ Bar\ ()\ =\ Int
+\end{tabular}]
+\end{haddockdesc}
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+data\ family\ Baz\ a
+\end{tabular}]\haddockbegindoc
+A data family\par
+
+\end{haddockdesc}
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+newtype\ instance\ Baz\ Double\\data\ instance\ Baz\ Int\\data\ instance\ Baz\ ()
+\end{tabular}]
+\end{haddockdesc}

--- a/latex-test/ref/TypeFamilies3/haddock.sty
+++ b/latex-test/ref/TypeFamilies3/haddock.sty
@@ -1,0 +1,57 @@
+% Default Haddock style definitions.  To use your own style, invoke
+% Haddock with the option --latex-style=mystyle.
+
+\usepackage{tabulary} % see below
+
+% make hyperlinks in the PDF, and add an expandabale index
+\usepackage[pdftex,bookmarks=true]{hyperref}
+
+\newenvironment{haddocktitle}
+  {\begin{center}\bgroup\large\bfseries}
+  {\egroup\end{center}}
+\newenvironment{haddockprologue}{\vspace{1in}}{}
+
+\newcommand{\haddockmoduleheading}[1]{\chapter{\texttt{#1}}}
+
+\newcommand{\haddockbeginheader}{\hrulefill}
+\newcommand{\haddockendheader}{\noindent\hrulefill}
+
+% a little gap before the ``Methods'' header
+\newcommand{\haddockpremethods}{\vspace{2ex}}
+
+% inserted before \\begin{verbatim}
+\newcommand{\haddockverb}{\small}
+
+% an identifier: add an index entry
+\newcommand{\haddockid}[1]{\haddocktt{#1}\index{#1@\texttt{#1}}}
+
+% The tabulary environment lets us have a column that takes up ``the
+% rest of the space''.  Unfortunately it doesn't allow
+% the \end{tabulary} to be in the expansion of a macro, it must appear
+% literally in the document text, so Haddock inserts
+% the \end{tabulary} itself.
+\newcommand{\haddockbeginconstrs}{\begin{tabulary}{\linewidth}{@{}llJ@{}}}
+\newcommand{\haddockbeginargs}{\begin{tabulary}{\linewidth}{@{}llJ@{}}}
+
+\newcommand{\haddocktt}[1]{{\small \texttt{#1}}}
+\newcommand{\haddockdecltt}[1]{{\small\bfseries \texttt{#1}}}
+
+\makeatletter
+\newenvironment{haddockdesc}
+               {\list{}{\labelwidth\z@ \itemindent-\leftmargin
+                        \let\makelabel\haddocklabel}}
+               {\endlist}
+\newcommand*\haddocklabel[1]{\hspace\labelsep\haddockdecltt{#1}}
+\makeatother
+
+% after a declaration, start a new line for the documentation.
+% Otherwise, the documentation starts right after the declaration,
+% because we're using the list environment and the declaration is the
+% ``label''.  I tried making this newline part of the label, but
+% couldn't get that to work reliably (the space seemed to stretch
+% sometimes).
+\newcommand{\haddockbegindoc}{\hfill\\[1ex]}
+
+% spacing between paragraphs and no \parindent looks better
+\parskip=10pt plus2pt minus2pt
+\setlength{\parindent}{0cm}

--- a/latex-test/ref/TypeFamilies3/main.tex
+++ b/latex-test/ref/TypeFamilies3/main.tex
@@ -1,0 +1,11 @@
+\documentclass{book}
+\usepackage{haddock}
+\begin{document}
+\begin{titlepage}
+\begin{haddocktitle}
+
+\end{haddocktitle}
+\end{titlepage}
+\tableofcontents
+\input{TypeFamilies3}
+\end{document}

--- a/latex-test/src/TypeFamilies3/TypeFamilies3.hs
+++ b/latex-test/src/TypeFamilies3/TypeFamilies3.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module TypeFamilies3 where
+
+-- | A closed type family
+type family Foo a where
+  Foo () = Int
+  Foo _ = ()
+
+-- | An open family
+type family Bar a
+
+type instance Bar Int = ()
+type instance Bar () = Int
+
+-- | A data family
+data family Baz a
+
+data instance Baz () = Baz1
+data instance Baz Int = Baz2 Bool
+newtype instance Baz Double = Baz3 Float


### PR DESCRIPTION
This PR adds some support for type/data families in the LaTeX backend, and cleans up some of the existing code around type/data families in the XHTML backend.

The XHTML backend has not changed in behaviour, save to use `newtype` instead of `data` for newtype data instances. The following use to not be accepted by the LaTeX backend.


```haskell
{-# LANGUAGE TypeFamilies #-}

module Test where

-- | A closed type family
type family Foo a where
  Foo () = Int
  Foo _ = ()

-- | An open family
type family Bar a

type instance Bar Int = ()
type instance Bar () = Int

-- | A data family 
data family Baz a

data instance Baz () = Baz1
data instance Baz Int = Baz2 Bool
newtype instance Baz Double = Baz3 Float
```

Now, it produces the following:

<img width="326" alt="screen shot 2018-01-16 at 1 27 50 pm" src="https://user-images.githubusercontent.com/10766081/35017804-75c77540-fad3-11e7-9cb1-e36d565e0ac7.png">

Obviously, it would be nice to also print out the data definitions behind these data instances. I haven’t done that yet mainly because I’m not sure what would look nicest. I’m not satisfied with what the XHTML backend does here either. In particular, I’d like to have a solution that uses the documentation that may be attached to these instances - but I’m not sure yet how this would be best achieved. When I do come up with something, I’ll propose it in a separate PR.

@ugeorge
