### PR TITLE
Add `SPDX-License-Identifier` as alised for "license" module header tokens

### DIFF
--- a/haddock-api/src/Haddock/Interface/ParseModuleHeader.hs
+++ b/haddock-api/src/Haddock/Interface/ParseModuleHeader.hs
@@ -37,21 +37,22 @@ parseModuleHeader dflags str0 =
       (copyrightOpt,str3) = getKey "Copyright" str2
       (licenseOpt,str4) = getKey "License" str3
       (licenceOpt,str5) = getKey "Licence" str4
-      (maintainerOpt,str6) = getKey "Maintainer" str5
-      (stabilityOpt,str7) = getKey "Stability" str6
-      (portabilityOpt,str8) = getKey "Portability" str7
+      (spdxLicenceOpt,str6) = getKey "SPDX-License-Identifier" str5
+      (maintainerOpt,str7) = getKey "Maintainer" str6
+      (stabilityOpt,str8) = getKey "Stability" str7
+      (portabilityOpt,str9) = getKey "Portability" str8
 
    in (HaddockModInfo {
           hmi_description = parseString dflags <$> descriptionOpt,
           hmi_copyright = copyrightOpt,
-          hmi_license = licenseOpt `mplus` licenceOpt,
+          hmi_license = spdxLicenceOpt `mplus` licenseOpt `mplus` licenceOpt,
           hmi_maintainer = maintainerOpt,
           hmi_stability = stabilityOpt,
           hmi_portability = portabilityOpt,
           hmi_safety = Nothing,
           hmi_language = Nothing, -- set in LexParseRn
           hmi_extensions = [] -- also set in LexParseRn
-          }, parseParas dflags str8)
+          }, parseParas dflags str9)
 
 -- | This function is how we read keys.
 --


### PR DESCRIPTION
The SPDX 2.1 specification promotes the use of a common syntax for declaring SPDX short identifiers, see [SPDX 2.1 - Appendix V](https://spdx.org/spdx-specification-21-web-version#h.twlc0ztnng3b) which tooling agnostic to language-specific syntaxes/grammars can easily scan for:

> The SPDX License Identifier syntax may consist of  a single license (represented by a short identifier from the SPDX license list) or a compound set of licenses (represented by joining together multiple licenses using the license expression syntax).
>
> The tag should appear on its own line in the source file, generally as part of a comment.
>
> ```
> SPDX-License-Identifier: <SPDX License Expression>
> ```

In the case of Haddock, there's support for a module header with `tag: value` pairs, which are rendered in a side-box in the upper right corner. However, the module header parser doesn't recognise the `SPDX-License-Identifier` tag; this patch remedies this.


See also haskell/cabal#5112