### PR TITLE
Add a module-level option to hide hyperlinked sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Changes in version 2.20.1
+
+ * `--hide-hyperlinked` allows module-level disabling of hyperlinked sources
+
 ## Changes in version 2.19.1
 
  * Show where instances are defined (#748)

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -261,7 +261,8 @@ render dflags flags sinceQual qual ifaces installedIfaces extSrcMap = do
       | unicode          = gopt_set dflags Opt_PrintUnicodeSyntax
       | otherwise        = dflags
 
-    visibleIfaces    = [ i | i <- ifaces, OptHide `notElem` ifaceOptions i ]
+    visibleIfaces        = [ i | i <- ifaces, OptHide `notElem` ifaceOptions i ]
+    visibleLinkedIfaces  = [ i | i <- ifaces, OptHideHyperlinked `notElem` ifaceOptions i ]
 
     -- /All/ visible interfaces including external package modules.
     allIfaces        = map toInstalledIface ifaces ++ installedIfaces
@@ -284,7 +285,7 @@ render dflags flags sinceQual qual ifaces installedIfaces extSrcMap = do
 
     srcMap = Map.union
       (Map.map SrcExternal extSrcMap)
-      (Map.fromList [ (ifaceMod iface, SrcLocal) | iface <- ifaces ])
+      (Map.fromList [ (ifaceMod iface, SrcLocal) | iface <- visibleLinkedIfaces ])
 
     pkgSrcMap = Map.mapKeys moduleUnitId extSrcMap
     pkgSrcMap'
@@ -388,10 +389,10 @@ render dflags flags sinceQual qual ifaces installedIfaces extSrcMap = do
                    libDir
       return ()
 
-  when (Flag_HyperlinkedSource `elem` flags && not (null ifaces)) $ do
+  when (Flag_HyperlinkedSource `elem` flags && not (null visibleLinkedIfaces)) $ do
     withTiming (pure dflags') "ppHyperlinkedSource" (const ()) $ do
       _ <- {-# SCC ppHyperlinkedSource #-}
-           ppHyperlinkedSource odir libDir opt_source_css pretty srcMap ifaces
+           ppHyperlinkedSource odir libDir opt_source_css pretty srcMap visibleLinkedIfaces
       return ()
 
 

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -335,6 +335,7 @@ mkDocOpts mbOpts flags mdl = do
             | m == Flag_ShowAllModules        = filter (/= OptHide) os
             | m == Flag_IgnoreAllExports      = OptIgnoreExports : os
             | m == Flag_ShowExtensions mdlStr = OptIgnoreExports : os
+            | m == Flag_HideHyperlinked mdlStr = OptHideHyperlinked : os
             | otherwise                       = os
 
 parseOption :: String -> ErrMsgM (Maybe DocOption)
@@ -343,6 +344,7 @@ parseOption "prune"           = return (Just OptPrune)
 parseOption "ignore-exports"  = return (Just OptIgnoreExports)
 parseOption "not-home"        = return (Just OptNotHome)
 parseOption "show-extensions" = return (Just OptShowExtensions)
+parseOption "hide-hyperlinked" = return (Just OptHideHyperlinked)
 parseOption other = tell ["Unrecognised option: " ++ other] >> return Nothing
 
 

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -407,6 +407,8 @@ instance Binary DocOption where
             putByte bh 3
     put_ bh OptShowExtensions = do
             putByte bh 4
+    put_ bh OptHideHyperlinked = do
+            putByte bh 5
     get bh = do
             h <- getByte bh
             case h of
@@ -420,6 +422,8 @@ instance Binary DocOption where
                     return OptNotHome
               4 -> do
                     return OptShowExtensions
+              5 -> do
+                    return OptHideHyperlinked
               _ -> fail "invalid binary data found"
 
 

--- a/haddock-api/src/Haddock/Options.hs
+++ b/haddock-api/src/Haddock/Options.hs
@@ -93,6 +93,7 @@ data Flag
   | Flag_ShowModule String
   | Flag_ShowAllModules
   | Flag_ShowExtensions String
+  | Flag_HideHyperlinked String
   | Flag_OptGhc String
   | Flag_GhcLibDir String
   | Flag_GhcVersion
@@ -195,6 +196,8 @@ options backwardsCompat =
       "behave as if not modules have the hide attribute",
     Option [] ["show-extensions"] (ReqArg Flag_ShowExtensions "MODULE")
       "behave as if MODULE has the show-extensions attribute",
+    Option [] ["hide-hyperlinked"] (ReqArg Flag_HideHyperlinked "MODULE")
+      "don't generate hyperlinked source for MODULE",
     Option [] ["optghc"] (ReqArg Flag_OptGhc "OPTION")
       "option to be forwarded to GHC",
     Option []  ["ghc-version"]  (NoArg Flag_GhcVersion)

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -529,6 +529,7 @@ data DocOption
   | OptNotHome         -- ^ Not the best place to get docs for things
                        -- exported by this module.
   | OptShowExtensions  -- ^ Render enabled extensions for this module.
+  | OptHideHyperlinked -- ^ Do not generate hyperlinked sources for this module
   deriving (Eq, Show)
 
 


### PR DESCRIPTION
The idea is to have an option to disable hyperlinked sources on modules whose source is programmatically generated, huge, and uninteresting. You can tell Haddock to not generate hyperlinked sources for the module `Foo` either via an option `--hide-hyperlinked=Foo` or a Haddock pragma `{-# OPTIONS_HADDOCK hide-hyperlinked #-}`.

Fixes https://github.com/haskell/haddock/issues/758.