### PR TITLE
Don't put attoparsec in its own library

### DIFF
--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -26,12 +26,10 @@ library
       base         >= 4.5     && < 4.12
     , bytestring   >= 0.9.2.1 && < 0.11
     , containers   >= 0.4.2.1 && < 0.6
+    , deepseq      >= 1.3     && < 1.5
     , transformers >= 0.3.0   && < 0.6
 
-  -- internal sub-lib
-  build-depends:        attoparsec
-
-  hs-source-dirs:       src
+  hs-source-dirs:       src, vendor/attoparsec-0.13.1.0
 
   exposed-modules:
     Documentation.Haddock.Doc
@@ -42,38 +40,18 @@ library
     Documentation.Haddock.Utf8
 
   other-modules:
-    Documentation.Haddock.Parser.Util
-
-  ghc-options: -funbox-strict-fields -Wall -fwarn-tabs -O2
-  if impl(ghc >= 8.0)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
-
-library attoparsec
-  default-language:     Haskell2010
-
-  build-depends:
-      base         >= 4.5     && < 4.12
-    , bytestring   >= 0.9.2.1 && < 0.11
-    , deepseq      >= 1.3     && < 1.5
-
-  hs-source-dirs:       vendor/attoparsec-0.13.1.0
-
-  -- NB: haddock-library needs only small part of lib:attoparsec
-  --     internally, so we only bundle that subset here
-  exposed-modules:
-    Data.Attoparsec.ByteString
-    Data.Attoparsec.ByteString.Char8
-    Data.Attoparsec.Combinator
-
-  other-modules:
     Data.Attoparsec
+    Data.Attoparsec.ByteString
     Data.Attoparsec.ByteString.Buffer
+    Data.Attoparsec.ByteString.Char8
     Data.Attoparsec.ByteString.FastSet
     Data.Attoparsec.ByteString.Internal
+    Data.Attoparsec.Combinator
     Data.Attoparsec.Internal
     Data.Attoparsec.Internal.Fhthagn
     Data.Attoparsec.Internal.Types
     Data.Attoparsec.Number
+    Documentation.Haddock.Parser.Util
 
   ghc-options: -funbox-strict-fields -Wall -fwarn-tabs -O2
   if impl(ghc >= 8.0)
@@ -89,12 +67,22 @@ test-suite spec
   hs-source-dirs:
       test
     , src
+    , vendor/attoparsec-0.13.1.0
   ghc-options: -Wall
 
   cpp-options:
       -DTEST
 
   other-modules:
+      Data.Attoparsec.ByteString
+      Data.Attoparsec.ByteString.Buffer
+      Data.Attoparsec.ByteString.Char8
+      Data.Attoparsec.ByteString.FastSet
+      Data.Attoparsec.ByteString.Internal
+      Data.Attoparsec.Combinator
+      Data.Attoparsec.Internal
+      Data.Attoparsec.Internal.Fhthagn
+      Data.Attoparsec.Internal.Types
       Documentation.Haddock.Doc
       Documentation.Haddock.Parser
       Documentation.Haddock.Parser.Monad
@@ -106,21 +94,14 @@ test-suite spec
       Documentation.Haddock.Utf8Spec
 
   build-depends:
-      base-compat   ^>= 0.9.3
+      base           >= 4.5     && < 4.12
+    , base-compat   ^>= 0.9.3
+    , bytestring   >= 0.9.2.1 && < 0.11
     , containers   >= 0.4.2.1 && < 0.6
+    , deepseq      >= 1.3     && < 1.5
     , transformers   >= 0.3.0   && < 0.6
     , hspec         ^>= 2.4.4
     , QuickCheck    ^>= 2.11
-
-  -- internal sub-lib
-  build-depends: attoparsec
-
-  -- Versions for the dependencies below are transitively pinned by
-  -- dependency on haddock-library:lib:attoparsec
-  build-depends:
-      base
-    , bytestring
-    , deepseq
 
   build-tool-depends:
     hspec-discover:hspec-discover ^>= 2.4.4
@@ -140,12 +121,8 @@ test-suite fixtures
 
   -- Depend on the library.
   build-depends:
-    haddock-library
-
-  -- Versions for the dependencies below are transitively pinned by
-  -- dependency on haddock-library:lib:attoparsec
-  build-depends:
       base
+    , haddock-library
 
 source-repository head
   type:     git


### PR DESCRIPTION
This reverts 3bf3d4c95c3b32ff350e127ee087c85d5bbb24c6 as a temporary fix for two problems:

1. Rebuilds with `stack`: https://github.com/commercialhaskell/stack/issues/3899, https://github.com/jgm/pandoc/issues/4482
2. Can't document itself? https://github.com/haskell/cabal/issues/4969

The stack issue doesn't seem to have a clear solution and easy haddocks for haddock should make contributions easier. The revert seems like the simplest solution to me.