### PR TITLE
Make testsuite work with haddock-1.19.0 release

### DIFF
--- a/html-test/Main.hs
+++ b/html-test/Main.hs
@@ -47,7 +47,22 @@ stripIfRequired mdl =
 preserveLinksModules :: [String]
 preserveLinksModules = ["Bug253"]
 
+ingoredTests :: [FilePath]
+ingoredTests =
+  [
+    -- Currently some declarations are exported twice
+    -- we need a reliable way to deduplicate here.
+    -- Happens since PR #688.
+    "B"
+
+    -- ignore-exports flag broke with PR #688. We use
+    -- the Avails calculated by GHC now. Probably
+    -- requires a change to GHC to "ignore" a modules
+    -- export list reliably.
+  , "IgnoreExports"
+  ]
 
 checkIgnore :: FilePath -> Bool
+checkIgnore file | takeBaseName file `elem` ingoredTests = True
 checkIgnore file@(c:_) | takeExtension file == ".html" && isUpper c = False
 checkIgnore _ = True

--- a/html-test/ref/A.html
+++ b/html-test/ref/A.html
@@ -54,13 +54,13 @@
 	    ><li class="src short"
 	    ><a href="#"
 	      >other</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >test2</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Bool"
 	      >Bool</a
 	      ></li
 	    ><li class="src short"
@@ -74,7 +74,7 @@
 	    ><li class="src short"
 	    ><a href="#"
 	      >reExport</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -111,7 +111,7 @@
 	><p class="src"
 	  ><a id="v:other" class="def"
 	    >other</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -121,7 +121,7 @@
 	><p class="src"
 	  ><a id="v:test2" class="def"
 	    >test2</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Bool"
 	    >Bool</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -165,7 +165,7 @@
 	><p class="src"
 	  ><a id="v:reExport" class="def"
 	    >reExport</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug1.html
+++ b/html-test/ref/Bug1.html
@@ -70,7 +70,7 @@
 	  ><p
 	    >We should have different anchors for constructors and types/classes.  This
  hyperlink should point to the type constructor by default: <code
-	      ><a href="#"
+	      ><a href="#" title="Bug1"
 		>T</a
 		></code
 	      >.</p

--- a/html-test/ref/Bug2.html
+++ b/html-test/ref/Bug2.html
@@ -45,7 +45,7 @@
 	><p class="src"
 	  ><a id="v:x" class="def"
 	    >x</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="A"
 	    >A</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -81,7 +81,7 @@
 	    >This link should generate <code
 	      >#v</code
 	      > anchor: <code
-	      ><a href="#"
+	      ><a href="#" title="DoesNotExist"
 		>fakeFakeFake</a
 		></code
 	      ></p

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -130,7 +130,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Bug26"
 	      >c_f</a
 	      ></p
 	    ></div
@@ -160,7 +160,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:C:C:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug26"
 		      >C</a
 		      > ()</span
 		    > <a href="#" class="selflink"

--- a/html-test/ref/Bug280.html
+++ b/html-test/ref/Bug280.html
@@ -61,7 +61,7 @@
 	><p class="src"
 	  ><a id="v:x" class="def"
 	    >x</a
-	    > :: [<a href="#"
+	    > :: [<a href="#" title="Data.Char"
 	    >Char</a
 	    >] <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -62,9 +62,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="Bug294"
 		      >DP</a
-		      > <a href="#"
+		      > <a href="#" title="Bug294"
 		      >A</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -81,13 +81,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>DP</a
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>A</a
 			> = <a id="v:ProblemCtor-39-" class="def"
 			>ProblemCtor'</a
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>A</a
 			></div
 		      ></details
@@ -100,7 +100,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > TP <a href="#"
+		      > <a href="#" title="Bug294"
+		      >TP</a
+		      > <a href="#" title="Bug294"
 		      >A</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -117,11 +119,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> TP <a href="#"
+			> <a href="#" title="Bug294"
+			>TP</a
+			> <a href="#" title="Bug294"
 			>A</a
 			> = <a id="v:ProblemCtor" class="def"
 			>ProblemCtor</a
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>A</a
 			></div
 		      ></details
@@ -135,9 +139,9 @@
 	><p class="src"
 	  ><a id="v:problemField" class="def"
 	    >problemField</a
-	    > :: TO <a href="#"
+	    > :: TO <a href="#" title="Bug294"
 	    >A</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Bug294"
 	    >A</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -147,9 +151,9 @@
 	><p class="src"
 	  ><a id="v:problemField-39-" class="def"
 	    >problemField'</a
-	    > :: DO <a href="#"
+	    > :: DO <a href="#" title="Bug294"
 	    >A</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Bug294"
 	    >A</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -159,9 +163,9 @@
 	><p class="src"
 	  ><a id="v:gadtField" class="def"
 	    >gadtField</a
-	    > :: ({..} -&gt; GADT <a href="#"
+	    > :: ({..} -&gt; GADT <a href="#" title="Bug294"
 	    >A</a
-	    >) -&gt; <a href="#"
+	    >) -&gt; <a href="#" title="Bug294"
 	    >A</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -171,9 +175,67 @@
 	><p class="src"
 	  ><span class="keyword"
 	    >data family</span
+	    > <a id="t:TP" class="def"
+	    >TP</a
+	    > t :: <a href="#" title="Data.Kind"
+	    >*</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs instances"
+	  ><details id="i:TP" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:TP:TP:1"
+		      ></span
+		      > <span class="keyword"
+		      >data</span
+		      > <a href="#" title="Bug294"
+		      >TP</a
+		      > <a href="#" title="Bug294"
+		      >A</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:TP:TP:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="src"
+		      ><span class="keyword"
+			>data</span
+			> <a href="#" title="Bug294"
+			>TP</a
+			> <a href="#" title="Bug294"
+			>A</a
+			> = <a id="v:ProblemCtor" class="def"
+			>ProblemCtor</a
+			> <a href="#" title="Bug294"
+			>A</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data family</span
 	    > <a id="t:DP" class="def"
 	    >DP</a
-	    > t :: <a href="#"
+	    > t :: <a href="#" title="Data.Kind"
 	    >*</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -190,9 +252,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="Bug294"
 		      >DP</a
-		      > <a href="#"
+		      > <a href="#" title="Bug294"
 		      >A</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -209,14 +271,66 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>DP</a
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>A</a
 			> = <a id="v:ProblemCtor-39-" class="def"
 			>ProblemCtor'</a
-			> <a href="#"
+			> <a href="#" title="Bug294"
 			>A</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data family</span
+	    > <a id="t:TO-39-" class="def"
+	    >TO'</a
+	    > t :: <a href="#" title="Data.Kind"
+	    >*</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs instances"
+	  ><details id="i:TO-39-" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:TO-39-:TO-39-:1"
+		      ></span
+		      > <span class="keyword"
+		      >data</span
+		      > <a href="#" title="Bug294"
+		      >TO'</a
+		      > a</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:TO-39-:TO-39-:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="src"
+		      ><span class="keyword"
+			>data</span
+			> <a href="#" title="Bug294"
+			>TO'</a
+			> a = <a id="v:PolyCtor" class="def"
+			>PolyCtor</a
 			></div
 		      ></details
 		    ></td

--- a/html-test/ref/Bug298.html
+++ b/html-test/ref/Bug298.html
@@ -111,19 +111,19 @@
 	  ><div class="doc"
 	  ><p
 	    >Links to <code
-	      ><a href="#"
+	      ><a href="#" title="Bug298"
 		>&lt;^&gt;</a
 		></code
 	      > and <code
-	      ><a href="#"
+	      ><a href="#" title="Bug298"
 		>^&gt;</a
 		></code
 	      >, <code
-	      ><a href="#"
+	      ><a href="#" title="Bug298"
 		>&lt;^</a
 		></code
 	      > and <code
-	      ><a href="#"
+	      ><a href="#" title="Bug298"
 		>&#8902;^</a
 		></code
 	      >.</p

--- a/html-test/ref/Bug3.html
+++ b/html-test/ref/Bug3.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug310.html
+++ b/html-test/ref/Bug310.html
@@ -46,13 +46,13 @@
 	  ><li class="src short"
 	    ><span class="keyword"
 	      >type family</span
-	      > (a :: <a href="#"
+	      > (a :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
 	      >) <a href="#"
 	      >+</a
-	      > (b :: <a href="#"
+	      > (b :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
-	      >) :: <a href="#"
+	      >) :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
 	      > <span class="keyword"
 	      >where ...</span
@@ -67,13 +67,13 @@
 	><p class="src"
 	  ><span class="keyword"
 	    >type family</span
-	    > (a :: <a href="#"
+	    > (a :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
 	    >) <a id="t:-43-" class="def"
 	    >+</a
-	    > (b :: <a href="#"
+	    > (b :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
-	    >) :: <a href="#"
+	    >) :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
 	    > <span class="keyword"
 	    >where ...</span
@@ -87,6 +87,10 @@
 	  ><div class="doc"
 	  ><p
 	    >Addition of type-level naturals.</p
+	    ><p
+	    ><em
+	      >Since: 4.7.0.0</em
+	      ></p
 	    ></div
 	  ></div
 	></div

--- a/html-test/ref/Bug387.html
+++ b/html-test/ref/Bug387.html
@@ -60,13 +60,13 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >test1</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >test2</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -83,7 +83,7 @@
 	><p class="src"
 	  ><a id="v:test1" class="def"
 	    >test1</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -99,7 +99,7 @@
 	><p class="src"
 	  ><a id="v:test2" class="def"
 	    >test2</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug4.html
+++ b/html-test/ref/Bug4.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug546.html
+++ b/html-test/ref/Bug546.html
@@ -46,15 +46,15 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >x</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >compile</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.String"
 	      >String</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.String"
 	      >String</a
 	      ></li
 	    ></ul
@@ -67,7 +67,7 @@
 	><p class="src"
 	  ><a id="v:x" class="def"
 	    >x</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -89,9 +89,9 @@
 	><p class="src"
 	  ><a id="v:compile" class="def"
 	    >compile</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.String"
 	    >String</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.String"
 	    >String</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bug548.html
+++ b/html-test/ref/Bug548.html
@@ -47,11 +47,11 @@
 	    >newtype</span
 	    > <a id="t:WrappedArrow" class="def"
 	    >WrappedArrow</a
-	    > (a :: <a href="#"
+	    > (a :: <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    >) b c <a href="#" class="selflink"
 	    >#</a
@@ -98,13 +98,15 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Generic1:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="GHC.Generics"
 		      >Generic1</a
-		      > <a href="#"
-		      >*</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
-		      > a b)</span
+		      > a b :: <a href="#" title="Data.Kind"
+		      >*</a
+		      > -&gt; <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    ></td
 		  ><td class="doc empty"
 		  ></td
@@ -120,15 +122,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="GHC.Generics"
 			  >Rep1</a
-			  > (<a href="#"
+			  > (<a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b) (f :: <a href="#"
-			  >WrappedArrow</a
-			  > a b -&gt; <a href="#"
-			  >*</a
-			  >) :: k -&gt; <a href="#"
+			  > a b) :: k -&gt; <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -140,21 +138,25 @@
 			><p class="src"
 			><a href="#"
 			  >from1</a
-			  > :: f a0 -&gt; <a href="#"
-			  >Rep1</a
-			  > (<a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b) f a0 <a href="#" class="selflink"
+			  > a b a0 -&gt; <a href="#" title="GHC.Generics"
+			  >Rep1</a
+			  > (<a href="#" title="Bug548"
+			  >WrappedArrow</a
+			  > a b) a0 <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
 			><a href="#"
 			  >to1</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="GHC.Generics"
 			  >Rep1</a
-			  > (<a href="#"
+			  > (<a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b) f a0 -&gt; f a0 <a href="#" class="selflink"
+			  > a b) a0 -&gt; <a href="#" title="Bug548"
+			  >WrappedArrow</a
+			  > a b a0 <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			></div
@@ -166,11 +168,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Functor:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Control.Arrow"
 		      >Arrow</a
-		      > a =&gt; <a href="#"
+		      > a =&gt; <a href="#" title="Data.Functor"
 		      >Functor</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
 		      > a b)</span
 		    ></td
@@ -192,9 +194,9 @@
 			><p class="src"
 			><a href="#"
 			  >fmap</a
-			  > :: (a0 -&gt; b0) -&gt; <a href="#"
+			  > :: (a0 -&gt; b0) -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b b0 <a href="#" class="selflink"
 			  >#</a
@@ -202,9 +204,9 @@
 			><p class="src"
 			><a href="#"
 			  >(&lt;$)</a
-			  > :: a0 -&gt; <a href="#"
+			  > :: a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b b0 -&gt; <a href="#"
+			  > a b b0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -218,11 +220,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Applicative:3"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Control.Arrow"
 		      >Arrow</a
-		      > a =&gt; <a href="#"
+		      > a =&gt; <a href="#" title="Control.Applicative"
 		      >Applicative</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
 		      > a b)</span
 		    ></td
@@ -244,7 +246,7 @@
 			><p class="src"
 			><a href="#"
 			  >pure</a
-			  > :: a0 -&gt; <a href="#"
+			  > :: a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -252,11 +254,11 @@
 			><p class="src"
 			><a href="#"
 			  >(&lt;*&gt;)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b (a0 -&gt; b0) -&gt; <a href="#"
+			  > a b (a0 -&gt; b0) -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b b0 <a href="#" class="selflink"
 			  >#</a
@@ -264,11 +266,11 @@
 			><p class="src"
 			><a href="#"
 			  >liftA2</a
-			  > :: (a0 -&gt; b0 -&gt; c) -&gt; <a href="#"
+			  > :: (a0 -&gt; b0 -&gt; c) -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b b0 -&gt; <a href="#"
+			  > a b b0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b c <a href="#" class="selflink"
 			  >#</a
@@ -276,11 +278,11 @@
 			><p class="src"
 			><a href="#"
 			  >(*&gt;)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b b0 -&gt; <a href="#"
+			  > a b b0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b b0 <a href="#" class="selflink"
 			  >#</a
@@ -288,11 +290,11 @@
 			><p class="src"
 			><a href="#"
 			  >(&lt;*)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b b0 -&gt; <a href="#"
+			  > a b b0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -306,13 +308,13 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Alternative:4"
 		      ></span
-		      > (<a href="#"
+		      > (<a href="#" title="Control.Arrow"
 		      >ArrowZero</a
-		      > a, <a href="#"
+		      > a, <a href="#" title="Control.Arrow"
 		      >ArrowPlus</a
-		      > a) =&gt; <a href="#"
+		      > a) =&gt; <a href="#" title="Control.Applicative"
 		      >Alternative</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
 		      > a b)</span
 		    ></td
@@ -334,7 +336,7 @@
 			><p class="src"
 			><a href="#"
 			  >empty</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -342,11 +344,11 @@
 			><p class="src"
 			><a href="#"
 			  >(&lt;|&gt;)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -354,9 +356,9 @@
 			><p class="src"
 			><a href="#"
 			  >some</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b [a0] <a href="#" class="selflink"
 			  >#</a
@@ -364,9 +366,9 @@
 			><p class="src"
 			><a href="#"
 			  >many</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b a0 -&gt; <a href="#"
+			  > a b a0 -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b [a0] <a href="#" class="selflink"
 			  >#</a
@@ -380,9 +382,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:WrappedArrow:Generic:5"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="GHC.Generics"
 		      >Generic</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
 		      > a b c)</span
 		    ></td
@@ -400,13 +402,13 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="GHC.Generics"
 			  >Rep</a
-			  > (<a href="#"
+			  > (<a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b c) :: <a href="#"
+			  > a b c) :: <a href="#" title="Data.Kind"
 			  >*</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -418,11 +420,11 @@
 			><p class="src"
 			><a href="#"
 			  >from</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b c -&gt; <a href="#"
+			  > a b c -&gt; <a href="#" title="GHC.Generics"
 			  >Rep</a
-			  > (<a href="#"
+			  > (<a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b c) x <a href="#" class="selflink"
 			  >#</a
@@ -430,11 +432,11 @@
 			><p class="src"
 			><a href="#"
 			  >to</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="GHC.Generics"
 			  >Rep</a
-			  > (<a href="#"
+			  > (<a href="#" title="Bug548"
 			  >WrappedArrow</a
-			  > a b c) x -&gt; <a href="#"
+			  > a b c) x -&gt; <a href="#" title="Bug548"
 			  >WrappedArrow</a
 			  > a b c <a href="#" class="selflink"
 			  >#</a
@@ -450,13 +452,15 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="GHC.Generics"
 		      >Rep1</a
-		      > <a href="#"
-		      >*</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
-		      > a b)</span
+		      > a b :: <a href="#" title="Data.Kind"
+		      >*</a
+		      > -&gt; <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    ></td
 		  ><td class="doc empty"
 		  ></td
@@ -469,50 +473,42 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="GHC.Generics"
 			>Rep1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="Bug548"
 			>WrappedArrow</a
-			> a b) = <a href="#"
+			> a b :: <a href="#" title="Data.Kind"
+			>*</a
+			> -&gt; <a href="#" title="Data.Kind"
+			>*</a
+			>) = <a href="#" title="GHC.Generics"
 			>D1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="GHC.Generics"
 			>MetaData</a
-			> &quot;WrappedArrow&quot; &quot;Control.Applicative&quot; &quot;base&quot; <a href="#"
+			> &quot;WrappedArrow&quot; &quot;Control.Applicative&quot; &quot;base&quot; <a href="#" title="Data.Bool"
 			>True</a
-			>) (<a href="#"
+			>) (<a href="#" title="GHC.Generics"
 			>C1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="GHC.Generics"
 			>MetaCons</a
-			> &quot;WrapArrow&quot; <a href="#"
+			> &quot;WrapArrow&quot; <a href="#" title="GHC.Generics"
 			>PrefixI</a
-			> <a href="#"
+			> <a href="#" title="Data.Bool"
 			>True</a
-			>) (<a href="#"
+			>) (<a href="#" title="GHC.Generics"
 			>S1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="GHC.Generics"
 			>MetaSel</a
-			> (<a href="#"
+			> (<a href="#" title="Data.Maybe"
 			>Just</a
-			> <a href="#"
-			>Symbol</a
-			> &quot;unwrapArrow&quot;) <a href="#"
+			> &quot;unwrapArrow&quot;) <a href="#" title="GHC.Generics"
 			>NoSourceUnpackedness</a
-			> <a href="#"
+			> <a href="#" title="GHC.Generics"
 			>NoSourceStrictness</a
-			> <a href="#"
+			> <a href="#" title="GHC.Generics"
 			>DecidedLazy</a
-			>) (<a href="#"
+			>) (<a href="#" title="GHC.Generics"
 			>Rec1</a
-			> <a href="#"
-			>*</a
 			> (a b))))</div
 		      ></details
 		    ></td
@@ -524,9 +520,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="GHC.Generics"
 		      >Rep</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug548"
 		      >WrappedArrow</a
 		      > a b c)</span
 		    ></td
@@ -541,48 +537,38 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="GHC.Generics"
 			>Rep</a
-			> (<a href="#"
+			> (<a href="#" title="Bug548"
 			>WrappedArrow</a
-			> a b c) = <a href="#"
+			> a b c) = <a href="#" title="GHC.Generics"
 			>D1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="GHC.Generics"
 			>MetaData</a
