### PR TITLE
Show where instances are defined

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -530,14 +530,14 @@ ppDocInstances unicode (i : rest)
     (is, rest') = spanWith isUndocdInstance rest
 
 isUndocdInstance :: DocInstance a -> Maybe (InstHead a)
-isUndocdInstance (i,Nothing,_) = Just i
+isUndocdInstance (i,Nothing,_,_) = Just i
 isUndocdInstance _ = Nothing
 
 -- | Print a possibly commented instance. The instance header is printed inside
 -- an 'argBox'. The comment is printed to the right of the box in normal comment
 -- style.
 ppDocInstance :: Bool -> DocInstance DocNameI -> LaTeX
-ppDocInstance unicode (instHead, doc, _) =
+ppDocInstance unicode (instHead, doc, _, _) =
   declWithDoc (ppInstDecl unicode instHead) (fmap docToLaTeX $ fmap _doc doc)
 
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -566,8 +566,8 @@ ppInstances links origin instances splice unicode qual
   where
     instName = getOccString origin
     instDecl :: Int -> DocInstance DocNameI -> (SubDecl,Located DocName)
-    instDecl no (inst, mdoc, loc) =
-        ((ppInstHead links splice unicode qual mdoc origin False no inst), loc)
+    instDecl no (inst, mdoc, loc, mdl) =
+        ((ppInstHead links splice unicode qual mdoc origin False no inst mdl), loc)
 
 
 ppOrphanInstances :: LinksInfo
@@ -581,8 +581,8 @@ ppOrphanInstances links instances splice unicode qual
     instOrigin inst = OriginClass (ihdClsName inst)
 
     instDecl :: Int -> DocInstance DocNameI -> (SubDecl,Located DocName)
-    instDecl no (inst, mdoc, loc) =
-        ((ppInstHead links splice unicode qual mdoc (instOrigin inst) True no inst), loc)
+    instDecl no (inst, mdoc, loc, mdl) =
+        ((ppInstHead links splice unicode qual mdoc (instOrigin inst) True no inst mdl), loc)
 
 
 ppInstHead :: LinksInfo -> Splice -> Unicode -> Qualification
@@ -591,13 +591,14 @@ ppInstHead :: LinksInfo -> Splice -> Unicode -> Qualification
            -> Bool -- ^ Is instance orphan
            -> Int  -- ^ Normal
            -> InstHead DocNameI
+           -> Maybe Module
            -> SubDecl
-ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) =
+ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) mdl =
     case ihdInstType of
         ClassInst { .. } ->
             ( subInstHead iid $ ppContextNoLocs clsiCtx unicode qual HideEmptyContexts <+> typ
             , mdoc
-            , [subInstDetails iid ats sigs]
+            , [subInstDetails iid ats sigs mname]
             )
           where
             sigs = ppInstanceSigs links splice unicode qual clsiSigs
@@ -605,7 +606,7 @@ ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) =
         TypeInst rhs ->
             ( subInstHead iid ptype
             , mdoc
-            , [subFamInstDetails iid prhs]
+            , [subFamInstDetails iid prhs mname]
             )
           where
             ptype = keyword "type" <+> typ
@@ -614,11 +615,12 @@ ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) =
         DataInst dd ->
             ( subInstHead iid pdata
             , mdoc
-            , [subFamInstDetails iid pdecl])
+            , [subFamInstDetails iid pdecl mname])
           where
             pdata = keyword "data" <+> typ
             pdecl = pdata <+> ppShortDataDecl False True dd [] unicode qual
   where
+    mname = maybe noHtml (\m -> hsep [toHtml "(Defined in", ppModule m, toHtml ")"]) mdl
     iid = instanceId origin no orphan ihd
     typ = ppAppNameTypes ihdClsName ihdTypes unicode qual
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -620,7 +620,7 @@ ppInstHead links splice unicode qual mdoc origin orphan no ihd@(InstHead {..}) m
             pdata = keyword "data" <+> typ
             pdecl = pdata <+> ppShortDataDecl False True dd [] unicode qual
   where
