### PR TITLE
Renamer: Warn about ambiguous identifiers

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -184,10 +184,10 @@ processModule verbosity modsum flags modMap instIfaceMap = do
 
   if not $ isBootSummary modsum then do
     out verbosity verbose "Creating interface..."
-    (interface, msg) <- {-# SCC createIterface #-}
+    (interface, msgs) <- {-# SCC createIterface #-}
                         withTiming getDynFlags "createInterface" (const ()) $ do
                           runWriterGhc $ createInterface tm flags modMap instIfaceMap
-    liftIO $ mapM_ putStrLn msg
+    liftIO $ mapM_ putStrLn (nub msgs)
     dflags <- getDynFlags
     let (haddockable, haddocked) = ifaceHaddockCoverage interface
         percentage = round (fromIntegral haddocked * 100 / fromIntegral haddockable :: Double) :: Int


### PR DESCRIPTION
Also deduplicate warnings.

Example:

    Warning: 'elem' is ambiguous. It is defined
        * in ‘Data.Foldable’
        * at /home/simon/tmp/hdk/src/Lib.hs:7:1
        You may be able to disambiguate the identifier by qualifying it or
        by hiding some imports.
        Defaulting to 'elem' defined at /home/simon/tmp/hdk/src/Lib.hs:7:1

Fixes #830.

/cc @hvr