-			> &quot;WrappedArrow&quot; &quot;Control.Applicative&quot; &quot;base&quot; <a href="#"
+			> &quot;WrappedArrow&quot; &quot;Control.Applicative&quot; &quot;base&quot; <a href="#" title="Data.Bool"
 			>True</a
-			>) (<a href="#"
+			>) (<a href="#" title="GHC.Generics"
 			>C1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="GHC.Generics"
 			>MetaCons</a
-			> &quot;WrapArrow&quot; <a href="#"
+			> &quot;WrapArrow&quot; <a href="#" title="GHC.Generics"
 			>PrefixI</a
-			> <a href="#"
+			> <a href="#" title="Data.Bool"
 			>True</a
-			>) (<a href="#"
+			>) (<a href="#" title="GHC.Generics"
 			>S1</a
-			> <a href="#"
-			>*</a
-			> (<a href="#"
+			> (<a href="#" title="GHC.Generics"
 			>MetaSel</a
-			> (<a href="#"
+			> (<a href="#" title="Data.Maybe"
 			>Just</a
-			> <a href="#"
-			>Symbol</a
-			> &quot;unwrapArrow&quot;) <a href="#"
+			> &quot;unwrapArrow&quot;) <a href="#" title="GHC.Generics"
 			>NoSourceUnpackedness</a
-			> <a href="#"
+			> <a href="#" title="GHC.Generics"
 			>NoSourceStrictness</a
-			> <a href="#"
+			> <a href="#" title="GHC.Generics"
 			>DecidedLazy</a
-			>) (<a href="#"
+			>) (<a href="#" title="GHC.Generics"
 			>Rec0</a
-			> <a href="#"
-			>*</a
 			> (a b c))))</div
 		      ></details
 		    ></td

--- a/html-test/ref/Bug6.html
+++ b/html-test/ref/Bug6.html
@@ -58,7 +58,7 @@
 	      >A</a
 	      > = <a href="#"
 	      >A</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
@@ -68,15 +68,17 @@
 	      >B</a
 	      > = <a href="#"
 	      >B</a
-	      > {<ul class="subs"
-	      ><li
-		><a href="#"
-		  >b</a
-		  > :: <a href="#"
-		  >Int</a
-		  ></li
-		></ul
-	      >}</li
+	      > <a href="#" title="Data.Int"
+	      >Int</a
+	      ></li
+	    ><li class="src short"
+	    ><a href="#"
+	      >b</a
+	      > :: <a href="#" title="Bug6"
+	      >B</a
+	      > -&gt; <a href="#" title="Data.Int"
+	      >Int</a
+	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
 	      >data</span
@@ -88,13 +90,13 @@
 	      ><li
 		><a href="#"
 		  >c1</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		><li
 		><a href="#"
 		  >c2</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		></ul
@@ -106,9 +108,9 @@
 	      >D</a
 	      > = <a href="#"
 	      >D</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
@@ -118,7 +120,7 @@
 	      >E</a
 	      > = <a href="#"
 	      >E</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -148,7 +150,7 @@
 	      ><td class="src"
 		><a id="v:A" class="def"
 		  >A</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc empty"
@@ -179,32 +181,26 @@
 	      ><td class="src"
 		><a id="v:B" class="def"
 		  >B</a
+		  > <a href="#" title="Data.Int"
+		  >Int</a
 		  ></td
 		><td class="doc empty"
 		></td
 		></tr
-	      ><tr
-	      ><td colspan="2"
-		><div class="subs fields"
-		  ><p class="caption"
-		    >Fields</p
-		    ><ul
-		    ><li
-		      ><dfn class="src"
-			><a id="v:b" class="def"
-			  >b</a
-			  > :: <a href="#"
-			  >Int</a
-			  ></dfn
-			><div class="doc empty"
-			></div
-			></li
-		      ></ul
-		    ></div
-		  ></td
-		></tr
 	      ></table
 	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:b" class="def"
+	    >b</a
+	    > :: <a href="#" title="Bug6"
+	    >B</a
+	    > -&gt; <a href="#" title="Data.Int"
+	    >Int</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
 	  ></div
 	><div class="top"
 	><p class="src"
@@ -241,7 +237,7 @@
 		      ><dfn class="src"
 			><a id="v:c1" class="def"
 			  >c1</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc empty"
@@ -251,7 +247,7 @@
 		      ><dfn class="src"
 			><a id="v:c2" class="def"
 			  >c2</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc empty"
@@ -286,9 +282,9 @@
 	      ><td class="src"
 		><a id="v:D" class="def"
 		  >D</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc empty"
@@ -318,7 +314,7 @@
 	      ><td class="src"
 		><a id="v:E" class="def"
 		  >E</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc empty"

--- a/html-test/ref/Bug613.html
+++ b/html-test/ref/Bug613.html
@@ -82,7 +82,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Bug613"
 	      >fmap</a
 	      ></p
 	    ></div
@@ -106,9 +106,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Functor:Functor:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug613"
 		      >Functor</a
-		      > (<a href="#"
+		      > (<a href="#" title="Data.Either"
 		      >Either</a
 		      > a)</span
 		    > <a href="#" class="selflink"
@@ -128,9 +128,9 @@
 			><p class="src"
 			><a href="#"
 			  >fmap</a
-			  > :: (a0 -&gt; b) -&gt; <a href="#"
+			  > :: (a0 -&gt; b) -&gt; <a href="#" title="Data.Either"
 			  >Either</a
-			  > a a0 -&gt; <a href="#"
+			  > a a0 -&gt; <a href="#" title="Data.Either"
 			  >Either</a
 			  > a b <a href="#" class="selflink"
 			  >#</a
@@ -144,9 +144,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Functor:Functor:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug613"
 		      >Functor</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug613"
 		      >ThreeVars</a
 		      > a0 a)</span
 		    > <a href="#" class="selflink"
@@ -166,9 +166,9 @@
 			><p class="src"
 			><a href="#"
 			  >fmap</a
-			  > :: (a1 -&gt; b) -&gt; <a href="#"
+			  > :: (a1 -&gt; b) -&gt; <a href="#" title="Bug613"
 			  >ThreeVars</a
-			  > a0 a a1 -&gt; <a href="#"
+			  > a0 a a1 -&gt; <a href="#" title="Bug613"
 			  >ThreeVars</a
 			  > a0 a b <a href="#" class="selflink"
 			  >#</a
@@ -218,9 +218,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:ThreeVars:Functor:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug613"
 		      >Functor</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug613"
 		      >ThreeVars</a
 		      > a0 a)</span
 		    > <a href="#" class="selflink"
@@ -240,9 +240,9 @@
 			><p class="src"
 			><a href="#"
 			  >fmap</a
-			  > :: (a1 -&gt; b) -&gt; <a href="#"
+			  > :: (a1 -&gt; b) -&gt; <a href="#" title="Bug613"
 			  >ThreeVars</a
-			  > a0 a a1 -&gt; <a href="#"
+			  > a0 a a1 -&gt; <a href="#" title="Bug613"
 			  >ThreeVars</a
 			  > a0 a b <a href="#" class="selflink"
 			  >#</a

--- a/html-test/ref/Bug647.html
+++ b/html-test/ref/Bug647.html
@@ -56,7 +56,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Bug647"
 	      >f</a
 	      ></p
 	    ></div

--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -74,9 +74,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Bar:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug679"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug679"
 		      >Bar</a
 		      > a)</span
 		    > <a href="#" class="selflink"
@@ -96,9 +96,9 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug679"
 			  >Bar</a
-			  > a -&gt; <a href="#"
+			  > a -&gt; <a href="#" title="Bug679"
 			  >Bar</a
 			  > a <a href="#" class="selflink"
 			  >#</a
@@ -126,7 +126,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Bug679"
 	      >foo</a
 	      ></p
 	    ></div
@@ -150,9 +150,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug679"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Bug679"
 		      >Bar</a
 		      > a)</span
 		    > <a href="#" class="selflink"
@@ -172,9 +172,9 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Bug679"
 			  >Bar</a
-			  > a -&gt; <a href="#"
+			  > a -&gt; <a href="#" title="Bug679"
 			  >Bar</a
 			  > a <a href="#" class="selflink"
 			  >#</a

--- a/html-test/ref/Bug7.html
+++ b/html-test/ref/Bug7.html
@@ -109,11 +109,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Foo:Bar:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug7"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="Bug7"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="Bug7"
 		      >Foo</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -159,11 +159,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Bug7"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="Bug7"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="Bug7"
 		      >Foo</a
 		      ></span
 		    > <a href="#" class="selflink"

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -58,9 +58,9 @@
 	      ><td class="src"
 		><a id="v:Type" class="def"
 		  >Type</a
