### PR TITLE
Failing tests for the identifier parser

### DIFF
--- a/haddock-library/test/Documentation/Haddock/ParserSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/ParserSpec.hs
@@ -102,8 +102,11 @@ spec = do
       it "doesn't parse empty identifiers" $ do
         "``" `shouldParseTo` "``"
 
-      it "can parse infix identifiers" $ do
+      it "can parse an identifier in infix notation enclosed within backticks" $ do
         "``infix``" `shouldParseTo` "`" <> DocIdentifier "infix" <> "`"
+
+      it "can parse identifiers in infix notation enclosed within single quotes" $ do
+        "'`infix`'" `shouldParseTo` "`" <> DocIdentifier "infix" <> "`"
 
       it "parses a pretend-identifier that starts with a digit as a string" $ do
         "'0foo'" `shouldParseTo` "'0foo'"

--- a/haddock-library/test/Documentation/Haddock/ParserSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/ParserSpec.hs
@@ -86,6 +86,9 @@ spec = do
       it "parses identifiers enclosed within backticks" $ do
         "`foo`" `shouldParseTo` DocIdentifier "foo"
 
+      it "doesn't parse a composed function as an identifier" $ do
+        "'foo.bar'" `shouldParseTo` "'foo.bar'"
+
       it "parses a word with an one of the delimiters in it as DocString" $ do
           "don't" `shouldParseTo` "don't"
 
@@ -101,6 +104,15 @@ spec = do
 
       it "can parse infix identifiers" $ do
         "``infix``" `shouldParseTo` "`" <> DocIdentifier "infix" <> "`"
+
+      it "parses a pretend-identifier that starts with a digit as a string" $ do
+        "'0foo'" `shouldParseTo` "'0foo'"
+
+      it "can parse an identifier preceded by a single quote and a digit" $ do
+        "'0'foo'" `shouldParseTo` "'0" <> DocIdentifier "foo"
+
+      it "doesn't parse a mix of letters and operator symbols" $ do
+        "'f$'" `shouldParseTo` "'f$'"
 
     context "when parsing URLs" $ do
       it "parses a URL" $ do


### PR DESCRIPTION
While extending the ~~identifier parser~~ identifier parser tests I found the following test cases that I thought should pass.

If someone can confirm that they should pass, I'll try to fix the parser.