### PR TITLE
Run builds concurrently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /hypsrc-test/out/
 /latex-test/out/
 /hoogle-test/out/
+/perf-test/out/
 
 /doc/haddock
 /doc/haddock.ps

--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -42,19 +42,27 @@ import Haddock.Options hiding (verbosity)
 import Haddock.Types
 import Haddock.Utils
 
+import Control.Concurrent (forkIOWithUnmask, killThread)
+import Control.Concurrent.MVar
+import Control.Concurrent.QSem
 import Control.Monad
 import Data.List
 import qualified Data.Map as Map
+import Data.Maybe
 import qualified Data.Set as Set
 import Distribution.Verbosity
 import System.Directory
 import System.FilePath
 import Text.Printf
 
+import GHC.Conc ( getNumProcessors)
+
 import Digraph
 import DynFlags hiding (verbosity)
 import Exception
 import GHC hiding (verbosity)
+import GhcMake
+import GhcMonad
 import HscTypes
 import FastString (unpackFS)
 import MonadUtils (liftIO)
@@ -149,17 +157,52 @@ createIfaces0 verbosity modules flags instIfaceMap =
 
 createIfaces :: Verbosity -> [Flag] -> InstIfaceMap -> ModuleGraph -> Ghc [Interface]
 createIfaces verbosity flags instIfaceMap mods = do
-  let sortedMods = flattenSCCs $ topSortModuleGraph False mods Nothing
-  out verbosity normal "Haddock coverage:"
-  (ifaces, _) <- foldM f ([], Map.empty) sortedMods
-  return (reverse ifaces)
-  where
-    f (ifaces, ifaceMap) modSummary = do
-      x <- processModule verbosity modSummary flags ifaceMap instIfaceMap
-      return $ case x of
-        Just iface -> (iface:ifaces, Map.insert (ifaceMod iface) iface ifaceMap)
-        Nothing    -> (ifaces, ifaceMap) -- Boot modules don't generate ifaces.
+  hsc_env <- getSession
+  let dflags = hsc_dflags hsc_env
+  let full_mg = topSortModuleGraph False mods Nothing
 