-		  > (<a href="#"
+		  > (<a href="#" title="Bug8"
 		  >Typ</a
-		  >, [<a href="#"
+		  >, [<a href="#" title="Bug8"
 		  >Typ</a
 		  >])</td
 		><td class="doc empty"
@@ -70,9 +70,9 @@
 	      ><td class="src"
 		><a id="v:TFree" class="def"
 		  >TFree</a
-		  > (<a href="#"
+		  > (<a href="#" title="Bug8"
 		  >Typ</a
-		  >, [<a href="#"
+		  >, [<a href="#" title="Bug8"
 		  >Typ</a
 		  >])</td
 		><td class="doc empty"
@@ -85,7 +85,7 @@
 	><p class="src"
 	  ><a id="v:-45--45--62-" class="def"
 	    >(--&gt;)</a
-	    > :: p1 -&gt; p2 -&gt; <a href="#"
+	    > :: p1 -&gt; p2 -&gt; <a href="#" title="Bug8"
 	    >Typ</a
 	    > <span class="fixity"
 	    >infix 9</span
@@ -99,11 +99,11 @@
 	><p class="src"
 	  ><a id="v:-45--45--45--62-" class="def"
 	    >(---&gt;)</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Foldable"
 	    >Foldable</a
-	    > t0 =&gt; t0 t -&gt; <a href="#"
+	    > t0 =&gt; t0 t -&gt; <a href="#" title="Bug8"
 	    >Typ</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Bug8"
 	    >Typ</a
 	    > <span class="fixity"
 	    >infix 9</span

--- a/html-test/ref/Bug85.html
+++ b/html-test/ref/Bug85.html
@@ -47,13 +47,13 @@
 	    >data</span
 	    > <a id="t:Foo" class="def"
 	    >Foo</a
-	    > :: (<a href="#"
+	    > :: (<a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    >) -&gt; <a href="#"
+	    >) -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -68,7 +68,7 @@
 	      ><td class="src"
 		><a id="v:Bar" class="def"
 		  >Bar</a
-		  > :: f x -&gt; <a href="#"
+		  > :: f x -&gt; <a href="#" title="Bug85"
 		  >Foo</a
 		  > f (f x)</td
 		><td class="doc empty"
@@ -83,7 +83,7 @@
 	    >data</span
 	    > <a id="t:Baz" class="def"
 	    >Baz</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -98,7 +98,7 @@
 	      ><td class="src"
 		><a id="v:Baz-39-" class="def"
 		  >Baz'</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Bug85"
 		  >Baz</a
 		  ></td
 		><td class="doc empty"
@@ -126,7 +126,7 @@
 	      ><td class="src"
 		><a id="v:Quux" class="def"
 		  >Quux</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Bug85"
 		  >Qux</a
 		  ></td
 		><td class="doc empty"

--- a/html-test/ref/BugDeprecated.html
+++ b/html-test/ref/BugDeprecated.html
@@ -46,37 +46,37 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >bar</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >baz</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >one</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >two</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >three</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -89,7 +89,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -105,7 +105,7 @@
 	><p class="src"
 	  ><a id="v:bar" class="def"
 	    >bar</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -121,7 +121,7 @@
 	><p class="src"
 	  ><a id="v:baz" class="def"
 	    >baz</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -137,7 +137,7 @@
 	><p class="src"
 	  ><a id="v:one" class="def"
 	    >one</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -155,7 +155,7 @@
 	><p class="src"
 	  ><a id="v:two" class="def"
 	    >two</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -171,7 +171,7 @@
 	><p class="src"
 	  ><a id="v:three" class="def"
 	    >three</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/BugExportHeadings.html
+++ b/html-test/ref/BugExportHeadings.html
@@ -76,37 +76,37 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >bar</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >baz</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >one</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >two</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >three</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -121,7 +121,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -135,7 +135,7 @@
 	><p class="src"
 	  ><a id="v:bar" class="def"
 	    >bar</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -149,7 +149,7 @@
 	><p class="src"
 	  ><a id="v:baz" class="def"
 	    >baz</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -163,7 +163,7 @@
 	><p class="src"
 	  ><a id="v:one" class="def"
 	    >one</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -183,7 +183,7 @@
 	><p class="src"
 	  ><a id="v:two" class="def"
 	    >two</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -203,7 +203,7 @@
 	><p class="src"
 	  ><a id="v:three" class="def"
 	    >three</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Bugs.html
+++ b/html-test/ref/Bugs.html
@@ -58,7 +58,7 @@
 	      ><td class="src"
 		><a id="v:A" class="def"
 		  >A</a
-		  > a (a -&gt; <a href="#"
+		  > a (a -&gt; <a href="#" title="Data.Int"
 		  >Int</a
 		  >)</td
 		><td class="doc empty"

--- a/html-test/ref/BundledPatterns.html
+++ b/html-test/ref/BundledPatterns.html
@@ -48,11 +48,11 @@
 	      >data</span
 	      > <a href="#"
 	      >Vec</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
 	      > <span class="keyword"
 	      >where</span
@@ -60,7 +60,7 @@
 	      ><li
 		><a href="#"
 		  >Nil</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="BundledPatterns"
 		  >Vec</a
 		  > 0 a</li
 		><li
@@ -68,11 +68,11 @@
 		  >pattern</span
 		  > <a href="#"
 		  >(:&gt;)</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns"
 		  >Vec</a
-		  > n a -&gt; <a href="#"
+		  > n a -&gt; <a href="#" title="BundledPatterns"
 		  >Vec</a
-		  > (n <a href="#"
+		  > (n <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a</li
 		></ul
@@ -82,11 +82,11 @@
 	      >data</span
 	      > <a href="#"
 	      >RTree</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
 	      > <span class="keyword"
 	      >where</span
@@ -96,7 +96,7 @@
 		  >pattern</span
 		  > <a href="#"
 		  >LR</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns"
 		  >RTree</a
 		  > 0 a</li
 		><li
@@ -104,13 +104,13 @@
 		  >pattern</span
 		  > <a href="#"
 		  >BR</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="BundledPatterns"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns"
 		  >RTree</a
-		  > (d <a href="#"
+		  > (d <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a</li
 		></ul
@@ -127,11 +127,11 @@
 	    >data</span
 	    > <a id="t:Vec" class="def"
 	    >Vec</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -146,7 +146,7 @@
 	      >Lists with their length encoded in their type</li
 	      ><li
 	      ><code
-		><a href="#"
+		><a href="#" title="BundledPatterns"
 		  >Vec</a
 		  ></code
 		>tor elements have an <strong
@@ -154,7 +154,7 @@
 		> subscript starting from 0 and
    ending at <code
 		><code
-		  ><a href="#"
+		  ><a href="#" title="Data.Foldable"
 		    >length</a
 		    ></code
 		  > - 1</code
@@ -169,7 +169,7 @@
 	      ><td class="src"
 		><a id="v:Nil" class="def"
 		  >Nil</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="BundledPatterns"
 		  >Vec</a
 		  > 0 a</td
 		><td class="doc empty"
@@ -187,11 +187,11 @@
 		  >pattern</span
 		  > <a id="v::-62-" class="def"
 		  >(:&gt;)</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns"
 		  >Vec</a
-		  > n a -&gt; <a href="#"
+		  > n a -&gt; <a href="#" title="BundledPatterns"
 		  >Vec</a
-		  > (n <a href="#"
+		  > (n <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a <span class="fixity"
 		  >infixr 5</span
@@ -293,11 +293,11 @@
 	    >data</span
 	    > <a id="t:RTree" class="def"
 	    >RTree</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -328,7 +328,7 @@
 		  >pattern</span
 		  > <a id="v:LR" class="def"
 		  >LR</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns"
 		  >RTree</a
 		  > 0 a</td
 		><td class="doc"
@@ -394,13 +394,13 @@
 		  >pattern</span
 		  > <a id="v:BR" class="def"
 		  >BR</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="BundledPatterns"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns"
 		  >RTree</a
-		  > (d <a href="#"
+		  > (d <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a</td
 		><td class="doc"

--- a/html-test/ref/BundledPatterns2.html
+++ b/html-test/ref/BundledPatterns2.html
@@ -48,11 +48,11 @@
 	      >data</span
 	      > <a href="#"
 	      >Vec</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
 	      > <span class="keyword"
 	      >where</span
@@ -61,22 +61,22 @@
 		><span class="keyword"
 		  >pattern</span
 		  > <a href="#"
-		  >Empty</a
-		  > :: <a href="#"
+		  >(:&gt;)</a
+		  > :: a -&gt; <a href="#" title="BundledPatterns2"
 		  >Vec</a
-		  > 0 a</li
+		  > n a -&gt; <a href="#" title="BundledPatterns2"
+		  >Vec</a
+		  > (n <a href="#" title="Bug310"
+		  >+</a
+		  > 1) a</li
 		><li
 		><span class="keyword"
 		  >pattern</span
 		  > <a href="#"
-		  >(:&gt;)</a
-		  > :: a -&gt; <a href="#"
+		  >Empty</a
+		  > :: <a href="#" title="BundledPatterns2"
 		  >Vec</a
-		  > n a -&gt; <a href="#"
-		  >Vec</a
-		  > (n <a href="#"
-		  >+</a
-		  > 1) a</li
+		  > 0 a</li
 		></ul
 	      ></li
 	    ><li class="src short"
@@ -84,11 +84,11 @@
 	      >data</span
 	      > <a href="#"
 	      >RTree</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="GHC.TypeNats"
 	      >Nat</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
 	      > <span class="keyword"
 	      >where</span
@@ -98,7 +98,7 @@
 		  >pattern</span
 		  > <a href="#"
 		  >LR</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns2"
 		  >RTree</a
 		  > 0 a</li
 		><li
@@ -106,13 +106,13 @@
 		  >pattern</span
 		  > <a href="#"
 		  >BR</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="BundledPatterns2"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns2"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns2"
 		  >RTree</a
-		  > (d <a href="#"
+		  > (d <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a</li
 		></ul
@@ -129,11 +129,11 @@
 	    >data</span
 	    > <a id="t:Vec" class="def"
 	    >Vec</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -148,7 +148,7 @@
 	      >Lists with their length encoded in their type</li
 	      ><li
 	      ><code
-		><a href="#"
+		><a href="#" title="BundledPatterns2"
 		  >Vec</a
 		  ></code
 		>tor elements have an <strong
@@ -156,7 +156,7 @@
 		> subscript starting from 0 and
    ending at <code
 		><code
-		  ><a href="#"
+		  ><a href="#" title="Data.Foldable"
 		    >length</a
 		    ></code
 		  > - 1</code
@@ -171,25 +171,13 @@
 	      ><td class="src"
 		><span class="keyword"
 		  >pattern</span
-		  > <a id="v:Empty" class="def"
-		  >Empty</a
-		  > :: <a href="#"
-		  >Vec</a
-		  > 0 a</td
-		><td class="doc empty"
-		></td
-		></tr
-	      ><tr
-	      ><td class="src"
-		><span class="keyword"
-		  >pattern</span
 		  > <a id="v::-62-" class="def"
 		  >(:&gt;)</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns2"
 		  >Vec</a
-		  > n a -&gt; <a href="#"
+		  > n a -&gt; <a href="#" title="BundledPatterns2"
 		  >Vec</a
-		  > (n <a href="#"
+		  > (n <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a <span class="fixity"
 		  >infixr 5</span
@@ -282,6 +270,18 @@
 </pre
 		  ></td
 		></tr
+	      ><tr
+	      ><td class="src"
+		><span class="keyword"
+		  >pattern</span
+		  > <a id="v:Empty" class="def"
+		  >Empty</a
+		  > :: <a href="#" title="BundledPatterns2"
+		  >Vec</a
+		  > 0 a</td
+		><td class="doc empty"
+		></td
+		></tr
 	      ></table
 	    ></div
 	  ></div
@@ -291,11 +291,11 @@
 	    >data</span
 	    > <a id="t:RTree" class="def"
 	    >RTree</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="GHC.TypeNats"
 	    >Nat</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -326,7 +326,7 @@
 		  >pattern</span
 		  > <a id="v:LR" class="def"
 		  >LR</a
-		  > :: a -&gt; <a href="#"
+		  > :: a -&gt; <a href="#" title="BundledPatterns2"
 		  >RTree</a
 		  > 0 a</td
 		><td class="doc"
@@ -392,13 +392,13 @@
 		  >pattern</span
 		  > <a id="v:BR" class="def"
 		  >BR</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="BundledPatterns2"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns2"
 		  >RTree</a
-		  > d a -&gt; <a href="#"
+		  > d a -&gt; <a href="#" title="BundledPatterns2"
 		  >RTree</a
-		  > (d <a href="#"
+		  > (d <a href="#" title="Bug310"
 		  >+</a
 		  > 1) a</td
 		><td class="doc"

--- a/html-test/ref/ConstructorPatternExport.html
+++ b/html-test/ref/ConstructorPatternExport.html
@@ -47,7 +47,7 @@
 	    >pattern</span
 	    > <a id="v:FooCons" class="def"
 	    >FooCons</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.String"
 	    >String</a
 	    > -&gt; a -&gt; Foo a <a href="#" class="selflink"
 	    >#</a
@@ -59,9 +59,9 @@
 	    >pattern</span
 	    > <a id="v:MyRecCons" class="def"
 	    >MyRecCons</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Bool"
 	    >Bool</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Int"
 	    >Int</a
 	    > -&gt; MyRec <a href="#" class="selflink"
 	    >#</a
@@ -73,7 +73,7 @@
 	    >pattern</span
 	    > <a id="v::-43-" class="def"
 	    >(:+)</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.String"
 	    >String</a
 	    > -&gt; a -&gt; MyInfix a <a href="#" class="selflink"
 	    >#</a
@@ -85,7 +85,7 @@
 	    >pattern</span
 	    > <a id="v:BlubCons" class="def"
 	    >BlubCons</a
-	    > :: () =&gt; <a href="#"
+	    > :: () =&gt; <a href="#" title="Text.Show"
 	    >Show</a
 	    > b =&gt; b -&gt; Blub <a href="#" class="selflink"
 	    >#</a
@@ -99,13 +99,13 @@
 	    >MyGADTCons</a
 	    > :: () =&gt; <span class="keyword"
 	    >forall</span
-	    > a. <a href="#"
+	    > a. <a href="#" title="Data.Eq"
 	    >Eq</a
-	    > a =&gt; a -&gt; <a href="#"
+	    > a =&gt; a -&gt; <a href="#" title="Data.Int"
 	    >Int</a
-	    > -&gt; MyGADT (<a href="#"
+	    > -&gt; MyGADT (<a href="#" title="Data.Maybe"
 	    >Maybe</a
-	    > <a href="#"
+	    > <a href="#" title="Data.String"
 	    >String</a
 	    >) <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -92,7 +92,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="DeprecatedClass"
 	      >foo</a
 	      ></p
 	    ></div
@@ -136,7 +136,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="DeprecatedClass"
 	      >bar</a
 	      ></p
 	    ></div

--- a/html-test/ref/DeprecatedFunction.html
+++ b/html-test/ref/DeprecatedFunction.html
@@ -46,13 +46,13 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >bar</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -65,7 +65,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -74,7 +74,7 @@
 	  ><div class="warning"
 	    ><p
 	      >Deprecated: use <code
-		><a href="#"
+		><a href="#" title="DeprecatedFunction"
 		  >bar</a
 		  ></code
 		> instead</p
@@ -87,7 +87,7 @@
 	><p class="src"
 	  ><a id="v:bar" class="def"
 	    >bar</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedFunction2.html
+++ b/html-test/ref/DeprecatedFunction2.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedFunction3.html
+++ b/html-test/ref/DeprecatedFunction3.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedModule.html
+++ b/html-test/ref/DeprecatedModule.html
@@ -61,7 +61,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedModule2.html
+++ b/html-test/ref/DeprecatedModule2.html
@@ -55,7 +55,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedNewtype.html
+++ b/html-test/ref/DeprecatedNewtype.html
@@ -50,7 +50,7 @@
 	      >SomeNewType</a
 	      > = <a href="#"
 	      >SomeNewTypeConst</a
-	      > <a href="#"
+	      > <a href="#" title="Data.String"
 	      >String</a
 	      ></li
 	    ><li class="src short"
@@ -60,7 +60,7 @@
 	      >SomeOtherNewType</a
 	      > = <a href="#"
 	      >SomeOtherNewTypeConst</a
-	      > <a href="#"
+	      > <a href="#" title="Data.String"
 	      >String</a
 	      ></li
 	    ></ul
@@ -94,7 +94,7 @@
 	      ><td class="src"
 		><a id="v:SomeNewTypeConst" class="def"
 		  >SomeNewTypeConst</a
-		  > <a href="#"
+		  > <a href="#" title="Data.String"
 		  >String</a
 		  ></td
 		><td class="doc"
@@ -132,7 +132,7 @@
 	      ><td class="src"
 		><a id="v:SomeOtherNewTypeConst" class="def"
 		  >SomeOtherNewTypeConst</a
-		  > <a href="#"
+		  > <a href="#" title="Data.String"
 		  >String</a
 		  ></td
 		><td class="doc"

--- a/html-test/ref/DeprecatedReExport.html
+++ b/html-test/ref/DeprecatedReExport.html
@@ -72,7 +72,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -87,7 +87,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -96,7 +96,7 @@
 	  ><div class="warning"
 	    ><p
 	      >Deprecated: use <code
-		><a href="#"
+		><a href="#" title="DeprecatedFunction"
 		  >bar</a
 		  ></code
 		> instead</p

--- a/html-test/ref/DeprecatedRecord.html
+++ b/html-test/ref/DeprecatedRecord.html
@@ -54,13 +54,13 @@
 	      ><li
 		><a href="#"
 		  >fooName</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.String"
 		  >String</a
 		  ></li
 		><li
 		><a href="#"
 		  >fooValue</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		></ul
@@ -106,7 +106,7 @@
 		      ><dfn class="src"
 			><a id="v:fooName" class="def"
 			  >fooName</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.String"
 			  >String</a
 			  ></dfn
 			><div class="doc"
@@ -118,7 +118,7 @@
 		      ><dfn class="src"
 			><a id="v:fooValue" class="def"
 			  >fooValue</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"

--- a/html-test/ref/DeprecatedTypeFamily.html
+++ b/html-test/ref/DeprecatedTypeFamily.html
@@ -48,9 +48,9 @@
 	      >data family</span
 	      > <a href="#"
 	      >SomeTypeFamily</a
-	      > k :: <a href="#"
+	      > k :: <a href="#" title="Data.Kind"
 	      >*</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
 	      ></li
 	    ><li class="src short"
@@ -58,9 +58,9 @@
 	      >data family</span
 	      > <a href="#"
 	      >SomeOtherTypeFamily</a
-	      > k :: <a href="#"
+	      > k :: <a href="#" title="Data.Kind"
 	      >*</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Kind"
 	      >*</a
 	      ></li
 	    ></ul
@@ -75,9 +75,9 @@
 	    >data family</span
 	    > <a id="t:SomeTypeFamily" class="def"
 	    >SomeTypeFamily</a
-	    > k :: <a href="#"
+	    > k :: <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -97,9 +97,9 @@
 	    >data family</span
 	    > <a id="t:SomeOtherTypeFamily" class="def"
 	    >SomeOtherTypeFamily</a
-	    > k :: <a href="#"
+	    > k :: <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/DeprecatedTypeSynonym.html
+++ b/html-test/ref/DeprecatedTypeSynonym.html
@@ -48,7 +48,7 @@
 	      >type</span
 	      > <a href="#"
 	      >TypeSyn</a
-	      > = <a href="#"
+	      > = <a href="#" title="Data.String"
 	      >String</a
 	      ></li
 	    ><li class="src short"
@@ -56,7 +56,7 @@
 	      >type</span
 	      > <a href="#"
 	      >OtherTypeSyn</a
-	      > = <a href="#"
+	      > = <a href="#" title="Data.String"
 	      >String</a
 	      ></li
 	    ></ul
@@ -71,7 +71,7 @@
 	    >type</span
 	    > <a id="t:TypeSyn" class="def"
 	    >TypeSyn</a
-	    > = <a href="#"
+	    > = <a href="#" title="Data.String"
 	    >String</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -91,7 +91,7 @@
 	    >type</span
 	    > <a id="t:OtherTypeSyn" class="def"
 	    >OtherTypeSyn</a
-	    > = <a href="#"
+	    > = <a href="#" title="Data.String"
 	    >String</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Examples.html
+++ b/html-test/ref/Examples.html
@@ -46,9 +46,9 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >fib</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ></ul
@@ -61,9 +61,9 @@
 	><p class="src"
 	  ><a id="v:fib" class="def"
 	    >fib</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -71,7 +71,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Fibonacci number of given <code
-	      ><a href="#"
+	      ><a href="#" title="Prelude"
 		>Integer</a
 		></code
 	      >.</p

--- a/html-test/ref/FunArgs.html
+++ b/html-test/ref/FunArgs.html
@@ -54,7 +54,7 @@
 	    ><table
 	    ><tr
 	      ><td class="src"
-		>:: <a href="#"
+		>:: <a href="#" title="Data.Ord"
 		  >Ord</a
 		  > a</td
 		><td class="doc empty"
@@ -62,7 +62,7 @@
 		></tr
 	      ><tr
 	      ><td class="src"
-		>=&gt; <a href="#"
+		>=&gt; <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc"
@@ -80,7 +80,7 @@
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="Data.Bool"
 		  >Bool</a
 		  ></td
 		><td class="doc"
@@ -214,7 +214,7 @@
 	      ><td class="src"
 		>:: <span class="keyword"
 		  >forall</span
-		  > (b :: ()). d ~ <a href="#"
+		  > (b :: ()). d ~ <a href="#" title="GHC.Tuple"
 		  >()</a
 		  ></td
 		><td class="doc empty"

--- a/html-test/ref/GADTRecords.html
+++ b/html-test/ref/GADTRecords.html
@@ -54,33 +54,33 @@
 	      ><li
 		><a href="#"
 		  >C1</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="GADTRecords"
 		  >H1</a
 		  > a b</li
 		><li
 		><a href="#"
 		  >C2</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Ord"
 		  >Ord</a
-		  > a =&gt; [a] -&gt; <a href="#"
+		  > a =&gt; [a] -&gt; <a href="#" title="GADTRecords"
 		  >H1</a
 		  > a a</li
 		><li
 		><a href="#"
 		  >C3</a
-		  > :: {..} -&gt; <a href="#"
+		  > :: {..} -&gt; <a href="#" title="GADTRecords"
 		  >H1</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		><li
 		><a href="#"
 		  >C4</a
-		  > :: {..} -&gt; <a href="#"
+		  > :: {..} -&gt; <a href="#" title="GADTRecords"
 		  >H1</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  > a</li
 		></ul
@@ -114,7 +114,7 @@
 	      ><td class="src"
 		><a id="v:C1" class="def"
 		  >C1</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="GADTRecords"
 		  >H1</a
 		  > a b</td
 		><td class="doc empty"
@@ -124,9 +124,9 @@
 	      ><td class="src"
 		><a id="v:C2" class="def"
 		  >C2</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Ord"
 		  >Ord</a
-		  > a =&gt; [a] -&gt; <a href="#"
+		  > a =&gt; [a] -&gt; <a href="#" title="GADTRecords"
 		  >H1</a
 		  > a a</td
 		><td class="doc empty"
@@ -136,11 +136,11 @@
 	      ><td class="src"
 		><a id="v:C3" class="def"
 		  >C3</a
-		  > :: {..} -&gt; <a href="#"
+		  > :: {..} -&gt; <a href="#" title="GADTRecords"
 		  >H1</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc empty"
@@ -156,7 +156,7 @@
 		      ><dfn class="src"
 			><a id="v:field" class="def"
 			  >field</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"
@@ -172,9 +172,9 @@
 	      ><td class="src"
 		><a id="v:C4" class="def"
 		  >C4</a
-		  > :: {..} -&gt; <a href="#"
+		  > :: {..} -&gt; <a href="#" title="GADTRecords"
 		  >H1</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  > a</td
 		><td class="doc empty"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -87,35 +87,35 @@
 	    ><li class="src short"
 	    ><a href="#"
 	      >new</a
-	      > :: (<a href="#"
+	      > :: (<a href="#" title="Data.Eq"
 	      >Eq</a
-	      > key, <a href="#"
+	      > key, <a href="#" title="Hash"
 	      >Hash</a
-	      > key) =&gt; <a href="#"
+	      > key) =&gt; <a href="#" title="Data.Int"
 	      >Int</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="System.IO"
 	      >IO</a
-	      > (<a href="#"
+	      > (<a href="#" title="Hash"
 	      >HashTable</a
 	      > key val)</li
 	    ><li class="src short"
 	    ><a href="#"
 	      >insert</a
-	      > :: (<a href="#"
+	      > :: (<a href="#" title="Data.Eq"
 	      >Eq</a
-	      > key, <a href="#"
+	      > key, <a href="#" title="Hash"
 	      >Hash</a
-	      > key) =&gt; key -&gt; val -&gt; <a href="#"
+	      > key) =&gt; key -&gt; val -&gt; <a href="#" title="System.IO"
 	      >IO</a
 	      > ()</li
 	    ><li class="src short"
 	    ><a href="#"
 	      >lookup</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Hash"
 	      >Hash</a
-	      > key =&gt; key -&gt; <a href="#"
+	      > key =&gt; key -&gt; <a href="#" title="System.IO"
 	      >IO</a
-	      > (<a href="#"
+	      > (<a href="#" title="Data.Maybe"
 	      >Maybe</a
 	      > val)</li
 	    ><li class="src short"
@@ -157,7 +157,7 @@
  The type <code
 	      >key</code
 	      > should be an instance of <code
-	      ><a href="#"
+	      ><a href="#" title="Data.Eq"
 		>Eq</a
 		></code
 	      >.</p
@@ -173,15 +173,15 @@
 	><p class="src"
 	  ><a id="v:new" class="def"
 	    >new</a
-	    > :: (<a href="#"
+	    > :: (<a href="#" title="Data.Eq"
 	    >Eq</a
-	    > key, <a href="#"
+	    > key, <a href="#" title="Hash"
 	    >Hash</a
-	    > key) =&gt; <a href="#"
+	    > key) =&gt; <a href="#" title="Data.Int"
 	    >Int</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="System.IO"
 	    >IO</a
-	    > (<a href="#"
+	    > (<a href="#" title="Hash"
 	    >HashTable</a
 	    > key val) <a href="#" class="selflink"
 	    >#</a
@@ -195,11 +195,11 @@
 	><p class="src"
 	  ><a id="v:insert" class="def"
 	    >insert</a
-	    > :: (<a href="#"
+	    > :: (<a href="#" title="Data.Eq"
 	    >Eq</a
-	    > key, <a href="#"
+	    > key, <a href="#" title="Hash"
 	    >Hash</a
-	    > key) =&gt; key -&gt; val -&gt; <a href="#"
+	    > key) =&gt; key -&gt; val -&gt; <a href="#" title="System.IO"
 	    >IO</a
 	    > () <a href="#" class="selflink"
 	    >#</a
@@ -213,11 +213,11 @@
 	><p class="src"
 	  ><a id="v:lookup" class="def"
 	    >lookup</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Hash"
 	    >Hash</a
-	    > key =&gt; key -&gt; <a href="#"
+	    > key =&gt; key -&gt; <a href="#" title="System.IO"
 	    >IO</a
-	    > (<a href="#"
+	    > (<a href="#" title="Data.Maybe"
 	    >Maybe</a
 	    > val) <a href="#" class="selflink"
 	    >#</a
@@ -226,13 +226,13 @@
 	  ><p
 	    >Looks up a key in the hash table, returns <code
 	      ><code
-		><a href="#"
+		><a href="#" title="Data.Maybe"
 		  >Just</a
 		  ></code
 		> val</code
 	      > if the key
  was found, or <code
-	      ><a href="#"
+	      ><a href="#" title="Data.Maybe"
 		>Nothing</a
 		></code
 	      > otherwise.</p
@@ -263,7 +263,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Hash"
 	      >hash</a
 	      ></p
 	    ></div
@@ -273,7 +273,7 @@
 	    ><p class="src"
 	    ><a id="v:hash" class="def"
 	      >hash</a
-	      > :: a -&gt; <a href="#"
+	      > :: a -&gt; <a href="#" title="Data.Int"
 	      >Int</a
 	      > <a href="#" class="selflink"
 	      >#</a
@@ -283,7 +283,7 @@
 	      >hashes the value of type <code
 		>a</code
 		> into an <code
-		><a href="#"
+		><a href="#" title="Data.Int"
 		  >Int</a
 		  ></code
 		></p
@@ -299,9 +299,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Hash:Hash:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Hash"
 		      >Hash</a
-		      > <a href="#"
+		      > <a href="#" title="Prelude"
 		      >Float</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -321,9 +321,9 @@
 			><p class="src"
 			><a href="#"
 			  >hash</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Prelude"
 			  >Float</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Int"
 			  >Int</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -337,9 +337,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Hash:Hash:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Hash"
 		      >Hash</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -359,9 +359,9 @@
 			><p class="src"
 			><a href="#"
 			  >hash</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Int"
 			  >Int</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -375,11 +375,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Hash:Hash:3"
 		      ></span
-		      > (<a href="#"
+		      > (<a href="#" title="Hash"
 		      >Hash</a
-		      > a, <a href="#"
+		      > a, <a href="#" title="Hash"
 		      >Hash</a
-		      > b) =&gt; <a href="#"
+		      > b) =&gt; <a href="#" title="Hash"
 		      >Hash</a
 		      > (a, b)</span
 		    > <a href="#" class="selflink"
@@ -399,7 +399,7 @@
 			><p class="src"
 			><a href="#"
 			  >hash</a
-			  > :: (a, b) -&gt; <a href="#"
+			  > :: (a, b) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
 			  > <a href="#" class="selflink"
 			  >#</a

--- a/html-test/ref/HiddenInstances.html
+++ b/html-test/ref/HiddenInstances.html
@@ -84,9 +84,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:VisibleClass:VisibleClass:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstances"
 		      >VisibleClass</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -110,9 +110,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:VisibleClass:VisibleClass:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstances"
 		      >VisibleClass</a
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstances"
 		      >VisibleData</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -158,9 +158,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:VisibleData:Num:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Prelude"
 		      >Num</a
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstances"
 		      >VisibleData</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -182,11 +182,11 @@
 			><p class="src"
 			><a href="#"
 			  >(+)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -194,11 +194,11 @@
 			><p class="src"
 			><a href="#"
 			  >(-)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -206,11 +206,11 @@
 			><p class="src"
 			><a href="#"
 			  >(*)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -218,9 +218,9 @@
 			><p class="src"
 			><a href="#"
 			  >negate</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -228,9 +228,9 @@
 			><p class="src"
 			><a href="#"
 			  >abs</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -238,9 +238,9 @@
 			><p class="src"
 			><a href="#"
 			  >signum</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="HiddenInstances"
 			  >VisibleData</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -248,9 +248,9 @@
 			><p class="src"
 			><a href="#"
 			  >fromInteger</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Prelude"
 			  >Integer</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="HiddenInstances"
 			  >VisibleData</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -264,9 +264,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:VisibleData:VisibleClass:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstances"
 		      >VisibleClass</a
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstances"
 		      >VisibleData</a
 		      ></span
 		    > <a href="#" class="selflink"

--- a/html-test/ref/HiddenInstancesB.html
+++ b/html-test/ref/HiddenInstancesB.html
@@ -84,9 +84,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstancesB"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstancesB"
 		      >Bar</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -132,9 +132,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Bar:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstancesB"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="HiddenInstancesB"
 		      >Bar</a
 		      ></span
 		    > <a href="#" class="selflink"

--- a/html-test/ref/Hyperlinks.html
+++ b/html-test/ref/Hyperlinks.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/ImplicitParams.html
+++ b/html-test/ref/ImplicitParams.html
@@ -69,9 +69,9 @@
 	><p class="src"
 	  ><a id="v:c" class="def"
 	    >c</a
-	    > :: (?x :: <a href="#"
+	    > :: (?x :: <a href="#" title="ImplicitParams"
 	    >X</a
-	    >) =&gt; <a href="#"
+	    >) =&gt; <a href="#" title="ImplicitParams"
 	    >X</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -81,13 +81,13 @@
 	><p class="src"
 	  ><a id="v:d" class="def"
 	    >d</a
-	    > :: (?x :: <a href="#"
+	    > :: (?x :: <a href="#" title="ImplicitParams"
 	    >X</a
-	    >, ?y :: <a href="#"
+	    >, ?y :: <a href="#" title="ImplicitParams"
 	    >X</a
-	    >) =&gt; (<a href="#"
+	    >) =&gt; (<a href="#" title="ImplicitParams"
 	    >X</a
-	    >, <a href="#"
+	    >, <a href="#" title="ImplicitParams"
 	    >X</a
 	    >) <a href="#" class="selflink"
 	    >#</a
@@ -97,7 +97,7 @@
 	><p class="src"
 	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: ((?x :: <a href="#"
+	    > :: ((?x :: <a href="#" title="ImplicitParams"
 	    >X</a
 	    >) =&gt; a) -&gt; a <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -74,9 +74,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:-60--126--126-:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >(&lt;~~)</a
 		      > a)</span
 		    > <a href="#" class="selflink"
@@ -96,11 +96,11 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: (a <a href="#"
+			  > :: (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  >) -&gt; a0 -&gt; a <a href="#"
+			  >) -&gt; a0 -&gt; a <a href="#" title="Instances"
 			  >&lt;~~</a
 			  > a0 <a href="#" class="selflink"
 			  >#</a
@@ -108,17 +108,17 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: (a <a href="#"
+			  > :: (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > (a <a href="#"
+			  > (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > a0)) -&gt; <a href="#"
+			  > a0)) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a <a href="#"
+			  > -&gt; a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > (a <a href="#"
+			  > (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -148,7 +148,7 @@
 	    ><p class="src"
 	    ><a id="v:foo" class="def"
 	      >foo</a
-	      > :: f <a href="#"
+	      > :: f <a href="#" title="Data.Int"
 	      >Int</a
 	      > -&gt; a -&gt; f a <a href="#" class="selflink"
 	      >#</a
@@ -156,9 +156,9 @@
 	    ><p class="src"
 	    ><a id="v:foo-39-" class="def"
 	      >foo'</a
-	      > :: f (f a) -&gt; <a href="#"
+	      > :: f (f a) -&gt; <a href="#" title="Data.Int"
 	      >Int</a
-	      > -&gt; f (f <a href="#"
+	      > -&gt; f (f <a href="#" title="Data.Int"
 	      >Int</a
 	      >) <a href="#" class="selflink"
 	      >#</a
@@ -174,7 +174,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
 		      > []</span
 		    > <a href="#" class="selflink"
@@ -194,7 +194,7 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: [<a href="#"
+			  > :: [<a href="#" title="Data.Int"
 			  >Int</a
 			  >] -&gt; a -&gt; [a] <a href="#" class="selflink"
 			  >#</a
@@ -202,9 +202,9 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: [[a]] -&gt; <a href="#"
+			  > :: [[a]] -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; [[<a href="#"
+			  > -&gt; [[<a href="#" title="Data.Int"
 			  >Int</a
 			  >]] <a href="#" class="selflink"
 			  >#</a
@@ -218,9 +218,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Maybe"
 		      >Maybe</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -240,11 +240,11 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a -&gt; <a href="#"
+			  > -&gt; a -&gt; <a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > a <a href="#" class="selflink"
 			  >#</a
@@ -252,17 +252,17 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > a) -&gt; <a href="#"
+			  > a) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -276,9 +276,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:3"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Data.Either"
 		      >Either</a
 		      > a)</span
 		    > <a href="#" class="selflink"
@@ -298,11 +298,11 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Either"
 			  >Either</a
-			  > a <a href="#"
+			  > a <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a0 -&gt; <a href="#"
+			  > -&gt; a0 -&gt; <a href="#" title="Data.Either"
 			  >Either</a
 			  > a a0 <a href="#" class="selflink"
 			  >#</a
@@ -310,17 +310,17 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (<a href="#"
+			  > a (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a a0) -&gt; <a href="#"
+			  > a a0) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (<a href="#"
+			  > a (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a <a href="#"
+			  > a <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -334,13 +334,13 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:4"
 		      ></span
-		      > (<a href="#"
+		      > (<a href="#" title="Data.Eq"
 		      >Eq</a
-		      > a, <a href="#"
+		      > a, <a href="#" title="Instances"
 		      >Foo</a
-		      > f) =&gt; <a href="#"
+		      > f) =&gt; <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="GHC.Tuple"
 		      >(,)</a
 		      > (f a))</span
 		    > <a href="#" class="selflink"
@@ -360,7 +360,7 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: (f a, <a href="#"
+			  > :: (f a, <a href="#" title="Data.Int"
 			  >Int</a
 			  >) -&gt; a0 -&gt; (f a, a0) <a href="#" class="selflink"
 			  >#</a
@@ -368,9 +368,9 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: (f a, (f a, a0)) -&gt; <a href="#"
+			  > :: (f a, (f a, a0)) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; (f a, (f a, <a href="#"
+			  > -&gt; (f a, (f a, <a href="#" title="Data.Int"
 			  >Int</a
 			  >)) <a href="#" class="selflink"
 			  >#</a
@@ -384,9 +384,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:5"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >(&lt;~~)</a
 		      > a)</span
 		    > <a href="#" class="selflink"
@@ -406,11 +406,11 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: (a <a href="#"
+			  > :: (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  >) -&gt; a0 -&gt; a <a href="#"
+			  >) -&gt; a0 -&gt; a <a href="#" title="Instances"
 			  >&lt;~~</a
 			  > a0 <a href="#" class="selflink"
 			  >#</a
@@ -418,17 +418,17 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: (a <a href="#"
+			  > :: (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > (a <a href="#"
+			  > (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > a0)) -&gt; <a href="#"
+			  > a0)) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a <a href="#"
+			  > -&gt; a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > (a <a href="#"
+			  > (a <a href="#" title="Instances"
 			  >&lt;~~</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -442,9 +442,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:6"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="GHC.Tuple"
 		      >(,,)</a
 		      > a a)</span
 		    > <a href="#" class="selflink"
@@ -464,7 +464,7 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: (a, a, <a href="#"
+			  > :: (a, a, <a href="#" title="Data.Int"
 			  >Int</a
 			  >) -&gt; a0 -&gt; (a, a, a0) <a href="#" class="selflink"
 			  >#</a
@@ -472,9 +472,9 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: (a, a, (a, a, a0)) -&gt; <a href="#"
+			  > :: (a, a, (a, a, a0)) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; (a, a, (a, a, <a href="#"
+			  > -&gt; (a, a, (a, a, <a href="#" title="Data.Int"
 			  >Int</a
 			  >)) <a href="#" class="selflink"
 			  >#</a
@@ -488,9 +488,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:7"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
 		      > a b)</span
 		    > <a href="#" class="selflink"
@@ -510,11 +510,11 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a b <a href="#"
+			  > a b <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a0 -&gt; <a href="#"
+			  > -&gt; a0 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -522,17 +522,17 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a b (<a href="#"
+			  > a b (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b a0) -&gt; <a href="#"
+			  > a b a0) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a b (<a href="#"
+			  > a b (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b <a href="#"
+			  > a b <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -546,13 +546,13 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Foo:Foo:8"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > ((-&gt;) <a href="#"
-		      >LiftedRep</a
-		      > <a href="#"
-		      >LiftedRep</a
-		      > a)</span
+		      > ((-&gt;) a :: <a href="#" title="Data.Kind"
+		      >*</a
+		      > -&gt; <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -570,43 +570,19 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: (<a href="#"
-			  >LiftedRep</a
-			  > -&gt; <a href="#"
-			  >LiftedRep</a
-			  >) a <a href="#"
+			  > :: (a -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a0 -&gt; (<a href="#"
-			  >LiftedRep</a
-			  > -&gt; <a href="#"
-			  >LiftedRep</a
-			  >) a a0 <a href="#" class="selflink"
+			  >) -&gt; a0 -&gt; a -&gt; a0 <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: (<a href="#"
-			  >LiftedRep</a
-			  > -&gt; <a href="#"
-			  >LiftedRep</a
-			  >) a ((<a href="#"
-			  >LiftedRep</a
-			  > -&gt; <a href="#"
-			  >LiftedRep</a
-			  >) a a0) -&gt; <a href="#"
+			  > :: (a -&gt; a -&gt; a0) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; (<a href="#"
-			  >LiftedRep</a
-			  > -&gt; <a href="#"
-			  >LiftedRep</a
-			  >) a ((<a href="#"
-			  >LiftedRep</a
-			  > -&gt; <a href="#"
-			  >LiftedRep</a
-			  >) a <a href="#"
+			  > -&gt; a -&gt; a -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  >) <a href="#" class="selflink"
+			  > <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			></div
@@ -621,7 +597,7 @@
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="#"
+	    > <a href="#" title="Instances"
 	    >Foo</a
 	    > f =&gt; <a id="t:Bar" class="def"
 	    >Bar</a
@@ -636,7 +612,7 @@
 	    ><p class="src"
 	    ><a id="v:bar" class="def"
 	      >bar</a
-	      > :: f a -&gt; f <a href="#"
+	      > :: f a -&gt; f <a href="#" title="Data.Bool"
 	      >Bool</a
 	      > -&gt; a <a href="#" class="selflink"
 	      >#</a
@@ -670,11 +646,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Maybe"
 		      >Maybe</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Bool"
 		      >Bool</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -694,15 +670,15 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Bool"
 			  >Bool</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -710,17 +686,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  >) -&gt; <a href="#"
+			  >) -&gt; <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > b)) <a href="#" class="selflink"
 			  >#</a
@@ -728,17 +704,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar0</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  >, <a href="#"
+			  >, <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  >) -&gt; (<a href="#"
+			  >) -&gt; (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > b, <a href="#"
+			  > b, <a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > c) <a href="#" class="selflink"
 			  >#</a
@@ -746,17 +722,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar1</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  >, <a href="#"
+			  >, <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  >) -&gt; (<a href="#"
+			  >) -&gt; (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > b, <a href="#"
+			  > b, <a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > c) <a href="#" class="selflink"
 			  >#</a
@@ -770,9 +746,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Maybe"
 		      >Maybe</a
 		      > [a]</span
 		    > <a href="#" class="selflink"
@@ -792,11 +768,11 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > [a] -&gt; <a href="#"
+			  > [a] -&gt; <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
 			  > -&gt; [a] <a href="#" class="selflink"
 			  >#</a
@@ -804,15 +780,15 @@
 			><p class="src"
 			><a href="#"
 			  >bar'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > [a]) -&gt; <a href="#"
+			  > [a]) -&gt; <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > (<a href="#"
+			  > (<a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > b)) <a href="#" class="selflink"
 			  >#</a
@@ -820,13 +796,13 @@
 			><p class="src"
 			><a href="#"
 			  >bar0</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > [a], <a href="#"
+			  > [a], <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > [a]) -&gt; (<a href="#"
+			  > [a]) -&gt; (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > b, <a href="#"
+			  > b, <a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > c) <a href="#" class="selflink"
 			  >#</a
@@ -834,13 +810,13 @@
 			><p class="src"
 			><a href="#"
 			  >bar1</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > [a], <a href="#"
+			  > [a], <a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > [a]) -&gt; (<a href="#"
+			  > [a]) -&gt; (<a href="#" title="Data.Maybe"
 			  >Maybe</a
-			  > b, <a href="#"
+			  > b, <a href="#" title="Data.Maybe"
 			  >Maybe</a
 			  > c) <a href="#" class="selflink"
 			  >#</a
@@ -854,7 +830,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:3"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Bar</a
 		      > [] (a, a)</span
 		    > <a href="#" class="selflink"
@@ -874,7 +850,7 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: [(a, a)] -&gt; [<a href="#"
+			  > :: [(a, a)] -&gt; [<a href="#" title="Data.Bool"
 			  >Bool</a
 			  >] -&gt; (a, a) <a href="#" class="selflink"
 			  >#</a
@@ -906,11 +882,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:4"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > f =&gt; <a href="#"
+		      > f =&gt; <a href="#" title="Instances"
 		      >Bar</a
-		      > (<a href="#"
+		      > (<a href="#" title="Data.Either"
 		      >Either</a
 		      > a) (f a)</span
 		    > <a href="#" class="selflink"
@@ -930,11 +906,11 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (f a) -&gt; <a href="#"
+			  > a (f a) -&gt; <a href="#" title="Data.Either"
 			  >Either</a
-			  > a <a href="#"
+			  > a <a href="#" title="Data.Bool"
 			  >Bool</a
 			  > -&gt; f a <a href="#" class="selflink"
 			  >#</a
@@ -942,15 +918,15 @@
 			><p class="src"
 			><a href="#"
 			  >bar'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (<a href="#"
+			  > a (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a (f a)) -&gt; <a href="#"
+			  > a (f a)) -&gt; <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (<a href="#"
+			  > a (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a (<a href="#"
+			  > a (<a href="#" title="Data.Either"
 			  >Either</a
 			  > a b)) <a href="#" class="selflink"
 			  >#</a
@@ -958,13 +934,13 @@
 			><p class="src"
 			><a href="#"
 			  >bar0</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a (f a), <a href="#"
+			  > a (f a), <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (f a)) -&gt; (<a href="#"
+			  > a (f a)) -&gt; (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a b, <a href="#"
+			  > a b, <a href="#" title="Data.Either"
 			  >Either</a
 			  > a c) <a href="#" class="selflink"
 			  >#</a
@@ -972,13 +948,13 @@
 			><p class="src"
 			><a href="#"
 			  >bar1</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a (f a), <a href="#"
+			  > a (f a), <a href="#" title="Data.Either"
 			  >Either</a
-			  > a (f a)) -&gt; (<a href="#"
+			  > a (f a)) -&gt; (<a href="#" title="Data.Either"
 			  >Either</a
-			  > a b, <a href="#"
+			  > a b, <a href="#" title="Data.Either"
 			  >Either</a
 			  > a c) <a href="#" class="selflink"
 			  >#</a
@@ -992,13 +968,13 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:5"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="GHC.Tuple"
 		      >(,,)</a
-		      > a b) =&gt; <a href="#"
+		      > a b) =&gt; <a href="#" title="Instances"
 		      >Bar</a
-		      > (<a href="#"
+		      > (<a href="#" title="GHC.Tuple"
 		      >(,,)</a
 		      > a b) (a, b, a)</span
 		    > <a href="#" class="selflink"
@@ -1018,7 +994,7 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: (a, b, (a, b, a)) -&gt; (a, b, <a href="#"
+			  > :: (a, b, (a, b, a)) -&gt; (a, b, <a href="#" title="Data.Bool"
 			  >Bool</a
 			  >) -&gt; (a, b, a) <a href="#" class="selflink"
 			  >#</a
@@ -1050,11 +1026,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Bar:Bar:6"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Bar</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
-		      > a c) (<a href="#"
+		      > a c) (<a href="#" title="Instances"
 		      >Quux</a
 		      > a b c)</span
 		    > <a href="#" class="selflink"
@@ -1074,15 +1050,15 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c) -&gt; <a href="#"
+			  > a b c) -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a c <a href="#"
+			  > a c <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c <a href="#" class="selflink"
 			  >#</a
@@ -1090,17 +1066,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c)) -&gt; <a href="#"
+			  > a b c)) -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
 			  > a c b0)) <a href="#" class="selflink"
 			  >#</a
@@ -1108,17 +1084,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar0</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c), <a href="#"
+			  > a b c), <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c)) -&gt; (<a href="#"
+			  > a b c)) -&gt; (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c b0, <a href="#"
+			  > a c b0, <a href="#" title="Instances"
 			  >Quux</a
 			  > a c c0) <a href="#" class="selflink"
 			  >#</a
@@ -1126,17 +1102,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar1</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c), <a href="#"
+			  > a b c), <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c)) -&gt; (<a href="#"
+			  > a b c)) -&gt; (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c b0, <a href="#"
+			  > a c b0, <a href="#" title="Instances"
 			  >Quux</a
 			  > a c c0) <a href="#" class="selflink"
 			  >#</a
@@ -1206,7 +1182,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Baz:Baz:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Baz</a
 		      > [c]</span
 		    > <a href="#" class="selflink"
@@ -1264,7 +1240,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Baz:Baz:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Baz</a
 		      > (a -&gt; b)</span
 		    > <a href="#" class="selflink"
@@ -1322,7 +1298,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Baz:Baz:3"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Baz</a
 		      > (a, b, c)</span
 		    > <a href="#" class="selflink"
@@ -1380,9 +1356,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Baz:Baz:4"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Baz</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
 		      > a b c)</span
 		    > <a href="#" class="selflink"
@@ -1402,13 +1378,13 @@
 			><p class="src"
 			><a href="#"
 			  >baz</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c -&gt; (<span class="keyword"
 			  >forall</span
 			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c0. c0 -&gt; <a href="#"
+			  > c0. c0 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; (b0, c1) <a href="#" class="selflink"
 			  >#</a
@@ -1418,13 +1394,13 @@
 			  >baz'</a
 			  > :: b0 -&gt; (<span class="keyword"
 			  >forall</span
-			  > b1. b1 -&gt; <a href="#"
+			  > b1. b1 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; <a href="#"
+			  > b2. b2 -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a b c) -&gt; [(b0, <a href="#"
+			  > a b c) -&gt; [(b0, <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c)] <a href="#" class="selflink"
 			  >#</a
@@ -1436,7 +1412,7 @@
 			  >forall</span
 			  > b1. (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; <a href="#"
+			  > b2. b2 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; c0) -&gt; <span class="keyword"
 			  >forall</span
@@ -1452,7 +1428,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Baz:Baz:5"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Baz</a
 		      > (a, [b], b, a)</span
 		    > <a href="#" class="selflink"
@@ -1558,9 +1534,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Quux:Foo:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Foo</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
 		      > a b)</span
 		    > <a href="#" class="selflink"
@@ -1580,11 +1556,11 @@
 			><p class="src"
 			><a href="#"
 			  >foo</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a b <a href="#"
+			  > a b <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; a0 -&gt; <a href="#"
+			  > -&gt; a0 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b a0 <a href="#" class="selflink"
 			  >#</a
@@ -1592,17 +1568,17 @@
 			><p class="src"
 			><a href="#"
 			  >foo'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a b (<a href="#"
+			  > a b (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b a0) -&gt; <a href="#"
+			  > a b a0) -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a b (<a href="#"
+			  > a b (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b <a href="#"
+			  > a b <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -1616,11 +1592,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Quux:Bar:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Bar</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
-		      > a c) (<a href="#"
+		      > a c) (<a href="#" title="Instances"
 		      >Quux</a
 		      > a b c)</span
 		    > <a href="#" class="selflink"
@@ -1640,15 +1616,15 @@
 			><p class="src"
 			><a href="#"
 			  >bar</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c) -&gt; <a href="#"
+			  > a b c) -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a c <a href="#"
+			  > a c <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c <a href="#" class="selflink"
 			  >#</a
@@ -1656,17 +1632,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar'</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c)) -&gt; <a href="#"
+			  > a b c)) -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
 			  > a c b0)) <a href="#" class="selflink"
 			  >#</a
@@ -1674,17 +1650,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar0</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c), <a href="#"
+			  > a b c), <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c)) -&gt; (<a href="#"
+			  > a b c)) -&gt; (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c b0, <a href="#"
+			  > a c b0, <a href="#" title="Instances"
 			  >Quux</a
 			  > a c c0) <a href="#" class="selflink"
 			  >#</a
