### PR TITLE
Properly color pragma contents in hyperlinker

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
@@ -249,6 +249,7 @@ classify tok =
     ITwarning_prag      {} -> TkPragma
     ITdeprecated_prag   {} -> TkPragma
     ITline_prag         {} -> TkPragma
+    ITcolumn_prag       {} -> TkPragma
     ITscc_prag          {} -> TkPragma
     ITgenerated_prag    {} -> TkPragma
     ITcore_prag         {} -> TkPragma
@@ -396,6 +397,7 @@ inPragma False tok =
     ITwarning_prag      {} -> True
     ITdeprecated_prag   {} -> True
     ITline_prag         {} -> True
+    ITcolumn_prag       {} -> True
     ITscc_prag          {} -> True
     ITgenerated_prag    {} -> True
     ITcore_prag         {} -> True


### PR DESCRIPTION
The hyperlinker backend now classifies the content of pragmas as `TkPragma`. That means that in something like `{-# INLINE foo #-}`, `foo` still gets classified as a pragma token.

Given the following source:

```haskell
module Kaa where

kaa :: Int -> Int
kaa = (+1)
{-# INLINE [1] kaa #-}

koo :: Int -> ()
koo _ = ()
```

Output prior to this PR:

<img width="235" alt="screen shot 2018-01-22 at 11 52 03 am" src="https://user-images.githubusercontent.com/10766081/35241251-bcb7e32c-ff6a-11e7-82b2-93b4dd147cab.png">

New output:

<img width="244" alt="screen shot 2018-01-22 at 11 52 11 am" src="https://user-images.githubusercontent.com/10766081/35241262-c3ec3af8-ff6a-11e7-8635-c2e3f6ac4a3d.png">

---

Apart from this, the only thing that remains to be done for the hyperlinker backend is to add a case to the `classify`/`inPragma` functions for the new `ITcolumn_prag` that https://phabricator.haskell.org/D4336 will introduce.