+  graph' <- liftIO $ forM full_mg $ \m ->
+    case m of
+      CyclicSCC _ -> return Nothing
+      AcyclicSCC ms -> do
+        mvar <- newEmptyMVar
+        return (Just (moduleName $ ms_mod ms, (ms, mvar)))
+  let graph = catMaybes graph'
+      dep_graph = Map.fromList graph
+
+  n_jobs <- case parMakeCount dflags of
+                   Nothing -> liftIO getNumProcessors
+                   Just n -> return n
+
+  par_sem <- liftIO $ newQSem n_jobs
+
+  let
+    withSem sem = bracket_ (waitQSem sem) (signalQSem sem)
+
+    spawnWorkers s = forM graph $ \(_mn, (m, mvar)) ->
+      forkIOWithUnmask $ \_unmask -> do
+        let imps = map unLoc $ ms_home_imps m
+            deps = [ r | dep <- imps
+                       , Just r <- [Map.lookup dep dep_graph] ]
+        ifaces <- forM deps $ \(ms, imvar) -> do
+          r <- readMVar imvar
+          case r of
+            Nothing -> return Nothing
+            Just m' -> return (Just (ms_mod ms, m'))
+        let ifaceMap = Map.fromList $ catMaybes ifaces
+        x <- withSem par_sem $ reflectGhc
+          (processModule verbosity m flags ifaceMap instIfaceMap) s
+        putMVar mvar x
+
+    killWorkers = uninterruptibleMask_ . mapM_ killThread
+
+  ifaces <-
+    reifyGhc $ \s ->
+      liftIO $ bracket (spawnWorkers s) killWorkers $ \_ ->
+        forM (Map.elems dep_graph) $ \(_, mvar) -> do
+          readMVar mvar
+
+  return (reverse $ catMaybes ifaces)
 
 processModule :: Verbosity -> ModSummary -> [Flag] -> IfaceMap -> InstIfaceMap -> Ghc (Maybe Interface)
 processModule verbosity modsum flags modMap instIfaceMap = do

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -51,6 +51,7 @@ extra-source-files:
   latex-test/src/Simple/*.hs
   latex-test/ref/Simple/*.tex
   latex-test/ref/Simple/*.sty
+  perf-test/src/*.hs
 
 flag in-ghc-tree
   description: Are we in a GHC tree?
@@ -205,6 +206,14 @@ test-suite hoogle-test
   main-is:            Main.hs
   hs-source-dirs:     hoogle-test
   build-depends:      base, filepath, haddock-test == 0.0.1
+
+test-suite perf-test
+  type:               exitcode-stdio-1.0
+  build-tool-depends: haddock:haddock
+  default-language:   Haskell2010
+  main-is:            Main.hs
+  hs-source-dirs:     perf-test
+  build-depends:      base, filepath, haddock-test == 0.0.1, time
 
 source-repository head
   type:     git

--- a/perf-test/Main.hs
+++ b/perf-test/Main.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE CPP #-}
+
+
+import Data.Char
+import Data.Function (on)
+import Data.Time.Clock
+
+import System.Environment
+import System.Exit
+import System.FilePath
+
+import Test.Haddock
+import Test.Haddock.Xhtml
+
+main :: IO ()
+main = do
+  cfg <- parseArgs checkConfig dirConfig =<< getArgs
+
+  solo <- timeRun cfg 1
+  mult <- timeRun cfg 8
+
+  if mult < solo
+  then do
+    putStrLn "mult was faster than solo"
+    exitSuccess
+  else do
+    putStrLn "mult was slow"
+    exitFailure
+
+timeRun :: Config c -> Int -> IO Double
+timeRun cfg n = do
+  start <- getCurrentTime
+  runHaddock $ cfg
+    { cfgHaddockArgs = cfgHaddockArgs cfg ++
+      [ "--pretty-html"
+      , "--html"
+      , "--optghc=-j" ++ show n
+      ]
+    }
+  end <- getCurrentTime
+  return (realToFrac $ end `diffUTCTime` start)
+
+
+checkConfig :: CheckConfig Xml
+checkConfig = CheckConfig
+    { ccfgRead = parseXml
+    , ccfgClean = stripIfRequired
+    , ccfgDump = dumpXml
+    , ccfgEqual = (==) `on` dumpXml
+    }
+
+
+dirConfig :: DirConfig
+dirConfig = (defaultDirConfig $ takeDirectory __FILE__)
+    { dcfgCheckIgnore = checkIgnore
+    }
+
+stripIfRequired :: String -> Xml -> Xml
+stripIfRequired mdl = stripLinks . stripFooter
+
+checkIgnore :: FilePath -> Bool
+checkIgnore file@(c:_) | takeExtension file == ".html" && isUpper c = False
+checkIgnore _ = True

--- a/perf-test/src/A.hs
+++ b/perf-test/src/A.hs
@@ -1,0 +1,5 @@
+module A where
+
+-- | Foo is the firs thing to compile
+foo :: Int
+foo = 7

--- a/perf-test/src/B01.hs
+++ b/perf-test/src/B01.hs
@@ -1,0 +1,7 @@
+module B01 where
+
+import A (foo)
+
+-- | bar01 is an intermediate node
+bar01 :: String
+bar01 = show foo

--- a/perf-test/src/B02.hs
+++ b/perf-test/src/B02.hs
@@ -1,0 +1,7 @@
+module B02 where
+
+import A (foo)
+
+-- | bar02 is an intermediate node
+bar02 :: String
+bar02 = show foo

--- a/perf-test/src/B03.hs
+++ b/perf-test/src/B03.hs
@@ -1,0 +1,7 @@
+module B03 where
+
+import A (foo)
+
+-- | bar03 is an intermediate node
+bar03 :: String
+bar03 = show foo

--- a/perf-test/src/B04.hs
+++ b/perf-test/src/B04.hs
@@ -1,0 +1,7 @@
+module B04 where
+
+import A (foo)
+
+-- | bar04 is an intermediate node
+bar04 :: String
+bar04 = show foo

--- a/perf-test/src/B05.hs
+++ b/perf-test/src/B05.hs
@@ -1,0 +1,7 @@
+module B05 where
+
+import A (foo)
+
+-- | bar05 is an intermediate node
+bar05 :: String
+bar05 = show foo

--- a/perf-test/src/B06.hs
+++ b/perf-test/src/B06.hs
@@ -1,0 +1,7 @@
+module B06 where
+
+import A (foo)
+
+-- | bar06 is an intermediate node
+bar06 :: String
+bar06 = show foo

--- a/perf-test/src/B07.hs
+++ b/perf-test/src/B07.hs
@@ -1,0 +1,7 @@
+module B07 where
+
+import A (foo)
+
+-- | bar07 is an intermediate node
+bar07 :: String
+bar07 = show foo

--- a/perf-test/src/B08.hs
+++ b/perf-test/src/B08.hs
@@ -1,0 +1,7 @@
+module B08 where
+
+import A (foo)
+
+-- | bar08 is an intermediate node
+bar08 :: String
+bar08 = show foo

--- a/perf-test/src/B09.hs
+++ b/perf-test/src/B09.hs
@@ -1,0 +1,7 @@
+module B09 where
+
+import A (foo)
+
+-- | bar09 is an intermediate node
+bar09 :: String
+bar09 = show foo

--- a/perf-test/src/B10.hs
+++ b/perf-test/src/B10.hs
@@ -1,0 +1,7 @@
+module B10 where
+
+import A (foo)
+
+-- | bar10 is an intermediate node
+bar10 :: String
+bar10 = show foo

--- a/perf-test/src/B11.hs
+++ b/perf-test/src/B11.hs
@@ -1,0 +1,7 @@
+module B11 where
+
+import A (foo)
+
+-- | bar11 is an intermediate node
+bar11 :: String
+bar11 = show foo

--- a/perf-test/src/B12.hs
+++ b/perf-test/src/B12.hs
@@ -1,0 +1,7 @@
+module B12 where
+
+import A (foo)
+
+-- | bar12 is an intermediate node
+bar12 :: String
+bar12 = show foo

--- a/perf-test/src/B13.hs
+++ b/perf-test/src/B13.hs
@@ -1,0 +1,7 @@
+module B13 where
+
+import A (foo)
+
+-- | bar13 is an intermediate node
+bar13 :: String
+bar13 = show foo

--- a/perf-test/src/B14.hs
+++ b/perf-test/src/B14.hs
@@ -1,0 +1,7 @@
+module B14 where
+
+import A (foo)
+
+-- | bar14 is an intermediate node
+bar14 :: String
+bar14 = show foo

--- a/perf-test/src/B15.hs
+++ b/perf-test/src/B15.hs
@@ -1,0 +1,7 @@
+module B15 where
+
+import A (foo)
+
+-- | bar15 is an intermediate node
+bar15 :: String
+bar15 = show foo

--- a/perf-test/src/B16.hs
+++ b/perf-test/src/B16.hs
@@ -1,0 +1,7 @@
+module B16 where
+
+import A (foo)
+
+-- | bar16 is an intermediate node
+bar16 :: String
+bar16 = show foo

--- a/perf-test/src/B17.hs
+++ b/perf-test/src/B17.hs
@@ -1,0 +1,7 @@
+module B17 where
+
+import A (foo)
+
+-- | bar17 is an intermediate node
+bar17 :: String
+bar17 = show foo

--- a/perf-test/src/B18.hs
+++ b/perf-test/src/B18.hs
@@ -1,0 +1,7 @@
+module B18 where
+
+import A (foo)
+
+-- | bar18 is an intermediate node
+bar18 :: String
+bar18 = show foo

--- a/perf-test/src/B19.hs
+++ b/perf-test/src/B19.hs
@@ -1,0 +1,7 @@
+module B19 where
+
+import A (foo)
+
+-- | bar19 is an intermediate node
+bar19 :: String
+bar19 = show foo

--- a/perf-test/src/B20.hs
+++ b/perf-test/src/B20.hs
@@ -1,0 +1,7 @@
+module B20 where
+
+import A (foo)
+
+-- | bar20 is an intermediate node
+bar20 :: String
+bar20 = show foo

--- a/perf-test/src/B21.hs
+++ b/perf-test/src/B21.hs
@@ -1,0 +1,7 @@
+module B21 where
+
+import A (foo)
+
+-- | bar21 is an intermediate node
+bar21 :: String
+bar21 = show foo

--- a/perf-test/src/B22.hs
+++ b/perf-test/src/B22.hs
@@ -1,0 +1,7 @@
+module B22 where
+
+import A (foo)
+
+-- | bar22 is an intermediate node
+bar22 :: String
+bar22 = show foo

--- a/perf-test/src/B23.hs
+++ b/perf-test/src/B23.hs
@@ -1,0 +1,7 @@
+module B23 where
+
+import A (foo)
+
+-- | bar23 is an intermediate node
+bar23 :: String
+bar23 = show foo

--- a/perf-test/src/B24.hs
+++ b/perf-test/src/B24.hs
@@ -1,0 +1,7 @@
+module B24 where
+
+import A (foo)
+
+-- | bar24 is an intermediate node
+bar24 :: String
+bar24 = show foo

--- a/perf-test/src/B25.hs
+++ b/perf-test/src/B25.hs
@@ -1,0 +1,7 @@
+module B25 where
+
+import A (foo)
+
+-- | bar25 is an intermediate node
+bar25 :: String
+bar25 = show foo

--- a/perf-test/src/B26.hs
+++ b/perf-test/src/B26.hs
@@ -1,0 +1,7 @@
+module B26 where
+
+import A (foo)
+
+-- | bar26 is an intermediate node
+bar26 :: String
+bar26 = show foo

--- a/perf-test/src/B27.hs
+++ b/perf-test/src/B27.hs
@@ -1,0 +1,7 @@
+module B27 where
+
+import A (foo)
+
+-- | bar27 is an intermediate node
+bar27 :: String
+bar27 = show foo

--- a/perf-test/src/B28.hs
+++ b/perf-test/src/B28.hs
@@ -1,0 +1,7 @@
+module B28 where
+
+import A (foo)
+
+-- | bar28 is an intermediate node
+bar28 :: String
+bar28 = show foo

--- a/perf-test/src/B29.hs
+++ b/perf-test/src/B29.hs
@@ -1,0 +1,7 @@
+module B29 where
+
+import A (foo)
+
+-- | bar29 is an intermediate node
+bar29 :: String
+bar29 = show foo

--- a/perf-test/src/B30.hs
+++ b/perf-test/src/B30.hs
@@ -1,0 +1,7 @@
+module B30 where
+
+import A (foo)
+
+-- | bar30 is an intermediate node
+bar30 :: String
+bar30 = show foo

--- a/perf-test/src/B31.hs
+++ b/perf-test/src/B31.hs
@@ -1,0 +1,7 @@
+module B31 where
+
+import A (foo)
+
+-- | bar31 is an intermediate node
+bar31 :: String
+bar31 = show foo

--- a/perf-test/src/B32.hs
+++ b/perf-test/src/B32.hs
@@ -1,0 +1,7 @@
+module B32 where
+
+import A (foo)
+
+-- | bar32 is an intermediate node
+bar32 :: String
+bar32 = show foo

--- a/perf-test/src/C.hs
+++ b/perf-test/src/C.hs
@@ -1,0 +1,70 @@
+module C where
+
+import B01
+import B02
+import B03
+import B04
+import B05
+import B06
+import B07
+import B08
+import B09
+import B10
+import B11
+import B12
+import B13
+import B14
+import B15
+import B16
+import B17
+import B18
+import B19
+import B20
+import B21
+import B22
+import B23
+import B24
+import B25
+import B26
+import B27
+import B28
+import B29
+import B30
+import B31
+import B32
+
+-- | baz is the bottom of all the nodes and should be built last
+baz :: String
+baz =
+  bar01 ++
+  bar02 ++
+  bar03 ++
+  bar04 ++
+  bar05 ++
+  bar06 ++
+  bar07 ++
+  bar08 ++
+  bar09 ++
+  bar10 ++
+  bar11 ++
+  bar12 ++
+  bar13 ++
+  bar14 ++
+  bar15 ++
+  bar16 ++
+  bar17 ++
+  bar18 ++
+  bar19 ++
+  bar20 ++
+  bar21 ++
+  bar22 ++
+  bar23 ++
+  bar24 ++
+  bar25 ++
+  bar26 ++
+  bar27 ++
+  bar28 ++
+  bar29 ++
+  bar30 ++
+  bar31 ++
+  bar32


### PR DESCRIPTION
Haddock builds run sequentially, unlike GhcMake which runs builds of independent modules concurrently. This changes Haddock to process modules concurrently using a similar technique that GhcMake uses itself.
I'm not convinced this is the best way to do things and worry I'm missing nuances in places.

I've also added a test that exercises the difference in performance.
I don't think this is a great test to keep around. Putting a `threadDelay` inside processModule demonstrated a large performance difference.

I'm open to any suggestions.

I was unable to thoroughly test this on the ghc-8.4 branch as cabal doesn't feel like resolving constraints.