@@ -1692,17 +1668,17 @@
 			><p class="src"
 			><a href="#"
 			  >bar1</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c), <a href="#"
+			  > a b c), <a href="#" title="Instances"
 			  >Quux</a
-			  > a c (<a href="#"
+			  > a c (<a href="#" title="Instances"
 			  >Quux</a
-			  > a b c)) -&gt; (<a href="#"
+			  > a b c)) -&gt; (<a href="#" title="Instances"
 			  >Quux</a
-			  > a c b0, <a href="#"
+			  > a c b0, <a href="#" title="Instances"
 			  >Quux</a
 			  > a c c0) <a href="#" class="selflink"
 			  >#</a
@@ -1716,9 +1692,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Quux:Baz:3"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Baz</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
 		      > a b c)</span
 		    > <a href="#" class="selflink"
@@ -1738,13 +1714,13 @@
 			><p class="src"
 			><a href="#"
 			  >baz</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c -&gt; (<span class="keyword"
 			  >forall</span
 			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c0. c0 -&gt; <a href="#"
+			  > c0. c0 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; (b0, c1) <a href="#" class="selflink"
 			  >#</a
@@ -1754,13 +1730,13 @@
 			  >baz'</a
 			  > :: b0 -&gt; (<span class="keyword"
 			  >forall</span
-			  > b1. b1 -&gt; <a href="#"
+			  > b1. b1 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; <a href="#"
+			  > b2. b2 -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a b c) -&gt; [(b0, <a href="#"
+			  > a b c) -&gt; [(b0, <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c)] <a href="#" class="selflink"
 			  >#</a
@@ -1772,7 +1748,7 @@
 			  >forall</span
 			  > b1. (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; <a href="#"
+			  > b2. b2 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; c0) -&gt; <span class="keyword"
 			  >forall</span
@@ -1790,11 +1766,11 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Thud</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
-		      > (<a href="#"
+		      > (<a href="#" title="Instances"
 		      >Quux</a
 		      > a [a] c)</span
 		    > <a href="#" class="selflink"
@@ -1811,11 +1787,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="Instances"
 			>Thud</a
-			> <a href="#"
+			> <a href="#" title="Data.Int"
 			>Int</a
-			> (<a href="#"
+			> (<a href="#" title="Instances"
 			>Quux</a
 			> a [a] c) <ul class="inst"
 			><li class="inst"
@@ -1825,9 +1801,9 @@
 			  ><li class="inst"
 			  >| <a id="v:Thuuud" class="def"
 			    >Thuuud</a
-			    > <a href="#"
+			    > <a href="#" title="Data.Int"
 			    >Int</a
-			    > <a href="#"
+			    > <a href="#" title="Data.Int"
 			    >Int</a
 			    ></li
 			  ></ul
@@ -1876,7 +1852,7 @@
 	    ><p class="src"
 	    ><a id="v:norf" class="def"
 	      >norf</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Instances"
 	      >Plugh</a
 	      > a c b -&gt; a -&gt; (a -&gt; c) -&gt; b <a href="#" class="selflink"
 	      >#</a
@@ -1892,11 +1868,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Norf:Norf:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Norf</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Bool"
 		      >Bool</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1916,13 +1892,13 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="Instances"
 			  >Plugh</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  > c <a href="#"
+			  > c <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1930,11 +1906,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >data</span
-			  > <a href="#"
+			  > <a href="#" title="Instances"
 			  >Thud</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  > c :: <a href="#"
+			  > c :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1946,17 +1922,17 @@
 			><p class="src"
 			><a href="#"
 			  >norf</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Plugh</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  > c <a href="#"
+			  > c <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; (<a href="#"
+			  > -&gt; (<a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; c) -&gt; <a href="#"
+			  > -&gt; c) -&gt; <a href="#" title="Data.Bool"
 			  >Bool</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1970,7 +1946,7 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Norf:Norf:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Instances"
 		      >Norf</a
 		      > [a] [b]</span
 		    > <a href="#" class="selflink"
@@ -1990,9 +1966,9 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="Instances"
 			  >Plugh</a
-			  > [a] c [b] :: <a href="#"
+			  > [a] c [b] :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -2000,9 +1976,9 @@
 			><p class="src"
 			><span class="keyword"
 			  >data</span
-			  > <a href="#"
+			  > <a href="#" title="Instances"
 			  >Thud</a
-			  > [a] c :: <a href="#"
+			  > [a] c :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -2014,7 +1990,7 @@
 			><p class="src"
 			><a href="#"
 			  >norf</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Instances"
 			  >Plugh</a
 			  > [a] c [b] -&gt; [a] -&gt; ([a] -&gt; c) -&gt; [b] <a href="#" class="selflink"
 			  >#</a

--- a/html-test/ref/Math.html
+++ b/html-test/ref/Math.html
@@ -62,7 +62,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >f</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ></ul
@@ -75,7 +75,7 @@
 	><p class="src"
 	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -64,19 +64,19 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Minimal"
 	      >foo</a
-	      >, <a href="#"
+	      >, <a href="#" title="Minimal"
 	      >bar</a
-	      > | <a href="#"
+	      > | <a href="#" title="Minimal"
 	      >bar</a
-	      >, <a href="#"
+	      >, <a href="#" title="Minimal"
 	      >bat</a
-	      > | <a href="#"
+	      > | <a href="#" title="Minimal"
 	      >foo</a
-	      >, <a href="#"
+	      >, <a href="#" title="Minimal"
 	      >bat</a
-	      > | <a href="#"
+	      > | <a href="#" title="Minimal"
 	      >fooBarBat</a
 	      ></p
 	    ></div
@@ -190,9 +190,9 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Minimal"
 	      >x</a
-	      >, <a href="#"
+	      >, <a href="#" title="Minimal"
 	      >y</a
 	      ></p
 	    ></div
@@ -234,9 +234,9 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Minimal"
 	      >aaa</a
-	      >, <a href="#"
+	      >, <a href="#" title="Minimal"
 	      >bbb</a
 	      ></p
 	    ></div
@@ -272,7 +272,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Minimal"
 	      >ccc</a
 	      >, ddd</p
 	    ></div

--- a/html-test/ref/ModuleWithWarning.html
+++ b/html-test/ref/ModuleWithWarning.html
@@ -61,7 +61,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/NoLayout.html
+++ b/html-test/ref/NoLayout.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >g</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -67,7 +67,7 @@
 	  ><div class="doc"
 	  ><p
 	    >the function <code
-	      ><a href="#"
+	      ><a href="#" title="NoLayout"
 		>g</a
 		></code
 	      ></p

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -70,19 +70,19 @@
 	      >Foo</a
 	      ><ul class="subs"
 	      ><li
-		>= <a href="#"
+		>= <a href="#" title="Operators"
 		  >Foo</a
 		  > <a href="#"
 		  >`Bar`</a
-		  > <a href="#"
+		  > <a href="#" title="Operators"
 		  >Foo</a
 		  ></li
 		><li
-		>| <a href="#"
+		>| <a href="#" title="Operators"
 		  >Foo</a
 		  > <a href="#"
 		  >:-</a
-		  > <a href="#"
+		  > <a href="#" title="Operators"
 		  >Foo</a
 		  ></li
 		></ul
@@ -106,7 +106,7 @@
 	      ><li
 		><a href="#"
 		  >(:&lt;-&gt;)</a
-		  > :: a -&gt; b -&gt; a <a href="#"
+		  > :: a -&gt; b -&gt; a <a href="#" title="Operators"
 		  >&lt;-&gt;</a
 		  > b</li
 		></ul
@@ -136,7 +136,7 @@
 		  >type</span
 		  > a <a href="#"
 		  >&lt;&gt;&lt;</a
-		  > b :: <a href="#"
+		  > b :: <a href="#" title="Data.Kind"
 		  >*</a
 		  ></li
 		><li
@@ -152,7 +152,7 @@
 	      >type</span
 	      > <a href="#"
 	      >(&gt;-&lt;)</a
-	      > a b = a <a href="#"
+	      > a b = a <a href="#" title="Operators"
 	      >&lt;-&gt;</a
 	      > b</li
 	    ></ul
@@ -224,11 +224,11 @@
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="Operators"
 		  >Foo</a
 		  > <a id="v:Bar" class="def"
 		  >`Bar`</a
-		  > <a href="#"
+		  > <a href="#" title="Operators"
 		  >Foo</a
 		  > <span class="fixity"
 		  >infixl 3</span
@@ -242,11 +242,11 @@
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="Operators"
 		  >Foo</a
 		  > <a id="v::-45-" class="def"
 		  >:-</a
-		  > <a href="#"
+		  > <a href="#" title="Operators"
 		  >Foo</a
 		  > <span class="fixity"
 		  >infixr 5</span
@@ -308,7 +308,7 @@
 	      ><td class="src"
 		><a id="v::-60--45--62-" class="def"
 		  >(:&lt;-&gt;)</a
-		  > :: a -&gt; b -&gt; a <a href="#"
+		  > :: a -&gt; b -&gt; a <a href="#" title="Operators"
 		  >&lt;-&gt;</a
 		  > b <span class="fixity"
 		  >infixr 6</span
@@ -380,17 +380,17 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Operators"
 	      >(&gt;&gt;&lt;)</a
-	      >, <a href="#"
+	      >, <a href="#" title="Operators"
 	      >(&lt;&lt;&gt;)</a
-	      >, <a href="#"
+	      >, <a href="#" title="Operators"
 	      >(**&gt;)</a
-	      >, <a href="#"
+	      >, <a href="#" title="Operators"
 	      >(**&lt;)</a
-	      >, <a href="#"
+	      >, <a href="#" title="Operators"
 	      >(&gt;**)</a
-	      >, <a href="#"
+	      >, <a href="#" title="Operators"
 	      >(&lt;**)</a
 	      ></p
 	    ></div
@@ -402,7 +402,7 @@
 	      >type</span
 	      > a <a id="t:-60--62--60-" class="def"
 	      >&lt;&gt;&lt;</a
-	      > b :: <a href="#"
+	      > b :: <a href="#" title="Data.Kind"
 	      >*</a
 	      > <span class="fixity"
 	      >infixl 2</span
@@ -511,7 +511,7 @@
 	    >type</span
 	    > <a id="t:-62--45--60-" class="def"
 	    >(&gt;-&lt;)</a
-	    > a b = a <a href="#"
+	    > a b = a <a href="#" title="Operators"
 	    >&lt;-&gt;</a
 	    > b <span class="fixity"
 	    >infixl 6</span

--- a/html-test/ref/OrphanInstances.html
+++ b/html-test/ref/OrphanInstances.html
@@ -48,18 +48,8 @@
 	    ></li
 	  ></ul
 	></div
-      ><div id="synopsis"
-      ><details id="syn"
-	><summary
-	  >Synopsis</summary
-	  ><ul class="details-toggle" data-details-id="syn"
-	  ></ul
-	  ></details
-	></div
       ><div id="interface"
       ><h1
-	>Documentation</h1
-	><h1
 	>Orphan instances</h1
 	><div id="section.orphans"
 	><table
@@ -68,9 +58,9 @@
 	      ><span class="inst-left"
 		><span class="instance details-toggle-control details-toggle" data-details-id="i:o:ic:AClass:AClass:1"
 		  ></span
-		  > <a href="#"
+		  > <a href="#" title="OrphanInstancesClass"
 		  >AClass</a
-		  > <a href="#"
+		  > <a href="#" title="OrphanInstancesType"
 		  >AType</a
 		  ></span
 		> <a href="#" class="selflink"
@@ -92,9 +82,9 @@
 		    ><p class="src"
 		    ><a href="#"
 		      >aClass</a
-		      > :: <a href="#"
+		      > :: <a href="#" title="OrphanInstancesType"
 		      >AType</a
-		      > -&gt; <a href="#"
+		      > -&gt; <a href="#" title="Data.Int"
 		      >Int</a
 		      > <a href="#" class="selflink"
 		      >#</a

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -56,7 +56,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="OrphanInstancesClass"
 	      >aClass</a
 	      ></p
 	    ></div
@@ -66,11 +66,59 @@
 	    ><p class="src"
 	    ><a id="v:aClass" class="def"
 	      >aClass</a
-	      > :: a -&gt; <a href="#"
+	      > :: a -&gt; <a href="#" title="Data.Int"
 	      >Int</a
 	      > <a href="#" class="selflink"
 	      >#</a
 	      ></p
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:AClass" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:AClass:AClass:1"
+		      ></span
+		      > <a href="#" title="OrphanInstancesClass"
+		      >AClass</a
+		      > <a href="#" title="OrphanInstancesType"
+		      >AType</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >This is an orphan instance.</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:ic:AClass:AClass:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >aClass</a
+			  > :: <a href="#" title="OrphanInstancesType"
+			  >AType</a
+			  > -&gt; <a href="#" title="Data.Int"
+			  >Int</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
 	    ></div
 	  ></div
 	></div

--- a/html-test/ref/OrphanInstancesType.html
+++ b/html-test/ref/OrphanInstancesType.html
@@ -58,13 +58,61 @@
 	      ><td class="src"
 		><a id="v:AType" class="def"
 		  >AType</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc empty"
 		></td
 		></tr
 	      ></table
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:AType" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:AType:AClass:1"
+		      ></span
+		      > <a href="#" title="OrphanInstancesClass"
+		      >AClass</a
+		      > <a href="#" title="OrphanInstancesType"
+		      >AType</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >This is an orphan instance.</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:AType:AClass:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >aClass</a
+			  > :: <a href="#" title="OrphanInstancesType"
+			  >AType</a
+			  > -&gt; <a href="#" title="Data.Int"
+			  >Int</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
 	    ></div
 	  ></div
 	></div

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -66,7 +66,7 @@
 	      >Foo</a
 	      > :: <span class="keyword"
 	      >forall</span
-	      > x. x -&gt; <a href="#"
+	      > x. x -&gt; <a href="#" title="PatternSyns"
 	      >FooType</a
 	      > x</li
 	    ><li class="src short"
@@ -76,9 +76,9 @@
 	      >Bar</a
 	      > :: <span class="keyword"
 	      >forall</span
-	      > x. x -&gt; <a href="#"
+	      > x. x -&gt; <a href="#" title="PatternSyns"
 	      >FooType</a
-	      > (<a href="#"
+	      > (<a href="#" title="PatternSyns"
 	      >FooType</a
 	      > x)</li
 	    ><li class="src short"
@@ -88,11 +88,11 @@
 	      >(:&lt;-&gt;)</a
 	      > :: <span class="keyword"
 	      >forall</span
-	      > x x1. x -&gt; x1 -&gt; (<a href="#"
+	      > x x1. x -&gt; x1 -&gt; (<a href="#" title="PatternSyns"
 	      >FooType</a
-	      > x, <a href="#"
+	      > x, <a href="#" title="PatternSyns"
 	      >FooType</a
-	      > (<a href="#"
+	      > (<a href="#" title="PatternSyns"
 	      >FooType</a
 	      > x1))</li
 	    ><li class="src short"
@@ -100,7 +100,7 @@
 	      >data</span
 	      > <a href="#"
 	      >BlubType</a
-	      > = <a href="#"
+	      > = <a href="#" title="Text.Show"
 	      >Show</a
 	      > x =&gt; <a href="#"
 	      >BlubCtor</a
@@ -112,15 +112,15 @@
 	      >Blub</a
 	      > :: () =&gt; <span class="keyword"
 	      >forall</span
-	      > x. <a href="#"
+	      > x. <a href="#" title="Text.Show"
 	      >Show</a
-	      > x =&gt; x -&gt; <a href="#"
+	      > x =&gt; x -&gt; <a href="#" title="PatternSyns"
 	      >BlubType</a
 	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
 	      >data</span
-	      > (a :: <a href="#"
+	      > (a :: <a href="#" title="Data.Kind"
 	      >*</a
 	      >) <a href="#"
 	      >&gt;&lt;</a
@@ -134,17 +134,17 @@
 	      >E</a
 	      > :: <span class="keyword"
 	      >forall</span
-	      > k a (b :: k). <a href="#"
-	      >(&gt;&lt;)</a
-	      > k a b</li
+	      > k a (b :: k). a <a href="#" title="PatternSyns"
+	      >&gt;&lt;</a
+	      > b</li
 	    ><li class="src short"
 	    ><span class="keyword"
 	      >pattern</span
 	      > <a href="#"
 	      >PatWithExplicitSig</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Eq"
 	      >Eq</a
-	      > somex =&gt; somex -&gt; <a href="#"
+	      > somex =&gt; somex -&gt; <a href="#" title="PatternSyns"
 	      >FooType</a
 	      > somex</li
 	    ></ul
@@ -189,7 +189,7 @@
 	    >Foo</a
 	    > :: <span class="keyword"
 	    >forall</span
-	    > x. x -&gt; <a href="#"
+	    > x. x -&gt; <a href="#" title="PatternSyns"
 	    >FooType</a
 	    > x <a href="#" class="selflink"
 	    >#</a
@@ -197,7 +197,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for <code
-	      ><a href="#"
+	      ><a href="#" title="PatternSyns"
 		>Foo</a
 		></code
 	      > x</p
@@ -211,9 +211,9 @@
 	    >Bar</a
 	    > :: <span class="keyword"
 	    >forall</span
-	    > x. x -&gt; <a href="#"
+	    > x. x -&gt; <a href="#" title="PatternSyns"
 	    >FooType</a
-	    > (<a href="#"
+	    > (<a href="#" title="PatternSyns"
 	    >FooType</a
 	    > x) <a href="#" class="selflink"
 	    >#</a
@@ -221,7 +221,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for <code
-	      ><a href="#"
+	      ><a href="#" title="PatternSyns"
 		>Bar</a
 		></code
 	      > x</p
@@ -235,11 +235,11 @@
 	    >(:&lt;-&gt;)</a
 	    > :: <span class="keyword"
 	    >forall</span
-	    > x x1. x -&gt; x1 -&gt; (<a href="#"
+	    > x x1. x -&gt; x1 -&gt; (<a href="#" title="PatternSyns"
 	    >FooType</a
-	    > x, <a href="#"
+	    > x, <a href="#" title="PatternSyns"
 	    >FooType</a
-	    > (<a href="#"
+	    > (<a href="#" title="PatternSyns"
 	    >FooType</a
 	    > x1)) <a href="#" class="selflink"
 	    >#</a
@@ -247,7 +247,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for (<code
-	      ><a href="#"
+	      ><a href="#" title="PatternSyns"
 		>:&lt;-&gt;</a
 		></code
 	      >)</p
@@ -272,7 +272,7 @@
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="Text.Show"
 		  >Show</a
 		  > x =&gt; <a id="v:BlubCtor" class="def"
 		  >BlubCtor</a
@@ -291,9 +291,9 @@
 	    >Blub</a
 	    > :: () =&gt; <span class="keyword"
 	    >forall</span
-	    > x. <a href="#"
+	    > x. <a href="#" title="Text.Show"
 	    >Show</a
-	    > x =&gt; x -&gt; <a href="#"
+	    > x =&gt; x -&gt; <a href="#" title="PatternSyns"
 	    >BlubType</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -301,7 +301,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Pattern synonym for <code
-	      ><a href="#"
+	      ><a href="#" title="PatternSyns"
 		>Blub</a
 		></code
 	      > x</p
@@ -311,7 +311,7 @@
 	><p class="src"
 	  ><span class="keyword"
 	    >data</span
-	    > (a :: <a href="#"
+	    > (a :: <a href="#" title="Data.Kind"
 	    >*</a
 	    >) <a id="t:-62--60-" class="def"
 	    >&gt;&lt;</a
@@ -321,7 +321,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Doc for (<code
-	      ><a href="#"
+	      ><a href="#" title="PatternSyns"
 		>&gt;&lt;</a
 		></code
 	      >)</p
@@ -349,15 +349,15 @@
 	    >E</a
 	    > :: <span class="keyword"
 	    >forall</span
-	    > k a (b :: k). <a href="#"
-	    >(&gt;&lt;)</a
-	    > k a b <a href="#" class="selflink"
+	    > k a (b :: k). a <a href="#" title="PatternSyns"
+	    >&gt;&lt;</a
+	    > b <a href="#" class="selflink"
 	    >#</a
 	    ></p
 	  ><div class="doc"
 	  ><p
 	    >Pattern for <code
-	      ><a href="#"
+	      ><a href="#" title="PatternSyns"
 		>Empty</a
 		></code
 	      ></p
@@ -369,9 +369,9 @@
 	    >pattern</span
 	    > <a id="v:PatWithExplicitSig" class="def"
 	    >PatWithExplicitSig</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Eq"
 	    >Eq</a
-	    > somex =&gt; somex -&gt; <a href="#"
+	    > somex =&gt; somex -&gt; <a href="#" title="PatternSyns"
 	    >FooType</a
 	    > somex <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/PromotedTypes.html
+++ b/html-test/ref/PromotedTypes.html
@@ -64,7 +64,7 @@
 		></tr
 	      ><tr
 	      ><td class="src"
-		>(<a href="#"
+		>(<a href="#" title="PromotedTypes"
 		  >RevList</a
 		  > a) <a id="v::-62-" class="def"
 		  >:&gt;</a
@@ -81,9 +81,9 @@
 	    >data</span
 	    > <a id="t:Pattern" class="def"
 	    >Pattern</a
-	    > :: [<a href="#"
+	    > :: [<a href="#" title="Data.Kind"
 	    >*</a
-	    >] -&gt; <a href="#"
+	    >] -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -98,7 +98,7 @@
 	      ><td class="src"
 		><a id="v:Nil" class="def"
 		  >Nil</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="PromotedTypes"
 		  >Pattern</a
 		  > '[]</td
 		><td class="doc empty"
@@ -108,11 +108,11 @@
 	      ><td class="src"
 		><a id="v:Cons" class="def"
 		  >Cons</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Maybe"
 		  >Maybe</a
-		  > h -&gt; <a href="#"
+		  > h -&gt; <a href="#" title="PromotedTypes"
 		  >Pattern</a
-		  > t -&gt; <a href="#"
+		  > t -&gt; <a href="#" title="PromotedTypes"
 		  >Pattern</a
 		  > (h ': t)</td
 		><td class="doc empty"
@@ -127,11 +127,11 @@
 	    >data</span
 	    > <a id="t:RevPattern" class="def"
 	    >RevPattern</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="PromotedTypes"
 	    >RevList</a
-	    > <a href="#"
+	    > <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -146,9 +146,9 @@
 	      ><td class="src"
 		><a id="v:RevNil" class="def"
 		  >RevNil</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="PromotedTypes"
 		  >RevPattern</a
-		  > <a href="#"
+		  > <a href="#" title="PromotedTypes"
 		  >RNil</a
 		  ></td
 		><td class="doc empty"
@@ -158,13 +158,13 @@
 	      ><td class="src"
 		><a id="v:RevCons" class="def"
 		  >RevCons</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Maybe"
 		  >Maybe</a
-		  > h -&gt; <a href="#"
+		  > h -&gt; <a href="#" title="PromotedTypes"
 		  >RevPattern</a
-		  > t -&gt; <a href="#"
+		  > t -&gt; <a href="#" title="PromotedTypes"
 		  >RevPattern</a
-		  > (t <a href="#"
+		  > (t <a href="#" title="PromotedTypes"
 		  >:&gt;</a
 		  > h)</td
 		><td class="doc empty"
@@ -179,11 +179,11 @@
 	    >data</span
 	    > <a id="t:Tuple" class="def"
 	    >Tuple</a
-	    > :: (<a href="#"
+	    > :: (<a href="#" title="Data.Kind"
 	    >*</a
-	    >, <a href="#"
+	    >, <a href="#" title="Data.Kind"
 	    >*</a
-	    >) -&gt; <a href="#"
+	    >) -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    > <span class="keyword"
 	    >where</span
@@ -198,7 +198,7 @@
 	      ><td class="src"
 		><a id="v:Tuple" class="def"
 		  >Tuple</a
-		  > :: a -&gt; b -&gt; <a href="#"
+		  > :: a -&gt; b -&gt; <a href="#" title="PromotedTypes"
 		  >Tuple</a
 		  > '(a, b)</td
 		><td class="doc empty"

--- a/html-test/ref/Properties.html
+++ b/html-test/ref/Properties.html
@@ -46,9 +46,9 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >fib</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ></ul
@@ -61,9 +61,9 @@
 	><p class="src"
 	  ><a id="v:fib" class="def"
 	    >fib</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -71,7 +71,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Fibonacci number of given <code
-	      ><a href="#"
+	      ><a href="#" title="Prelude"
 		>Integer</a
 		></code
 	      >.</p

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -58,7 +58,7 @@
 	      ><td class="src"
 		><a id="v:IntExpr" class="def"
 		  >IntExpr</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Integer</a
 		  ></td
 		><td class="doc empty"
@@ -68,7 +68,7 @@
 	      ><td class="src"
 		><a id="v:AntiIntExpr" class="def"
 		  >AntiIntExpr</a
-		  > <a href="#"
+		  > <a href="#" title="Data.String"
 		  >String</a
 		  ></td
 		><td class="doc empty"
@@ -78,11 +78,11 @@
 	      ><td class="src"
 		><a id="v:BinopExpr" class="def"
 		  >BinopExpr</a
-		  > <a href="#"
+		  > <a href="#" title="QuasiExpr"
 		  >BinOp</a
-		  > <a href="#"
+		  > <a href="#" title="QuasiExpr"
 		  >Expr</a
-		  > <a href="#"
+		  > <a href="#" title="QuasiExpr"
 		  >Expr</a
 		  ></td
 		><td class="doc empty"
@@ -92,7 +92,7 @@
 	      ><td class="src"
 		><a id="v:AntiExpr" class="def"
 		  >AntiExpr</a
-		  > <a href="#"
+		  > <a href="#" title="Data.String"
 		  >String</a
 		  ></td
 		><td class="doc empty"
@@ -110,9 +110,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Expr:Show:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Text.Show"
 		      >Show</a
-		      > <a href="#"
+		      > <a href="#" title="QuasiExpr"
 		      >Expr</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -132,11 +132,11 @@
 			><p class="src"
 			><a href="#"
 			  >showsPrec</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="QuasiExpr"
 			  >Expr</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Text.Show"
 			  >ShowS</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -144,9 +144,9 @@
 			><p class="src"
 			><a href="#"
 			  >show</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="QuasiExpr"
 			  >Expr</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.String"
 			  >String</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -154,9 +154,9 @@
 			><p class="src"
 			><a href="#"
 			  >showList</a
-			  > :: [<a href="#"
+			  > :: [<a href="#" title="QuasiExpr"
 			  >Expr</a
-			  >] -&gt; <a href="#"
+			  >] -&gt; <a href="#" title="Text.Show"
 			  >ShowS</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -226,9 +226,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:BinOp:Show:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Text.Show"
 		      >Show</a
-		      > <a href="#"
+		      > <a href="#" title="QuasiExpr"
 		      >BinOp</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -248,11 +248,11 @@
 			><p class="src"
 			><a href="#"
 			  >showsPrec</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="QuasiExpr"
 			  >BinOp</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Text.Show"
 			  >ShowS</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -260,9 +260,9 @@
 			><p class="src"
 			><a href="#"
 			  >show</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="QuasiExpr"
 			  >BinOp</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Data.String"
 			  >String</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -270,9 +270,9 @@
 			><p class="src"
 			><a href="#"
 			  >showList</a
-			  > :: [<a href="#"
+			  > :: [<a href="#" title="QuasiExpr"
 			  >BinOp</a
-			  >] -&gt; <a href="#"
+			  >] -&gt; <a href="#" title="Text.Show"
 			  >ShowS</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -289,9 +289,9 @@
 	><p class="src"
 	  ><a id="v:eval" class="def"
 	    >eval</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="QuasiExpr"
 	    >Expr</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -309,7 +309,7 @@
 	><p class="src"
 	  ><a id="v:parseExprExp" class="def"
 	    >parseExprExp</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.String"
 	    >String</a
 	    > -&gt; Q Exp <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -45,7 +45,7 @@
 	><p class="src"
 	  ><a id="v:val" class="def"
 	    >val</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/SpuriousSuperclassConstraints.html
+++ b/html-test/ref/SpuriousSuperclassConstraints.html
@@ -73,9 +73,9 @@ Fix spurious superclass constraints bug.</pre
 	    >data</span
 	    > <a id="t:SomeType" class="def"
 	    >SomeType</a
-	    > (f :: <a href="#"
+	    > (f :: <a href="#" title="Data.Kind"
 	    >*</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Kind"
 	    >*</a
 	    >) a <a href="#" class="selflink"
 	    >#</a
@@ -90,9 +90,9 @@ Fix spurious superclass constraints bug.</pre
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:SomeType:Functor:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Data.Functor"
 		      >Functor</a
-		      > (<a href="#"
+		      > (<a href="#" title="SpuriousSuperclassConstraints"
 		      >SomeType</a
 		      > f)</span
 		    > <a href="#" class="selflink"
@@ -112,9 +112,9 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >fmap</a
-			  > :: (a -&gt; b) -&gt; <a href="#"
+			  > :: (a -&gt; b) -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f a -&gt; <a href="#"
+			  > f a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f b <a href="#" class="selflink"
 			  >#</a
@@ -122,9 +122,9 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >(&lt;$)</a
-			  > :: a -&gt; <a href="#"
+			  > :: a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f b -&gt; <a href="#"
+			  > f b -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f a <a href="#" class="selflink"
 			  >#</a
@@ -138,11 +138,11 @@ Fix spurious superclass constraints bug.</pre
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:SomeType:Applicative:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Control.Applicative"
 		      >Applicative</a
-		      > f =&gt; <a href="#"
+		      > f =&gt; <a href="#" title="Control.Applicative"
 		      >Applicative</a
-		      > (<a href="#"
+		      > (<a href="#" title="SpuriousSuperclassConstraints"
 		      >SomeType</a
 		      > f)</span
 		    > <a href="#" class="selflink"
@@ -162,7 +162,7 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >pure</a
-			  > :: a -&gt; <a href="#"
+			  > :: a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f a <a href="#" class="selflink"
 			  >#</a
@@ -170,11 +170,11 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >(&lt;*&gt;)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f (a -&gt; b) -&gt; <a href="#"
+			  > f (a -&gt; b) -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f a -&gt; <a href="#"
+			  > f a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f b <a href="#" class="selflink"
 			  >#</a
@@ -182,11 +182,11 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >liftA2</a
-			  > :: (a -&gt; b -&gt; c) -&gt; <a href="#"
+			  > :: (a -&gt; b -&gt; c) -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f a -&gt; <a href="#"
+			  > f a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f b -&gt; <a href="#"
+			  > f b -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f c <a href="#" class="selflink"
 			  >#</a
@@ -194,11 +194,11 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >(*&gt;)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f a -&gt; <a href="#"
+			  > f a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f b -&gt; <a href="#"
+			  > f b -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f b <a href="#" class="selflink"
 			  >#</a
@@ -206,11 +206,11 @@ Fix spurious superclass constraints bug.</pre
 			><p class="src"
 			><a href="#"
 			  >(&lt;*)</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f a -&gt; <a href="#"
+			  > f a -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
-			  > f b -&gt; <a href="#"
+			  > f b -&gt; <a href="#" title="SpuriousSuperclassConstraints"
 			  >SomeType</a
 			  > f a <a href="#" class="selflink"
 			  >#</a

--- a/html-test/ref/Table.html
+++ b/html-test/ref/Table.html
@@ -202,7 +202,7 @@
 		><tr
 		><td
 		  > <code
-		    ><a href="#"
+		    ><a href="#" title="Table"
 		      >tableWithHeader</a
 		      ></code
 		    >      </td

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -133,19 +133,19 @@
 	><p
 	  >This module illustrates &amp; tests most of the features of Haddock.
  Testing references from the description: <code
-	    ><a href="#"
+	    ><a href="#" title="Test"
 	      >T</a
 	      ></code
 	    >, <code
-	    ><a href="#"
+	    ><a href="#" title="Test"
 	      >f</a
 	      ></code
 	    >, <code
-	    ><a href="#"
+	    ><a href="#" title="Test"
 	      >g</a
 	      ></code
 	    >, <code
-	    ><a href="#"
+	    ><a href="#" title="Visible"
 	      >visible</a
 	      ></code
 	    >.</p
@@ -165,23 +165,23 @@
 	      ><li
 		>= <a href="#"
 		  >A</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > (<a href="#"
+		  > (<a href="#" title="Data.Maybe"
 		  >Maybe</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
 		  >)</li
 		><li
 		>| <a href="#"
 		  >B</a
-		  > (<a href="#"
+		  > (<a href="#" title="Test"
 		  >T</a
-		  > a b, <a href="#"
+		  > a b, <a href="#" title="Test"
 		  >T</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
 		  >)</li
 		></ul
@@ -357,7 +357,7 @@
 		  ><li
 		    ><a href="#"
 		      >p</a
-		      > :: <a href="#"
+		      > :: <a href="#" title="Data.Int"
 		      >Int</a
 		      ></li
 		    ><li
@@ -371,7 +371,7 @@
 		      >r</a
 		      >, <a href="#"
 		      >s</a
-		      > :: <a href="#"
+		      > :: <a href="#" title="Data.Int"
 		      >Int</a
 		      ></li
 		    ></ul
@@ -383,25 +383,25 @@
 		  ><li
 		    ><a href="#"
 		      >t</a
-		      > :: T1 -&gt; <a href="#"
+		      > :: T1 -&gt; <a href="#" title="Test"
 		      >T2</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
-		      > -&gt; <a href="#"
+		      > -&gt; <a href="#" title="Test"
 		      >T3</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Bool"
 		      >Bool</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Bool"
 		      >Bool</a
-		      > -&gt; <a href="#"
+		      > -&gt; <a href="#" title="Test"
 		      >T4</a
-		      > <a href="#"
+		      > <a href="#" title="Prelude"
 		      >Float</a
-		      > <a href="#"
+		      > <a href="#" title="Prelude"
 		      >Float</a
-		      > -&gt; <a href="#"
+		      > -&gt; <a href="#" title="Test"
 		      >T5</a
 		      > () ()</li
 		    ><li
@@ -409,7 +409,7 @@
 		      >u</a
 		      >, <a href="#"
 		      >v</a
-		      > :: <a href="#"
+		      > :: <a href="#" title="Data.Int"
 		      >Int</a
 		      ></li
 		    ></ul
@@ -427,27 +427,51 @@
 	      ><li
 		><a href="#"
 		  >s1</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		><li
 		><a href="#"
 		  >s2</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		><li
 		><a href="#"
 		  >s3</a
-		  > :: <a href="#"
+		  > :: <a href="#" title="Data.Int"
 		  >Int</a
 		  ></li
 		></ul
 	      >}</li
 	    ><li class="src short"
+	    ><a href="#"
+	      >p</a
+	      > :: <a href="#" title="Test"
+	      >R</a
+	      > -&gt; <a href="#" title="Data.Int"
+	      >Int</a
+	      ></li
+	    ><li class="src short"
+	    ><a href="#"
+	      >q</a
+	      > :: <a href="#" title="Test"
+	      >R</a
+	      > -&gt; <span class="keyword"
+	      >forall</span
+	      > a. a -&gt; a</li
+	    ><li class="src short"
+	    ><a href="#"
+	      >u</a
+	      > :: <a href="#" title="Test"
+	      >R</a
+	      > -&gt; <a href="#" title="Data.Int"
+	      >Int</a
+	      ></li
+	    ><li class="src short"
 	    ><span class="keyword"
 	      >class</span
-	      > <a href="#"
+	      > <a href="#" title="Test"
 	      >D</a
 	      > a =&gt; <a href="#"
 	      >C</a
@@ -485,33 +509,33 @@
 	    ><li class="src short"
 	    ><a href="#"
 	      >a</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Test"
 	      >C</a
-	      > a =&gt; <a href="#"
+	      > a =&gt; <a href="#" title="System.IO"
 	      >IO</a
 	      > a</li
 	    ><li class="src short"
 	    ><a href="#"
 	      >f</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Test"
 	      >C</a
-	      > a =&gt; a -&gt; <a href="#"
+	      > a =&gt; a -&gt; <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >g</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="System.IO"
 	      >IO</a
 	      > CInt</li
 	    ><li class="src short"
 	    ><a href="#"
 	      >hidden</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
@@ -525,7 +549,7 @@
 	      >Ex</a
 	      > a<ul class="subs"
 	      ><li
-		>= <a href="#"
+		>= <a href="#" title="Test"
 		  >C</a
 		  > b =&gt; <a href="#"
 		  >Ex1</a
@@ -535,7 +559,7 @@
 		  >Ex2</a
 		  > b</li
 		><li
-		>| <a href="#"
+		>| <a href="#" title="Test"
 		  >C</a
 		  > a =&gt; <a href="#"
 		  >Ex3</a
@@ -551,75 +575,75 @@
 	    ><li class="src short"
 	    ><a href="#"
 	      >k</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Test"
 	      >T</a
-	      > () () -&gt; <a href="#"
+	      > () () -&gt; <a href="#" title="Test"
 	      >T2</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
-	      > -&gt; (<a href="#"
+	      > -&gt; (<a href="#" title="Test"
 	      >T3</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Bool"
 	      >Bool</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Bool"
 	      >Bool</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Test"
 	      >T4</a
-	      > <a href="#"
+	      > <a href="#" title="Prelude"
 	      >Float</a
-	      > <a href="#"
+	      > <a href="#" title="Prelude"
 	      >Float</a
-	      >) -&gt; <a href="#"
+	      >) -&gt; <a href="#" title="Test"
 	      >T5</a
-	      > () () -&gt; <a href="#"
+	      > () () -&gt; <a href="#" title="System.IO"
 	      >IO</a
 	      > ()</li
 	    ><li class="src short"
 	    ><a href="#"
 	      >l</a
-	      > :: (<a href="#"
+	      > :: (<a href="#" title="Data.Int"
 	      >Int</a
-	      >, <a href="#"
+	      >, <a href="#" title="Data.Int"
 	      >Int</a
-	      >, <a href="#"
+	      >, <a href="#" title="Prelude"
 	      >Float</a
-	      >) -&gt; <a href="#"
+	      >) -&gt; <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >m</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Test"
 	      >R</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="Test"
 	      >N1</a
-	      > () -&gt; <a href="#"
+	      > () -&gt; <a href="#" title="System.IO"
 	      >IO</a
-	      > <a href="#"
+	      > <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >o</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Float</a
-	      > -&gt; <a href="#"
+	      > -&gt; <a href="#" title="System.IO"
 	      >IO</a
-	      > <a href="#"
+	      > <a href="#" title="Prelude"
 	      >Float</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >f'</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >withType</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ><li class="src short"
@@ -662,17 +686,17 @@
 	      ><td class="src"
 		><a id="v:A" class="def"
 		  >A</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > (<a href="#"
+		  > (<a href="#" title="Data.Maybe"
 		  >Maybe</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
 		  >)</td
 		><td class="doc"
 		><p
 		  >This comment describes the <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >A</a
 		      ></code
 		    > constructor</p
@@ -682,19 +706,19 @@
 	      ><td class="src"
 		><a id="v:B" class="def"
 		  >B</a
-		  > (<a href="#"
+		  > (<a href="#" title="Test"
 		  >T</a
-		  > a b, <a href="#"
+		  > a b, <a href="#" title="Test"
 		  >T</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
 		  >)</td
 		><td class="doc"
 		><p
 		  >This comment describes the <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >B</a
 		      ></code
 		    > constructor</p
@@ -806,7 +830,7 @@
 		><td class="doc"
 		><p
 		  >documents <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >A3</a
 		      ></code
 		    ></p
@@ -820,7 +844,7 @@
 		><td class="doc"
 		><p
 		  >documents <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >B3</a
 		      ></code
 		    ></p
@@ -854,7 +878,7 @@
 		><td class="doc"
 		><p
 		  >This is the doc for <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >A4</a
 		      ></code
 		    ></p
@@ -868,7 +892,7 @@
 		><td class="doc"
 		><p
 		  >This is the doc for <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >B4</a
 		      ></code
 		    ></p
@@ -882,7 +906,7 @@
 		><td class="doc"
 		><p
 		  >This is the doc for <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >C4</a
 		      ></code
 		    ></p
@@ -1004,7 +1028,7 @@
 			><div class="doc"
 			><p
 			  >this is the <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >n3</a
 			      ></code
 			    > field</p
@@ -1145,7 +1169,7 @@
 		><td class="doc"
 		><p
 		  >The <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >N7</a
 		      ></code
 		    > constructor</p
@@ -1188,24 +1212,24 @@
 	  ><div class="doc"
 	  ><p
 	    >This is the documentation for the <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>R</a
 		></code
 	      > record, which has four fields,
  <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>p</a
 		></code
 	      >, <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>q</a
 		></code
 	      >, <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>r</a
 		></code
 	      >, and <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>s</a
 		></code
 	      >.</p
@@ -1222,7 +1246,7 @@
 		><td class="doc"
 		><p
 		  >This is the <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >C1</a
 		      ></code
 		    > record constructor, with the following fields:</p
@@ -1238,13 +1262,13 @@
 		      ><dfn class="src"
 			><a id="v:p" class="def"
 			  >p</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"
 			><p
 			  >This comment applies to the <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >p</a
 			      ></code
 			    > field</p
@@ -1260,7 +1284,7 @@
 			><div class="doc"
 			><p
 			  >This comment applies to the <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >q</a
 			      ></code
 			    > field</p
@@ -1272,17 +1296,17 @@
 			  >r</a
 			  >, <a id="v:s" class="def"
 			  >s</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"
 			><p
 			  >This comment applies to both <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >r</a
 			      ></code
 			    > and <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >s</a
 			      ></code
 			    ></p
@@ -1300,7 +1324,7 @@
 		><td class="doc"
 		><p
 		  >This is the <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >C2</a
 		      ></code
 		    > record constructor, also with some fields:</p
@@ -1316,25 +1340,25 @@
 		      ><dfn class="src"
 			><a id="v:t" class="def"
 			  >t</a
-			  > :: T1 -&gt; <a href="#"
+			  > :: T1 -&gt; <a href="#" title="Test"
 			  >T2</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Test"
 			  >T3</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Bool"
 			  >Bool</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Test"
 			  >T4</a
-			  > <a href="#"
+			  > <a href="#" title="Prelude"
 			  >Float</a
-			  > <a href="#"
+			  > <a href="#" title="Prelude"
 			  >Float</a
-			  > -&gt; <a href="#"
+			  > -&gt; <a href="#" title="Test"
 			  >T5</a
 			  > () ()</dfn
 			><div class="doc empty"
@@ -1346,7 +1370,7 @@
 			  >u</a
 			  >, <a id="v:v" class="def"
 			  >v</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc empty"
@@ -1384,7 +1408,7 @@
 		><td class="doc"
 		><p
 		  >This is the <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >C3</a
 		      ></code
 		    > record constructor</p
@@ -1400,13 +1424,13 @@
 		      ><dfn class="src"
 			><a id="v:s1" class="def"
 			  >s1</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"
 			><p
 			  >The <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >s1</a
 			      ></code
 			    > record selector</p
@@ -1416,13 +1440,13 @@
 		      ><dfn class="src"
 			><a id="v:s2" class="def"
 			  >s2</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"
 			><p
 			  >The <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >s2</a
 			      ></code
 			    > record selector</p
@@ -1432,13 +1456,13 @@
 		      ><dfn class="src"
 			><a id="v:s3" class="def"
 			  >s3</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Data.Int"
 			  >Int</a
 			  ></dfn
 			><div class="doc"
 			><p
 			  >The <code
-			    ><a href="#"
+			    ><a href="#" title="Test"
 			      >s3</a
 			      ></code
 			    > record selector</p
@@ -1455,6 +1479,58 @@
 	><p
 	  >test that we can export record selectors on their own:</p
 	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:p" class="def"
+	    >p</a
+	    > :: <a href="#" title="Test"
+	    >R</a
+	    > -&gt; <a href="#" title="Data.Int"
+	    >Int</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >This comment applies to the <code
+	      ><a href="#" title="Test"
+		>p</a
+		></code
+	      > field</p
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:q" class="def"
+	    >q</a
+	    > :: <a href="#" title="Test"
+	    >R</a
+	    > -&gt; <span class="keyword"
+	    >forall</span
+	    > a. a -&gt; a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >This comment applies to the <code
+	      ><a href="#" title="Test"
+		>q</a
+		></code
+	      > field</p
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:u" class="def"
+	    >u</a
+	    > :: <a href="#" title="Test"
+	    >R</a
+	    > -&gt; <a href="#" title="Data.Int"
+	    >Int</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
 	><a href="#" id="g:4"
 	><h1
 	  >Class declarations</h1
@@ -1463,7 +1539,7 @@
 	><p class="src"
 	  ><span class="keyword"
 	    >class</span
-	    > <a href="#"
+	    > <a href="#" title="Test"
 	    >D</a
 	    > a =&gt; <a id="t:C" class="def"
 	    >C</a
@@ -1477,7 +1553,7 @@
 	    >This comment applies to the <em
 	      >previous</em
 	      > declaration (the <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>C</a
 		></code
 	      > class)</p
@@ -1486,9 +1562,9 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Test"
 	      >a</a
-	      >, <a href="#"
+	      >, <a href="#" title="Test"
 	      >b</a
 	      ></p
 	    ></div
@@ -1498,7 +1574,7 @@
 	    ><p class="src"
 	    ><a id="v:a" class="def"
 	      >a</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="System.IO"
 	      >IO</a
 	      > a <a href="#" class="selflink"
 	      >#</a
@@ -1506,7 +1582,7 @@
 	    ><div class="doc"
 	    ><p
 	      >this is a description of the <code
-		><a href="#"
+		><a href="#" title="Test"
 		  >a</a
 		  ></code
 		> method</p
@@ -1520,7 +1596,7 @@
 	    ><div class="doc"
 	    ><p
 	      >this is a description of the <code
-		><a href="#"
+		><a href="#" title="Test"
 		  >b</a
 		  ></code
 		> method</p
@@ -1546,9 +1622,9 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Test"
 	      >d</a
-	      >, <a href="#"
+	      >, <a href="#" title="Test"
 	      >e</a
 	      ></p
 	    ></div
@@ -1558,7 +1634,7 @@
 	    ><p class="src"
 	    ><a id="v:d" class="def"
 	      >d</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Test"
 	      >T</a
 	      > a b <a href="#" class="selflink"
 	      >#</a
@@ -1580,9 +1656,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:D:D:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Test"
 		      >D</a
-		      > <a href="#"
+		      > <a href="#" title="Prelude"
 		      >Float</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1602,9 +1678,9 @@
 			><p class="src"
 			><a href="#"
 			  >d</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Test"
 			  >T</a
-			  > <a href="#"
+			  > <a href="#" title="Prelude"
 			  >Float</a
 			  > b <a href="#" class="selflink"
 			  >#</a
@@ -1612,9 +1688,9 @@
 			><p class="src"
 			><a href="#"
 			  >e</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Prelude"
 			  >Float</a
-			  >, <a href="#"
+			  >, <a href="#" title="Prelude"
 			  >Float</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -1628,9 +1704,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:D:D:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="Test"
 		      >D</a
-		      > <a href="#"
+		      > <a href="#" title="Data.Int"
 		      >Int</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1650,9 +1726,9 @@
 			><p class="src"
 			><a href="#"
 			  >d</a
-			  > :: <a href="#"
+			  > :: <a href="#" title="Test"
 			  >T</a
-			  > <a href="#"
+			  > <a href="#" title="Data.Int"
 			  >Int</a
 			  > b <a href="#" class="selflink"
 			  >#</a
@@ -1660,9 +1736,9 @@
 			><p class="src"
 			><a href="#"
 			  >e</a
-			  > :: (<a href="#"
+			  > :: (<a href="#" title="Data.Int"
 			  >Int</a
-			  >, <a href="#"
+			  >, <a href="#" title="Data.Int"
 			  >Int</a
 			  >) <a href="#" class="selflink"
 			  >#</a
@@ -1710,7 +1786,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Test"
 	      >ff</a
 	      ></p
 	    ></div
@@ -1733,9 +1809,9 @@
 	><p class="src"
 	  ><a id="v:a" class="def"
 	    >a</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Test"
 	    >C</a
-	    > a =&gt; <a href="#"
+	    > a =&gt; <a href="#" title="System.IO"
 	    >IO</a
 	    > a <a href="#" class="selflink"
 	    >#</a
@@ -1743,7 +1819,7 @@
 	  ><div class="doc"
 	  ><p
 	    >this is a description of the <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>a</a
 		></code
 	      > method</p
@@ -1757,9 +1833,9 @@
 	><p class="src"
 	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Test"
 	    >C</a
-	    > a =&gt; a -&gt; <a href="#"
+	    > a =&gt; a -&gt; <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -1768,7 +1844,7 @@
 	  ><p
 	    >In a comment string we can refer to identifiers in scope with
 single quotes like this: <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>T</a
 		></code
 	      >, and we can refer to modules by
@@ -1801,7 +1877,7 @@ using double quotes: <a href="#"
 	      ></dl
 	    ><pre
 	    >     This is a block of code, which can include other markup: <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>R</a
 		></code
 	      >
@@ -1821,9 +1897,9 @@ using double quotes: <a href="#"
 	><p class="src"
 	  ><a id="v:g" class="def"
 	    >g</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="System.IO"
 	    >IO</a
 	    > CInt <a href="#" class="selflink"
 	    >#</a
@@ -1936,9 +2012,9 @@ is at the beginning of the line).</pre
 	><p class="src"
 	  ><a id="v:hidden" class="def"
 	    >hidden</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -1981,7 +2057,7 @@ is at the beginning of the line).</pre
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="Test"
 		  >C</a
 		  > b =&gt; <a id="v:Ex1" class="def"
 		  >Ex1</a
@@ -1999,7 +2075,7 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="Test"
 		  >C</a
 		  > a =&gt; <a id="v:Ex3" class="def"
 		  >Ex3</a
@@ -2037,13 +2113,13 @@ is at the beginning of the line).</pre
 	    ><table
 	    ><tr
 	      ><td class="src"
-		>:: <a href="#"
+		>:: <a href="#" title="Test"
 		  >T</a
 		  > () ()</td
 		><td class="doc"
 		><p
 		  >This argument has type <code
-		    ><a href="#"
+		    ><a href="#" title="Test"
 		      >T</a
 		      ></code
 		    ></p
@@ -2051,11 +2127,11 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="Test"
 		  >T2</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc"
@@ -2065,17 +2141,17 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; (<a href="#"
+		>-&gt; (<a href="#" title="Test"
 		  >T3</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Bool"
 		  >Bool</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Bool"
 		  >Bool</a
-		  > -&gt; <a href="#"
+		  > -&gt; <a href="#" title="Test"
 		  >T4</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
 		  >)</td
 		><td class="doc"
@@ -2087,7 +2163,7 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="Test"
 		  >T5</a
 		  > () ()</td
 		><td class="doc"
@@ -2099,7 +2175,7 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="System.IO"
 		  >IO</a
 		  > ()</td
 		><td class="doc"
@@ -2127,11 +2203,11 @@ is at the beginning of the line).</pre
 	    ><table
 	    ><tr
 	      ><td class="src"
-		>:: (<a href="#"
+		>:: (<a href="#" title="Data.Int"
 		  >Int</a
-		  >, <a href="#"
+		  >, <a href="#" title="Data.Int"
 		  >Int</a
-		  >, <a href="#"
+		  >, <a href="#" title="Prelude"
 		  >Float</a
 		  >)</td
 		><td class="doc"
@@ -2141,13 +2217,13 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc"
 		><p
 		  >returns an <code
-		    ><a href="#"
+		    ><a href="#" title="Data.Int"
 		      >Int</a
 		      ></code
 		    ></p
@@ -2169,7 +2245,7 @@ is at the beginning of the line).</pre
 	    ><table
 	    ><tr
 	      ><td class="src"
-		>:: <a href="#"
+		>:: <a href="#" title="Test"
 		  >R</a
 		  ></td
 		><td class="doc empty"
@@ -2177,7 +2253,7 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="Test"
 		  >N1</a
 		  > ()</td
 		><td class="doc"
@@ -2187,9 +2263,9 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="System.IO"
 		  >IO</a
-		  > <a href="#"
+		  > <a href="#" title="Data.Int"
 		  >Int</a
 		  ></td
 		><td class="doc"
@@ -2217,7 +2293,7 @@ is at the beginning of the line).</pre
 	    ><table
 	    ><tr
 	      ><td class="src"
-		>:: <a href="#"
+		>:: <a href="#" title="Prelude"
 		  >Float</a
 		  ></td
 		><td class="doc"
@@ -2227,9 +2303,9 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		>-&gt; <a href="#"
+		>-&gt; <a href="#" title="System.IO"
 		  >IO</a
-		  > <a href="#"
+		  > <a href="#" title="Prelude"
 		  >Float</a
 		  ></td
 		><td class="doc"
@@ -2264,7 +2340,7 @@ is at the beginning of the line).</pre
 	><p class="src"
 	  ><a id="v:f-39-" class="def"
 	    >f'</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -2272,7 +2348,7 @@ is at the beginning of the line).</pre
 	  ><div class="doc"
 	  ><p
 	    >a function with a prime can be referred to as <code
-	      ><a href="#"
+	      ><a href="#" title="Test"
 		>f'</a
 		></code
 	      >
@@ -2283,7 +2359,7 @@ is at the beginning of the line).</pre
 	><p class="src"
 	  ><a id="v:withType" class="def"
 	    >withType</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -56,7 +56,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >f</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ></ul
@@ -69,7 +69,7 @@
 	><p class="src"
 	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -63,7 +63,7 @@
 	  ><div class="doc"
 	  ><p
 	    >...given a raw <code
-	      ><a href="#"
+	      ><a href="#" title="GHC.Exts"
 		>Addr#</a
 		></code
 	      > to the string, and the length of the string.</p

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -56,7 +56,7 @@
 	  ><p class="caption"
 	    >Minimal complete definition</p
 	    ><p class="src"
-	    ><a href="#"
+	    ><a href="#" title="Ticket61"
 	      >f</a
 	      ></p
 	    ></div

--- a/html-test/ref/Ticket75.html
+++ b/html-test/ref/Ticket75.html
@@ -54,7 +54,7 @@
 	    ><li class="src short"
 	    ><a href="#"
 	      >f</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -91,7 +91,7 @@
 	><p class="src"
 	  ><a id="v:f" class="def"
 	    >f</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -99,7 +99,7 @@
 	  ><div class="doc"
 	  ><p
 	    >A reference to <code
-	      ><a href="#"
+	      ><a href="#" title="Ticket75"
 		>:-</a
 		></code
 	      ></p

--- a/html-test/ref/TitledPicture.html
+++ b/html-test/ref/TitledPicture.html
@@ -46,13 +46,13 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >foo</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
 	      >bar</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Prelude"
 	      >Integer</a
 	      ></li
 	    ></ul
@@ -65,7 +65,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -73,7 +73,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Picture for <code
-	      ><a href="#"
+	      ><a href="#" title="TitledPicture"
 		>foo</a
 		></code
 	      > without a title <img src="bar"
@@ -84,7 +84,7 @@
 	><p class="src"
 	  ><a id="v:bar" class="def"
 	    >bar</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Prelude"
 	    >Integer</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -92,7 +92,7 @@
 	  ><div class="doc"
 	  ><p
 	    >Picture for <code
-	      ><a href="#"
+	      ><a href="#" title="TitledPicture"
 		>bar</a
 		></code
 	      > with title <img src="un&#8739;&#8705;&#8728;" title="&#948;&#8712;"

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -110,7 +110,7 @@
 	      >data family</span
 	      > <a href="#"
 	      >Bat</a
-	      > (a :: k) :: <a href="#"
+	      > (a :: k) :: <a href="#" title="Data.Kind"
 	      >*</a
 	      ></li
 	    ><li class="src short"
@@ -126,7 +126,7 @@
 		  >data</span
 		  > <a href="#"
 		  >AssocD</a
-		  > a :: <a href="#"
+		  > a :: <a href="#" title="Data.Kind"
 		  >*</a
 		  ></li
 		><li
@@ -134,7 +134,7 @@
 		  >type</span
 		  > <a href="#"
 		  >AssocT</a
-		  > a :: <a href="#"
+		  > a :: <a href="#" title="Data.Kind"
 		  >*</a
 		  ></li
 		></ul
@@ -224,13 +224,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:X:-62--60-:1"
 		      ></span
-		      > <a href="#"
-		      >(&gt;&lt;)</a
-		      > <a href="#"
-		      >X</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >XX</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
+		      >&gt;&lt;</a
+		      > <a href="#" title="TypeFamilies"
 		      >XXX</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -252,11 +250,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:X:Assoc:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Assoc</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -278,13 +274,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >data</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocD</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >X</a
-			  > (a :: <a href="#"
-			  >X</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -292,13 +286,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocT</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >X</a
-			  > (a :: <a href="#"
-			  >X</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -312,11 +304,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:X:Test:3"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Test</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -342,9 +332,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -361,11 +351,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Foo</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -378,13 +368,11 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
-		      >(&lt;&gt;)</a
-		      > <a href="#"
-		      >X</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >XXX</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
+		      >&lt;&gt;</a
+		      > <a href="#" title="TypeFamilies"
 		      >XX</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -401,15 +389,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
-			>(&lt;&gt;)</a
-			> <a href="#"
-			>X</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>XXX</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
+			>&lt;&gt;</a
+			> <a href="#" title="TypeFamilies"
 			>XX</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>X</a
 			></div
 		      ></details
@@ -422,11 +408,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >AssocD</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -443,11 +427,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>AssocD</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
 			> = <a id="v:AssocX" class="def"
 			>AssocX</a
@@ -462,11 +444,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >AssocT</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -483,19 +463,17 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>AssocT</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> = <a href="#"
+			> = (<a href="#" title="TypeFamilies"
 			>Foo</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			></div
+			> :: <a href="#" title="Data.Kind"
+			>*</a
+			>)</div
 		      ></details
 		    ></td
 		  ></tr
@@ -506,11 +484,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Bat</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -529,17 +505,15 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
 			> <ul class="inst"
 			><li class="inst"
 			  >= <a id="v:BatX" class="def"
 			    >BatX</a
-			    > <a href="#"
+			    > <a href="#" title="TypeFamilies"
 			    >X</a
 			    ></li
 			  ><li class="inst"
@@ -549,13 +523,13 @@
 			    ><li
 			      ><a id="v:aaa" class="def"
 				>aaa</a
-				> :: <a href="#"
+				> :: <a href="#" title="TypeFamilies"
 				>X</a
 				></li
 			      ><li
 			      ><a id="v:bbb" class="def"
 				>bbb</a
-				> :: <a href="#"
+				> :: <a href="#" title="TypeFamilies"
 				>Y</a
 				></li
 			      ></ul
@@ -572,11 +546,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Foo</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -593,13 +565,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Foo</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -612,13 +582,13 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
-		      >(&lt;&gt;)</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
-		      > a</span
+		      > <a href="#" title="TypeFamilies"
+		      >&lt;&gt;</a
+		      > (a :: <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -633,13 +603,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
-			>(&lt;&gt;)</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> a = <a href="#"
+			> <a href="#" title="TypeFamilies"
+			>&lt;&gt;</a
+			> (a :: <a href="#" title="Data.Kind"
+			>*</a
+			>) = <a href="#" title="TypeFamilies"
 			>X</a
 			></div
 		      ></details
@@ -672,11 +642,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Y:Assoc:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Assoc</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -698,13 +666,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >data</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocD</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >Y</a
-			  > (a :: <a href="#"
-			  >Y</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -712,13 +678,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocT</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >Y</a
-			  > (a :: <a href="#"
-			  >Y</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -732,11 +696,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Y:Test:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Test</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -762,9 +724,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -781,9 +743,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Bar</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -796,11 +758,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >AssocD</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -817,11 +777,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>AssocD</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			> = <a id="v:AssocY" class="def"
 			>AssocY</a
@@ -836,11 +794,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >AssocT</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -857,17 +813,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>AssocT</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -880,11 +832,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Bat</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -903,15 +853,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			> = <a id="v:BatY" class="def"
 			>BatY</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -924,11 +872,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Foo</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -945,13 +891,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Foo</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>X</a
 			></div
 		      ></details
@@ -964,13 +908,13 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
-		      >(&lt;&gt;)</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
-		      > a</span
+		      > <a href="#" title="TypeFamilies"
+		      >&lt;&gt;</a
+		      > (a :: <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -985,13 +929,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
-			>(&lt;&gt;)</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
-			> a = a</div
+			> <a href="#" title="TypeFamilies"
+			>&lt;&gt;</a
+			> (a :: <a href="#" title="Data.Kind"
+			>*</a
+			>) = a</div
 		      ></details
 		    ></td
 		  ></tr
@@ -1046,11 +990,11 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Bat</a
-		      > <a href="#"
+		      > (z :: <a href="#" title="TypeFamilies"
 		      >Z</a
-		      ></span
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -1067,31 +1011,27 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
+			> (z :: <a href="#" title="TypeFamilies"
 			>Z</a
-			> <span class="keyword"
+			>) <span class="keyword"
 			>where</span
 			><ul class="inst"
 			><li class="inst"
 			  ><a id="v:BatZ1" class="def"
 			    >BatZ1</a
-			    > :: <a href="#"
+			    > :: <a href="#" title="TypeFamilies"
 			    >Bat</a
-			    > <a href="#"
-			    >Z</a
-			    > <a href="#"
+			    > <a href="#" title="TypeFamilies"
 			    >ZA</a
 			    ></li
 			  ><li class="inst"
 			  ><a id="v:BatZ2" class="def"
 			    >BatZ2</a
-			    > :: <a href="#"
+			    > :: <a href="#" title="TypeFamilies"
 			    >Bat</a
-			    > <a href="#"
-			    >Z</a
-			    > <a href="#"
+			    > <a href="#" title="TypeFamilies"
 			    >ZB</a
 			    ></li
 			  ></ul
@@ -1126,11 +1066,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Test:Test:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Test</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1154,11 +1092,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Test:Test:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Test</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1206,11 +1142,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Foo</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1227,13 +1161,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Foo</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>X</a
 			></div
 		      ></details
@@ -1246,11 +1178,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Foo</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1267,13 +1197,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Foo</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -1289,7 +1217,7 @@
 	    >data family</span
 	    > <a id="t:Bat" class="def"
 	    >Bat</a
-	    > (a :: k) :: <a href="#"
+	    > (a :: k) :: <a href="#" title="Data.Kind"
 	    >*</a
 	    > <a href="#" class="selflink"
 	    >#</a
@@ -1310,11 +1238,11 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Bat</a
-		      > <a href="#"
+		      > (z :: <a href="#" title="TypeFamilies"
 		      >Z</a
-		      ></span
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -1331,31 +1259,27 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
+			> (z :: <a href="#" title="TypeFamilies"
 			>Z</a
-			> <span class="keyword"
+			>) <span class="keyword"
 			>where</span
 			><ul class="inst"
 			><li class="inst"
 			  ><a id="v:BatZ1" class="def"
 			    >BatZ1</a
-			    > :: <a href="#"
+			    > :: <a href="#" title="TypeFamilies"
 			    >Bat</a
-			    > <a href="#"
-			    >Z</a
-			    > <a href="#"
+			    > <a href="#" title="TypeFamilies"
 			    >ZA</a
 			    ></li
 			  ><li class="inst"
 			  ><a id="v:BatZ2" class="def"
 			    >BatZ2</a
-			    > :: <a href="#"
+			    > :: <a href="#" title="TypeFamilies"
 			    >Bat</a
-			    > <a href="#"
-			    >Z</a
-			    > <a href="#"
+			    > <a href="#" title="TypeFamilies"
 			    >ZB</a
 			    ></li
 			  ></ul
@@ -1370,11 +1294,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Bat</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1393,15 +1315,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			> = <a id="v:BatY" class="def"
 			>BatY</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -1414,11 +1334,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Bat</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1437,17 +1355,15 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Bat</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
 			> <ul class="inst"
 			><li class="inst"
 			  >= <a id="v:BatX" class="def"
 			    >BatX</a
-			    > <a href="#"
+			    > <a href="#" title="TypeFamilies"
 			    >X</a
 			    ></li
 			  ><li class="inst"
@@ -1457,13 +1373,13 @@
 			    ><li
 			      ><a id="v:aaa" class="def"
 				>aaa</a
-				> :: <a href="#"
+				> :: <a href="#" title="TypeFamilies"
 				>X</a
 				></li
 			      ><li
 			      ><a id="v:bbb" class="def"
 				>bbb</a
-				> :: <a href="#"
+				> :: <a href="#" title="TypeFamilies"
 				>Y</a
 				></li
 			      ></ul
@@ -1498,7 +1414,7 @@
 	      >data</span
 	      > <a id="t:AssocD" class="def"
 	      >AssocD</a
-	      > a :: <a href="#"
+	      > a :: <a href="#" title="Data.Kind"
 	      >*</a
 	      > <a href="#" class="selflink"
 	      >#</a
@@ -1512,7 +1428,7 @@
 	      >type</span
 	      > <a id="t:AssocT" class="def"
 	      >AssocT</a
-	      > a :: <a href="#"
+	      > a :: <a href="#" title="Data.Kind"
 	      >*</a
 	      > <a href="#" class="selflink"
 	      >#</a
@@ -1532,11 +1448,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Assoc:Assoc:1"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Assoc</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1558,13 +1472,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >data</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocD</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >Y</a
-			  > (a :: <a href="#"
-			  >Y</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1572,13 +1484,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocT</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >Y</a
-			  > (a :: <a href="#"
-			  >Y</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1592,11 +1502,9 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:Assoc:Assoc:2"
 		      ></span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Assoc</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1618,13 +1526,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >data</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocD</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >X</a
-			  > (a :: <a href="#"
-			  >X</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1632,13 +1538,11 @@
 			><p class="src"
 			><span class="keyword"
 			  >type</span
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >AssocT</a
-			  > <a href="#"
+			  > <a href="#" title="TypeFamilies"
 			  >X</a
-			  > (a :: <a href="#"
-			  >X</a
-			  >) :: <a href="#"
+			  > :: <a href="#" title="Data.Kind"
 			  >*</a
 			  > <a href="#" class="selflink"
 			  >#</a
@@ -1672,11 +1576,11 @@
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="TypeFamilies"
 		  >Bar</a
-		  > <a href="#"
+		  > <a href="#" title="TypeFamilies"
 		  >X</a
-		  > = <a href="#"
+		  > = <a href="#" title="TypeFamilies"
 		  >X</a
 		  ></td
 		><td class="doc empty"
@@ -1684,9 +1588,9 @@
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="#"
+		><a href="#" title="TypeFamilies"
 		  >Bar</a
-		  > y = <a href="#"
+		  > y = <a href="#" title="TypeFamilies"
 		  >Y</a
 		  ></td
 		><td class="doc empty"
@@ -1716,13 +1620,11 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
-		      >(&lt;&gt;)</a
-		      > <a href="#"
-		      >X</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >XXX</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
+		      >&lt;&gt;</a
+		      > <a href="#" title="TypeFamilies"
 		      >XX</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -1739,15 +1641,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
-			>(&lt;&gt;)</a
-			> <a href="#"
-			>X</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>XXX</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
+			>&lt;&gt;</a
+			> <a href="#" title="TypeFamilies"
 			>XX</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>X</a
 			></div
 		      ></details
@@ -1760,13 +1660,13 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
-		      >(&lt;&gt;)</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
-		      > a</span
+		      > <a href="#" title="TypeFamilies"
+		      >&lt;&gt;</a
+		      > (a :: <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -1781,13 +1681,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
-			>(&lt;&gt;)</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
-			> a = a</div
+			> <a href="#" title="TypeFamilies"
+			>&lt;&gt;</a
+			> (a :: <a href="#" title="Data.Kind"
+			>*</a
+			>) = a</div
 		      ></details
 		    ></td
 		  ></tr
@@ -1798,13 +1698,13 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
-		      >(&lt;&gt;)</a
-		      > <a href="#"
-		      >*</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
-		      > a</span
+		      > <a href="#" title="TypeFamilies"
+		      >&lt;&gt;</a
+		      > (a :: <a href="#" title="Data.Kind"
+		      >*</a
+		      >)</span
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
@@ -1819,13 +1719,13 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
-			>(&lt;&gt;)</a
-			> <a href="#"
-			>*</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> a = <a href="#"
+			> <a href="#" title="TypeFamilies"
+			>&lt;&gt;</a
+			> (a :: <a href="#" title="Data.Kind"
+			>*</a
+			>) = <a href="#" title="TypeFamilies"
 			>X</a
 			></div
 		      ></details
@@ -1854,13 +1754,11 @@
 		  ><span class="inst-left"
 		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:ic:-62--60-:-62--60-:1"
 		      ></span
-		      > <a href="#"
-		      >(&gt;&lt;)</a
-		      > <a href="#"
-		      >X</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >XX</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
+		      >&gt;&lt;</a
+		      > <a href="#" title="TypeFamilies"
 		      >XXX</a
 		      ></span
 		    > <a href="#" class="selflink"

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -92,9 +92,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >W</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -113,9 +113,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Bar</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>W</a
 			> = <a id="v:BarX" class="def"
 			>BarX</a
@@ -130,9 +130,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >W</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -149,9 +149,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Foo</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>W</a
 			></div
 		      ></details
@@ -186,9 +186,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >W</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -205,9 +205,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Foo</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>W</a
 			></div
 		      ></details
@@ -220,9 +220,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >type</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Foo</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >X</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -239,11 +239,11 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>type</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Foo</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>X</a
-			> = <a href="#"
+			> = <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details
@@ -278,9 +278,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >W</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -299,9 +299,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Bar</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>W</a
 			> = <a id="v:BarX" class="def"
 			>BarX</a
@@ -316,9 +316,9 @@
 		      ></span
 		      > <span class="keyword"
 		      >data</span
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies2"
 		      >Bar</a
-		      > <a href="#"
+		      > <a href="#" title="TypeFamilies"
 		      >Y</a
 		      ></span
 		    > <a href="#" class="selflink"
@@ -335,9 +335,9 @@
 		      ><div class="src"
 		      ><span class="keyword"
 			>data</span
-			> <a href="#"
+			> <a href="#" title="TypeFamilies2"
 			>Bar</a
-			> <a href="#"
+			> <a href="#" title="TypeFamilies"
 			>Y</a
 			></div
 		      ></details

--- a/html-test/ref/TypeOperators.html
+++ b/html-test/ref/TypeOperators.html
@@ -127,7 +127,7 @@
 	><p class="src"
 	  ><a id="v:biO" class="def"
 	    >biO</a
-	    > :: (g <a href="#"
+	    > :: (g <a href="#" title="TypeOperators"
 	    >`O`</a
 	    > f) a <a href="#" class="selflink"
 	    >#</a
@@ -153,11 +153,11 @@
 	><p class="src"
 	  ><a id="v:x" class="def"
 	    >x</a
-	    > :: (a <a href="#"
+	    > :: (a <a href="#" title="TypeOperators"
 	    >:-:</a
-	    > a) <a href="#"
+	    > a) <a href="#" title="TypeOperators"
 	    >&lt;=&gt;</a
-	    > (a <a href="#"
+	    > (a <a href="#" title="TypeOperators"
 	    >`Op`</a
 	    > a) =&gt; a <a href="#" class="selflink"
 	    >#</a
@@ -167,11 +167,11 @@
 	><p class="src"
 	  ><a id="v:y" class="def"
 	    >y</a
-	    > :: (a <a href="#"
+	    > :: (a <a href="#" title="TypeOperators"
 	    >&lt;=&gt;</a
-	    > a, (a <a href="#"
+	    > a, (a <a href="#" title="TypeOperators"
 	    >`Op`</a
-	    > a) <a href="#"
+	    > a) <a href="#" title="TypeOperators"
 	    >&lt;=&gt;</a
 	    > a) =&gt; a <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Unicode.html
+++ b/html-test/ref/Unicode.html
@@ -46,7 +46,7 @@
 	  ><li class="src short"
 	    ><a href="#"
 	      >x</a
-	      > :: <a href="#"
+	      > :: <a href="#" title="Data.Int"
 	      >Int</a
 	      ></li
 	    ></ul
@@ -59,7 +59,7 @@
 	><p class="src"
 	  ><a id="v:x" class="def"
 	    >x</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a

--- a/html-test/ref/Visible.html
+++ b/html-test/ref/Visible.html
@@ -45,9 +45,9 @@
 	><p class="src"
 	  ><a id="v:visible" class="def"
 	    >visible</a
-	    > :: <a href="#"
+	    > :: <a href="#" title="Data.Int"
 	    >Int</a
-	    > -&gt; <a href="#"
+	    > -&gt; <a href="#" title="Data.Int"
 	    >Int</a
 	    > <a href="#" class="selflink"
 	    >#</a


### PR DESCRIPTION
Most tests only needed to accept the new output. 

Tests `B` and `IgnoreExports` need more work (due to #688). Ignored for now as they are not critical.