### PR TITLE
Use `ClassOpSig` instead of `TypeSig` for class methods

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -475,9 +475,9 @@ ppShortClassDecl summary links (ClassDecl { tcdCtxt = lctxt, tcdLName = lname, t
 
                 -- ToDo: add associated type defaults
 
-            [ ppFunSig summary links loc doc names (hsSigWcType typ)
+            [ ppFunSig summary links loc doc names (hsSigType typ)
                        [] splice unicode pkg qual
-              | L _ (TypeSig lnames typ) <- sigs
+              | L _ (ClassOpSig False lnames typ) <- sigs
               , let doc = lookupAnySubdoc (head names) subdocs
                     names = map unLoc lnames ]
               -- FIXME: is taking just the first name ok? Is it possible that
@@ -537,12 +537,12 @@ ppClassDecl summary links instances fixities loc d subdocs
     minimalBit = case [ s | MinimalSig _ (L _ s) <- sigs ] of
       -- Miminal complete definition = every shown method
       And xs : _ | sort [getName n | L _ (Var (L _ n)) <- xs] ==
-                   sort [getName n | TypeSig ns _ <- sigs, L _ n <- ns]
+                   sort [getName n | ClassOpSig _ ns _ <- sigs, L _ n <- ns]
         -> noHtml
 
       -- Minimal complete definition = the only shown method
       Var (L _ n) : _ | [getName n] ==
-                        [getName n' | L _ (TypeSig ns _) <- lsigs, L _ n' <- ns]
+                        [getName n' | L _ (ClassOpSig _ ns _) <- lsigs, L _ n' <- ns]
         -> noHtml
 
       -- Minimal complete definition = nothing

--- a/html-test/ref/Bug26.html
+++ b/html-test/ref/Bug26.html
@@ -71,7 +71,11 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >c_f</a
+		  > :: a</li
+		></ul
 	      ></li
 	    ></ul
 	  ></details
@@ -124,14 +128,6 @@
 	    ><p
 	    ><em
 	      >Since: 1.0</em
-	      ></p
-	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Bug26"
-	      >c_f</a
 	      ></p
 	    ></div
 	  ><div class="subs methods"

--- a/html-test/ref/Bug613.html
+++ b/html-test/ref/Bug613.html
@@ -51,7 +51,11 @@
 	      > f <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >fmap</a
+		  > :: (a -&gt; b) -&gt; f a -&gt; f b</li
+		></ul
 	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
@@ -78,14 +82,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Bug613"
-	      >fmap</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p

--- a/html-test/ref/Bug647.html
+++ b/html-test/ref/Bug647.html
@@ -52,14 +52,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Bug647"
-	      >f</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p

--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -126,14 +126,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Bug679"
-	      >foo</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p

--- a/html-test/ref/DeprecatedClass.html
+++ b/html-test/ref/DeprecatedClass.html
@@ -51,7 +51,11 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >foo</a
+		  > :: a -&gt; a</li
+		></ul
 	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
@@ -61,7 +65,11 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >bar</a
+		  > :: a -&gt; a</li
+		></ul
 	      ></li
 	    ></ul
 	  ></details
@@ -87,14 +95,6 @@
 	      ></div
 	    ><p
 	    >some class</p
-	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="DeprecatedClass"
-	      >foo</a
-	      ></p
 	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
@@ -131,14 +131,6 @@
 	    ><p
 	      >Deprecated: SomeOtherClass</p
 	      ></div
-	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="DeprecatedClass"
-	      >bar</a
-	      ></p
 	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"

--- a/html-test/ref/Hash.html
+++ b/html-test/ref/Hash.html
@@ -126,7 +126,13 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >hash</a
+		  > :: a -&gt; <a href="#" title="Data.Int"
+		  >Int</a
+		  ></li
+		></ul
 	      ></li
 	    ></ul
 	  ></details
@@ -258,14 +264,6 @@
 	  ><div class="doc"
 	  ><p
 	    >A class of types which can be hashed.</p
-	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Hash"
-	      >hash</a
-	      ></p
 	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -146,6 +146,12 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    >Nothing</p
+	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
@@ -642,6 +648,12 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    >Nothing</p
+	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
@@ -1196,6 +1208,12 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    >Nothing</p
+	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
@@ -1922,6 +1940,12 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    >Nothing</p
+	    ></div
 	  ><div class="subs associated-types"
 	  ><p class="caption"
 	    >Associated Types</p

--- a/html-test/ref/Minimal.html
+++ b/html-test/ref/Minimal.html
@@ -128,6 +128,26 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    >(<a href="#" title="Minimal"
+	      >a</a
+	      >, <a href="#" title="Minimal"
+	      >b</a
+	      >, <a href="#" title="Minimal"
+	      >c</a
+	      > | (<a href="#" title="Minimal"
+	      >d</a
+	      > | <a href="#" title="Minimal"
+	      >e</a
+	      >, (<a href="#" title="Minimal"
+	      >f</a
+	      > | <a href="#" title="Minimal"
+	      >g</a
+	      >)))</p
+	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
@@ -230,16 +250,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Minimal"
-	      >aaa</a
-	      >, <a href="#" title="Minimal"
-	      >bbb</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
@@ -298,6 +308,12 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
+	  ><div class="subs minimal"
+	  ><p class="caption"
+	    >Minimal complete definition</p
+	    ><p class="src"
+	    >Nothing</p
+	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p

--- a/html-test/ref/Operators.html
+++ b/html-test/ref/Operators.html
@@ -145,6 +145,22 @@
 		  > a <a href="#"
 		  >&gt;&lt;&lt;</a
 		  > b</li
+		><li
+		><a href="#"
+		  >(&gt;&gt;&lt;)</a
+		  >, <a href="#"
+		  >(&lt;&lt;&gt;)</a
+		  > :: a -&gt; b -&gt; ()</li
+		><li
+		><a href="#"
+		  >(**&gt;)</a
+		  >, <a href="#"
+		  >(**&lt;)</a
+		  >, <a href="#"
+		  >(&gt;**)</a
+		  >, <a href="#"
+		  >(&lt;**)</a
+		  > :: a -&gt; a -&gt; ()</li
 		></ul
 	      ></li
 	    ><li class="src short"
@@ -375,24 +391,6 @@
 	  ><div class="doc"
 	  ><p
 	    >Class with fixity, including associated types</p
-	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Operators"
-	      >(&gt;&gt;&lt;)</a
-	      >, <a href="#" title="Operators"
-	      >(&lt;&lt;&gt;)</a
-	      >, <a href="#" title="Operators"
-	      >(**&gt;)</a
-	      >, <a href="#" title="Operators"
-	      >(**&lt;)</a
-	      >, <a href="#" title="Operators"
-	      >(&gt;**)</a
-	      >, <a href="#" title="Operators"
-	      >(&lt;**)</a
-	      ></p
 	    ></div
 	  ><div class="subs associated-types"
 	  ><p class="caption"

--- a/html-test/ref/OrphanInstancesClass.html
+++ b/html-test/ref/OrphanInstancesClass.html
@@ -52,14 +52,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="OrphanInstancesClass"
-	      >aClass</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -478,7 +478,17 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >a</a
+		  > :: <a href="#" title="System.IO"
+		  >IO</a
+		  > a</li
+		><li
+		><a href="#"
+		  >b</a
+		  > :: [a]</li
+		></ul
 	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
@@ -488,7 +498,17 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >d</a
+		  > :: <a href="#" title="Test"
+		  >T</a
+		  > a b</li
+		><li
+		><a href="#"
+		  >e</a
+		  > :: (a, a)</li
+		></ul
 	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
@@ -504,7 +524,11 @@
 	      > a <span class="keyword"
 	      >where</span
 	      ><ul class="subs"
-	      ></ul
+	      ><li
+		><a href="#"
+		  >ff</a
+		  > :: a</li
+		></ul
 	      ></li
 	    ><li class="src short"
 	    ><a href="#"
@@ -1558,16 +1582,6 @@
 		></code
 	      > class)</p
 	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Test"
-	      >a</a
-	      >, <a href="#" title="Test"
-	      >b</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p
@@ -1617,16 +1631,6 @@
 	  ><div class="doc"
 	  ><p
 	    >This is a class declaration with no separate docs for the methods</p
-	    ></div
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Test"
-	      >d</a
-	      >, <a href="#" title="Test"
-	      >e</a
-	      ></p
 	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
@@ -1790,14 +1794,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Test"
-	      >ff</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p

--- a/html-test/ref/Ticket61.html
+++ b/html-test/ref/Ticket61.html
@@ -52,14 +52,6 @@
 	    > <a href="#" class="selflink"
 	    >#</a
 	    ></p
-	  ><div class="subs minimal"
-	  ><p class="caption"
-	    >Minimal complete definition</p
-	    ><p class="src"
-	    ><a href="#" title="Ticket61"
-	      >f</a
-	      ></p
-	    ></div
 	  ><div class="subs methods"
 	  ><p class="caption"
 	    >Methods</p


### PR DESCRIPTION
From #834:

```haskell
module Minimal (C(..)) where 

-- | A  class
class C index where
  {-# MINIMAL (merge | mergeMany) #-}

  -- | One 
  merge :: index -> index -> index
  merge x1 x2 = mergeMany [x1,x2]

  -- | Two
  mergeMany :: [index] -> index
  mergeMany = foldr1 merge 
```

Looked like

<img width="472" alt="screen shot 2018-05-22 at 9 43 42 am" src="https://user-images.githubusercontent.com/10766081/40377034-b8a25158-5da4-11e8-938c-d4d77d058d04.png">

And now looks like

<img width="475" alt="screen shot 2018-05-22 at 9 43 47 am" src="https://user-images.githubusercontent.com/10766081/40377044-bf16a854-5da4-11e8-8989-281f9068beef.png">

I was going to add a test case, but it looks like the test suite is already full of test cases that were broken: minimal pragmas that weren't supposed to show up but did, minimal pragmas that were supposed to show up but didn't, class methods that weren't should up in the synopsis, you name it!