### PR TITLE
Don't barf on 'HsSpliceTy'

### DIFF
--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -264,9 +264,20 @@ renameType t = case t of
   HsCoreTy a              -> pure (HsCoreTy a)
   HsExplicitListTy i a b  -> HsExplicitListTy i a <$> mapM renameLType b
   HsExplicitTupleTy a b   -> HsExplicitTupleTy a <$> mapM renameLType b
-  HsSpliceTy _ _          -> error "renameType: HsSpliceTy"
+  HsSpliceTy s _          -> renameHsSpliceTy s
   HsWildCardTy a          -> HsWildCardTy <$> renameWildCardInfo a
   HsAppsTy _              -> error "renameType: HsAppsTy"
+
+-- | Rename splices, but _only_ those that turn out to be for types.
+-- I think this is actually safe for our possible inputs:
+--
+--  * the input is from after GHC's renamer, so should have an 'HsSpliced'
+--  * the input is typechecked, and only 'HsSplicedTy' should get through that
+--
+renameHsSpliceTy :: HsSplice Name -> RnM (HsType DocName)
+renameHsSpliceTy (HsSpliced _ (HsSplicedTy t)) = renameType t
+renameHsSpliceTy (HsSpliced _ _) = error "renameHsSpliceTy: not an HsSplicedTy"
+renameHsSpliceTy _ = error "renameHsSpliceTy: not an HsSpliced"
 
 renameLHsQTyVars :: LHsQTyVars Name -> RnM (LHsQTyVars DocName)
 renameLHsQTyVars (HsQTvs { hsq_implicit = _, hsq_explicit = tvs })


### PR DESCRIPTION
This handles `HsSpliceTy`s by replacing them with what they expand to. IIUC everything that is happening, `renameHsSpliceTy` should not be able to fail for the inputs we feed it from GHC.

This fixes #574.

---

Troublesome snippet from `secret-sharing` that was causing the error (FYI, this is [`primeField`](https://hackage.haskell.org/package/finite-field-0.9.0/docs/Data-FiniteField-PrimeField.html#v:primeField)):

```haskell
-- | A finite prime field. All computations are performed in this field.
newtype FField = FField { number :: $(primeField $ fromIntegral 1021) }
  deriving(Show,Read,Ord,Eq,Num,Fractional,Generic,Typeable,FiniteField)
```

Snippet of Haddock produced after this PR

<img width="427" alt="screen shot 2018-02-05 at 1 51 24 pm" src="https://user-images.githubusercontent.com/10766081/35830635-c14da356-0a7b-11e8-821c-aea9dd9ec8da.png">