-    mname = maybe noHtml (\m -> hsep [toHtml "(Defined in", ppModule m, toHtml ")"]) mdl
+    mname = maybe noHtml (\m -> toHtml "Defined in" <+> ppModule m) mdl
     iid = instanceId origin no orphan ihd
     typ = ppAppNameTypes ihdClsName ihdTypes unicode qual
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -47,7 +47,7 @@ import Haddock.Backends.Xhtml.Utils
 import Haddock.Types
 import Haddock.Utils (makeAnchorId, nameAnchorId)
 import qualified Data.Map as Map
-import Text.XHtml hiding ( name, title, p, quote )
+import Text.XHtml hiding ( name, title, quote )
 
 import FastString            ( unpackFS )
 import GHC
@@ -228,14 +228,16 @@ subInstHead iid hdr =
 subInstDetails :: String -- ^ Instance unique id (for anchor generation)
                -> [Html] -- ^ Associated type contents
                -> [Html] -- ^ Method contents (pretty-printed signatures)
+               -> Html   -- ^ Source module
                -> Html
-subInstDetails iid ats mets =
-    subInstSection iid << (subAssociatedTypes ats <+> subMethods mets)
+subInstDetails iid ats mets mdl =
+    subInstSection iid << (p mdl <+> subAssociatedTypes ats <+> subMethods mets)
 
 subFamInstDetails :: String -- ^ Instance unique id (for anchor generation)
                   -> Html   -- ^ Type or data family instance
+                  -> Html   -- ^ Source module TODO: use this
                   -> Html
-subFamInstDetails iid fi =
+subFamInstDetails iid fi _ =
     subInstSection iid << thediv ! [theclass "src"] << fi
 
 subInstSection :: String -- ^ Instance unique id (for anchor generation)

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -237,8 +237,8 @@ subFamInstDetails :: String -- ^ Instance unique id (for anchor generation)
                   -> Html   -- ^ Type or data family instance
                   -> Html   -- ^ Source module TODO: use this
                   -> Html
-subFamInstDetails iid fi _ =
-    subInstSection iid << thediv ! [theclass "src"] << fi
+subFamInstDetails iid fi mdl =
+    subInstSection iid << (p mdl <+> (thediv ! [theclass "src"] << fi))
 
 subInstSection :: String -- ^ Instance unique id (for anchor generation)
                -> Html

--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -69,7 +69,7 @@ attachInstances expInfo ifaces instIfaceMap = do
 
 attachOrphanInstances :: ExportInfo -> Interface -> IfaceMap -> InstIfaceMap -> [ClsInst] -> [DocInstance GhcRn]
 attachOrphanInstances expInfo iface ifaceMap instIfaceMap cls_instances =
