### PR TITLE
Extract docs from strict/unpacked constructor args

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -472,6 +472,7 @@ conArgDocs con = case getConArgs con of
                    RecCon _ -> go 1 ret
   where
     go n (HsDocTy _ _ (L _ ds) : tys) = M.insert n ds $ go (n+1) tys
+    go n (HsBangTy _ _ (L _ (HsDocTy _ _ (L _ ds))) : tys) = M.insert n ds $ go (n+1) tys
     go n (_ : tys) = go (n+1) tys
     go _ [] = M.empty
 


### PR DESCRIPTION
This fixes #836 by matching the GHC changes in https://phabricator.haskell.org/D4727.

The GHC diff fixes the parse error around strictness annotations by moving the `HsDocTy` into the `HsBangTy` (if there is one). This patch correspondingly teaches Haddock to look into `HsBangTy` for docstrings.