-  [ (synifyInstHead i, instLookup instDocMap n iface ifaceMap instIfaceMap, (L (getSrcSpan n) n))
+  [ (synifyInstHead i, instLookup instDocMap n iface ifaceMap instIfaceMap, (L (getSrcSpan n) n), Nothing)
   | let is = [ (instanceSig i, getName i) | i <- cls_instances, isOrphan (is_orphan i) ]
   , (i@(_,_,cls,tys), n) <- sortBy (comparing $ first instHead) is
   , not $ isInstanceHidden expInfo cls tys
@@ -91,7 +91,11 @@ attachToExportItem index expInfo iface ifaceMap instIfaceMap export =
         let mb_instances  = lookupNameEnv index (tcdName d)
             cls_instances = maybeToList mb_instances >>= fst
             fam_instances = maybeToList mb_instances >>= snd
-            fam_insts = [ (synifyFamInst i opaque, doc,spanNameE n (synifyFamInst i opaque) (L eSpan (tcdName d)) )
+            fam_insts = [ ( synifyFamInst i opaque
+                          , doc
+                          , spanNameE n (synifyFamInst i opaque) (L eSpan (tcdName d))
+                          , nameModule_maybe n
+                          )
                         | i <- sortBy (comparing instFam) fam_instances
                         , let n = getName i
                         , let doc = instLookup instDocMap n iface ifaceMap instIfaceMap
@@ -99,14 +103,18 @@ attachToExportItem index expInfo iface ifaceMap instIfaceMap export =
                         , not $ any (isTypeHidden expInfo) (fi_tys i)
                         , let opaque = isTypeHidden expInfo (fi_rhs i)
                         ]
-            cls_insts = [ (synifyInstHead i, instLookup instDocMap n iface ifaceMap instIfaceMap, spanName n (synifyInstHead i) (L eSpan (tcdName d)))
+            cls_insts = [ ( synifyInstHead i
+                          , instLookup instDocMap n iface ifaceMap instIfaceMap
+                          , spanName n (synifyInstHead i) (L eSpan (tcdName d))
+                          , nameModule_maybe n
+                          )
                         | let is = [ (instanceSig i, getName i) | i <- cls_instances ]
                         , (i@(_,_,cls,tys), n) <- sortBy (comparing $ first instHead) is
                         , not $ isInstanceHidden expInfo cls tys
                         ]
               -- fam_insts but with failing type fams filtered out
-            cleanFamInsts = [ (fi, n, L l r) | (Right fi, n, L l (Right r)) <- fam_insts ]
-            famInstErrs = [ errm | (Left errm, _, _) <- fam_insts ]
+            cleanFamInsts = [ (fi, n, L l r, m) | (Right fi, n, L l (Right r), m) <- fam_insts ]
+            famInstErrs = [ errm | (Left errm, _, _, _) <- fam_insts ]
         in do
           dfs <- getDynFlags
           let mkBug = (text "haddock-bug:" <+>) . text

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -627,11 +627,11 @@ renameWc rn_thing (HsWC { hswc_body = thing })
                       , hswc_wcs = PlaceHolder }) }
 
 renameDocInstance :: DocInstance GhcRn -> RnM (DocInstance DocNameI)
-renameDocInstance (inst, idoc, L l n) = do
+renameDocInstance (inst, idoc, L l n, m) = do
   inst' <- renameInstHead inst
   n' <- rename n
   idoc' <- mapM renameDoc idoc
-  return (inst', idoc',L l n')
+  return (inst', idoc', L l n', m)
 
 renameExportItem :: ExportItem GhcRn -> RnM (ExportItem DocNameI)
 renameExportItem item = case item of

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -388,7 +388,7 @@ mkPseudoFamilyDecl (FamilyDecl { .. }) = PseudoFamilyDecl
 
 
 -- | An instance head that may have documentation and a source location.
-type DocInstance name = (InstHead name, Maybe (MDoc (IdP name)), Located (IdP name))
+type DocInstance name = (InstHead name, Maybe (MDoc (IdP name)), Located (IdP name), Maybe Module)
 
 -- | The head of an instance. Consists of a class name, a list of type
 -- parameters (which may be annotated with kinds), and an instance type

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -180,7 +180,11 @@
 		  ><details id="i:ic:C:C:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug26</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -78,7 +78,11 @@
 		  ><details id="i:id:A:DP:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug294</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="Bug294"
@@ -116,7 +120,11 @@
 		  ><details id="i:id:A:TP:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug294</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="Bug294"
@@ -210,7 +218,11 @@
 		  ><details id="i:if:TP:TP:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug294</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="Bug294"
@@ -268,7 +280,11 @@
 		  ><details id="i:if:DP:DP:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug294</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="Bug294"
@@ -324,7 +340,11 @@
 		  ><details id="i:if:TO-39-:TO-39-:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug294</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="Bug294"

--- a/html-test/ref/Bug548.html
+++ b/html-test/ref/Bug548.html
@@ -116,7 +116,11 @@
 		  ><details id="i:id:WrappedArrow:Generic1:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -188,7 +192,11 @@
 		  ><details id="i:id:WrappedArrow:Functor:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -240,7 +248,11 @@
 		  ><details id="i:id:WrappedArrow:Applicative:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -330,7 +342,11 @@
 		  ><details id="i:id:WrappedArrow:Alternative:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -396,7 +412,11 @@
 		  ><details id="i:id:WrappedArrow:Generic:5"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -470,7 +490,11 @@
 		  ><details id="i:id:WrappedArrow:Rep1:6"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="GHC.Generics"
@@ -534,7 +558,11 @@
 		  ><details id="i:id:WrappedArrow:Rep:7"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Control.Applicative</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="GHC.Generics"

--- a/html-test/ref/Bug613.html
+++ b/html-test/ref/Bug613.html
@@ -122,7 +122,11 @@
 		  ><details id="i:ic:Functor:Functor:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug613</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -160,7 +164,11 @@
 		  ><details id="i:ic:Functor:Functor:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug613</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -234,7 +242,11 @@
 		  ><details id="i:id:ThreeVars:Functor:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug613</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -90,7 +90,11 @@
 		  ><details id="i:id:Bar:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug679</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -166,7 +170,11 @@
 		  ><details id="i:ic:Foo:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Bug679</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -129,6 +129,10 @@
 		  ><details id="i:id:Foo:Bar:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Bug7</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -179,6 +183,10 @@
 		  ><details id="i:ic:Bar:Bar:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Bug7</a
+			></p
 		      ></details
 		    ></td
 		  ></tr

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -315,7 +315,11 @@
 		  ><details id="i:ic:Hash:Hash:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Hash</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -353,7 +357,11 @@
 		  ><details id="i:ic:Hash:Hash:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Hash</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -393,7 +401,11 @@
 		  ><details id="i:ic:Hash:Hash:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Hash</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -102,6 +102,10 @@
 		  ><details id="i:ic:VisibleClass:VisibleClass:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>HiddenInstances</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -128,6 +132,10 @@
 		  ><details id="i:ic:VisibleClass:VisibleClass:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>HiddenInstances</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -176,7 +184,11 @@
 		  ><details id="i:id:VisibleData:Num:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>HiddenInstances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -282,6 +294,10 @@
 		  ><details id="i:id:VisibleData:VisibleClass:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>HiddenInstances</a
+			></p
 		      ></details
 		    ></td
 		  ></tr

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -102,6 +102,10 @@
 		  ><details id="i:ic:Foo:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>HiddenInstancesA</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -150,6 +154,10 @@
 		  ><details id="i:id:Bar:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>HiddenInstancesA</a
+			></p
 		      ></details
 		    ></td
 		  ></tr

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -90,7 +90,11 @@
 		  ><details id="i:id:-60--126--126-:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -188,7 +192,11 @@
 		  ><details id="i:ic:Foo:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -234,7 +242,11 @@
 		  ><details id="i:ic:Foo:Foo:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -292,7 +304,11 @@
 		  ><details id="i:ic:Foo:Foo:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -354,7 +370,11 @@
 		  ><details id="i:ic:Foo:Foo:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -400,7 +420,11 @@
 		  ><details id="i:ic:Foo:Foo:5"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -458,7 +482,11 @@
 		  ><details id="i:ic:Foo:Foo:6"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -504,7 +532,11 @@
 		  ><details id="i:ic:Foo:Foo:7"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -564,7 +596,11 @@
 		  ><details id="i:ic:Foo:Foo:8"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -664,7 +700,11 @@
 		  ><details id="i:ic:Bar:Bar:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -762,7 +802,11 @@
 		  ><details id="i:ic:Bar:Bar:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -844,7 +888,11 @@
 		  ><details id="i:ic:Bar:Bar:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -900,7 +948,11 @@
 		  ><details id="i:ic:Bar:Bar:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -988,7 +1040,11 @@
 		  ><details id="i:ic:Bar:Bar:5"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1044,7 +1100,11 @@
 		  ><details id="i:ic:Bar:Bar:6"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1196,7 +1256,11 @@
 		  ><details id="i:ic:Baz:Baz:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1254,7 +1318,11 @@
 		  ><details id="i:ic:Baz:Baz:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1312,7 +1380,11 @@
 		  ><details id="i:ic:Baz:Baz:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1372,7 +1444,11 @@
 		  ><details id="i:ic:Baz:Baz:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1442,7 +1518,11 @@
 		  ><details id="i:ic:Baz:Baz:5"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1550,7 +1630,11 @@
 		  ><details id="i:id:Quux:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1610,7 +1694,11 @@
 		  ><details id="i:id:Quux:Bar:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1708,7 +1796,11 @@
 		  ><details id="i:id:Quux:Baz:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1784,7 +1876,11 @@
 		  ><details id="i:id:Quux:Thud:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="Instances"
@@ -1886,7 +1982,11 @@
 		  ><details id="i:ic:Norf:Norf:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -1960,7 +2060,11 @@
 		  ><details id="i:ic:Norf:Norf:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>Instances</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"

--- a/html-test/ref/OrphanInstances.html
+++ b/html-test/ref/OrphanInstances.html
@@ -76,7 +76,9 @@
 	      ><details id="i:o:ic:AClass:AClass:1"
 		><summary class="hide-when-js-enabled"
 		  >Instance details</summary
-		  ><div class="subs methods"
+		  ><p
+		  ></p
+		  > <div class="subs methods"
 		  ><p class="caption"
 		    >Methods</p
 		    ><p class="src"

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -100,7 +100,11 @@
 		  ><details id="i:ic:AClass:AClass:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>OrphanInstances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/OrphanInstancesType.html
+++ b/html-test/ref/OrphanInstancesType.html
@@ -94,7 +94,11 @@
 		  ><details id="i:id:AType:AClass:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>OrphanInstances</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -126,7 +126,11 @@
 		  ><details id="i:id:Expr:Show:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>QuasiExpr</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -242,7 +246,11 @@
 		  ><details id="i:id:BinOp:Show:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>QuasiExpr</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -106,7 +106,11 @@ Fix spurious superclass constraints bug.</pre
 		  ><details id="i:id:SomeType:Functor:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>SpuriousSuperclassConstraints</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -156,7 +160,11 @@ Fix spurious superclass constraints bug.</pre
 		  ><details id="i:id:SomeType:Applicative:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>SpuriousSuperclassConstraints</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -1672,7 +1672,11 @@
 		  ><details id="i:ic:D:D:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Test</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"
@@ -1720,7 +1724,11 @@
 		  ><details id="i:ic:D:D:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs methods"
+		      ><p
+		      >Defined in <a href="#"
+			>Test</a
+			></p
+		      > <div class="subs methods"
 		      ><p class="caption"
 			>Methods</p
 			><p class="src"

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -242,6 +242,10 @@
 		  ><details id="i:id:X:-62--60-:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -268,7 +272,11 @@
 		  ><details id="i:id:X:Assoc:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -322,6 +330,10 @@
 		  ><details id="i:id:X:Test:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -348,7 +360,11 @@
 		  ><details id="i:id:X:Foo:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies2"
@@ -386,7 +402,11 @@
 		  ><details id="i:id:X:-60--62-:5"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -424,7 +444,11 @@
 		  ><details id="i:id:X:AssocD:6"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -460,7 +484,11 @@
 		  ><details id="i:id:X:AssocT:7"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -502,7 +530,11 @@
 		  ><details id="i:id:X:Bat:8"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -562,7 +594,11 @@
 		  ><details id="i:id:X:Foo:9"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -600,7 +636,11 @@
 		  ><details id="i:id:X:-60--62-:10"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -660,7 +700,11 @@
 		  ><details id="i:id:Y:Assoc:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -714,6 +758,10 @@
 		  ><details id="i:id:Y:Test:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -740,7 +788,11 @@
 		  ><details id="i:id:Y:Bar:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies2"
@@ -774,7 +826,11 @@
 		  ><details id="i:id:Y:AssocD:4"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -810,7 +866,11 @@
 		  ><details id="i:id:Y:AssocT:5"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -850,7 +910,11 @@
 		  ><details id="i:id:Y:Bat:6"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -888,7 +952,11 @@
 		  ><details id="i:id:Y:Foo:7"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -926,7 +994,11 @@
 		  ><details id="i:id:Y:-60--62-:8"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -1008,7 +1080,11 @@
 		  ><details id="i:id:Z:Bat:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -1084,6 +1160,10 @@
 		  ><details id="i:ic:Test:Test:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -1110,6 +1190,10 @@
 		  ><details id="i:ic:Test:Test:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
 		      ></details
 		    ></td
 		  ></tr
@@ -1158,7 +1242,11 @@
 		  ><details id="i:if:Foo:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -1194,7 +1282,11 @@
 		  ><details id="i:if:Foo:Foo:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -1256,7 +1348,11 @@
 		  ><details id="i:if:Bat:Bat:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -1312,7 +1408,11 @@
 		  ><details id="i:if:Bat:Bat:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -1352,7 +1452,11 @@
 		  ><details id="i:if:Bat:Bat:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies"
@@ -1466,7 +1570,11 @@
 		  ><details id="i:ic:Assoc:Assoc:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -1520,7 +1628,11 @@
 		  ><details id="i:ic:Assoc:Assoc:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="subs associated-types"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="subs associated-types"
 		      ><p class="caption"
 			>Associated Types</p
 			><p class="src"
@@ -1638,7 +1750,11 @@
 		  ><details id="i:if:-60--62-:-60--62-:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -1678,7 +1794,11 @@
 		  ><details id="i:if:-60--62-:-60--62-:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -1716,7 +1836,11 @@
 		  ><details id="i:if:-60--62-:-60--62-:3"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies"
@@ -1772,6 +1896,10 @@
 		  ><details id="i:ic:-62--60-:-62--60-:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
 		      ></details
 		    ></td
 		  ></tr

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -110,7 +110,11 @@
 		  ><details id="i:id:W:Bar:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies2</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies2"
@@ -146,7 +150,11 @@
 		  ><details id="i:id:W:Foo:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies2</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies2"
@@ -202,7 +210,11 @@
 		  ><details id="i:if:Foo:Foo:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies2</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies2"
@@ -236,7 +248,11 @@
 		  ><details id="i:if:Foo:Foo:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>type</span
 			> <a href="#" title="TypeFamilies2"
@@ -296,7 +312,11 @@
 		  ><details id="i:if:Bar:Bar:1"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies2</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies2"
@@ -332,7 +352,11 @@
 		  ><details id="i:if:Bar:Bar:2"
 		    ><summary class="hide-when-js-enabled"
 		      >Instance details</summary
-		      ><div class="src"
+		      ><p
+		      >Defined in <a href="#"
+			>TypeFamilies</a
+			></p
+		      > <div class="src"
 		      ><span class="keyword"
 			>data</span
 			> <a href="#" title="TypeFamilies2"


### PR DESCRIPTION
This is analogous to what GHCi's `:info` command does - it displays in the instance details where the instance was defined.

```
ghci> :info Bool
data Bool = False | True        -- Defined in ‘GHC.Types’
instance Bounded Bool -- Defined in ‘GHC.Enum’
instance Enum Bool -- Defined in ‘GHC.Enum’
instance Eq Bool -- Defined in ‘GHC.Classes’
instance Ord Bool -- Defined in ‘GHC.Classes’
instance Read Bool -- Defined in ‘GHC.Read’
instance Show Bool -- Defined in ‘GHC.Show’
instance Ix Bool -- Defined in ‘GHC.Arr’
```

Here is a snippet of the instances for `Bool` (Note the "(Defined in ...)" links):

<img width="449" alt="screen shot 2018-02-08 at 6 23 56 pm" src="https://user-images.githubusercontent.com/10766081/36008722-87aec66e-0cfd-11e8-988c-dd9cc42fb78b.png">

This fixes https://github.com/haskell/haddock/issues/296 as much as it can ever really hope to be fixed.

