### PR TITLE
Improve Hyperlinker's 'spanToNewline'

### DIFF
--- a/hypsrc-test/ref/src/CPP.html
+++ b/hypsrc-test/ref/src/CPP.html
@@ -1,0 +1,216 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><link rel="stylesheet" type="text/css" href="style.css"
+     /><script type="text/javascript" src="highlight.js"
+    ></script
+    ></head
+  ><body
+  ><pre
+    ><span class="hs-pragma"
+      >{-# LANGUAGE CPP #-}</span
+      ><span
+      >
+</span
+      ><a name="line-2"
+      ></a
+      ><span class="hs-keyword"
+      >module</span
+      ><span
+      > </span
+      ><span class="hs-identifier"
+      >CPP</span
+      ><span
+      > </span
+      ><span class="hs-keyword"
+      >where</span
+      ><span
+      >
+</span
+      ><a name="line-3"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-4"
+      ></a
+      ><span class="hs-cpp"
+      >#define SOMETHING1
+</span
+      ><span
+      >
+</span
+      ><a name="line-6"
+      ></a
+      ><span class="hs-identifier"
+      >foo</span
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >::</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-type"
+      >String</span
+      ><span
+      >
+</span
+      ><a name="line-7"
+      ></a
+      ><a name="foo"
+      ><a href="CPP.html#foo"
+	><span class="hs-identifier"
+	  >foo</span
+	  ></a
+	></a
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >=</span
+      ><span
+      > </span
+      ><span class="hs-comment"
+      >{-  &quot; single quotes are fine in block comments
+          {- nested block comments are fine -}
+       -}</span
+      ><span
+      > </span
+      ><span class="hs-string"
+      >&quot;foo&quot;</span
+      ><span
+      >
+</span
+      ><a name="line-10"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-11"
+      ></a
+      ><span class="hs-cpp"
+      >#define SOMETHING2
+</span
+      ><span
+      >
+</span
+      ><a name="line-13"
+      ></a
+      ><span class="hs-identifier"
+      >bar</span
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >::</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-type"
+      >String</span
+      ><span
+      >
+</span
+      ><a name="line-14"
+      ></a
+      ><a name="bar"
+      ><a href="CPP.html#bar"
+	><span class="hs-identifier"
+	  >bar</span
+	  ></a
+	></a
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >=</span
+      ><span
+      > </span
+      ><span class="hs-string"
+      >&quot;block comment in a string is not a comment {- &quot;</span
+      ><span
+      >
+</span
+      ><a name="line-15"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-16"
+      ></a
+      ><span class="hs-cpp"
+      >#define SOMETHING3
+</span
+      ><span
+      >
+</span
+      ><a name="line-18"
+      ></a
+      ><span class="hs-comment"
+      >-- &quot; single quotes are fine in line comments</span
+      ><span
+      >
+</span
+      ><a name="line-19"
+      ></a
+      ><span class="hs-comment"
+      >-- {- unclosed block comments are fine in line comments</span
+      ><span
+      >
+</span
+      ><a name="line-20"
+      ></a
+      ><span
+      >
+</span
+      ><a name="line-21"
+      ></a
+      ><span class="hs-comment"
+      >-- Multiline CPP is also fine</span
+      ><span
+      >
+</span
+      ><a name="line-22"
+      ></a
+      ><span class="hs-cpp"
+      >#define FOO\
+  1
+</span
+      ><span
+      >
+</span
+      ><a name="line-25"
+      ></a
+      ><span class="hs-identifier"
+      >baz</span
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >::</span
+      ><span
+      > </span
+      ><span class="hs-identifier hs-type"
+      >String</span
+      ><span
+      >
+</span
+      ><a name="line-26"
+      ></a
+      ><a name="baz"
+      ><a href="CPP.html#baz"
+	><span class="hs-identifier"
+	  >baz</span
+	  ></a
+	></a
+      ><span
+      > </span
+      ><span class="hs-glyph"
+      >=</span
+      ><span
+      > </span
+      ><span class="hs-string"
+      >&quot;line comment in a string is not a comment --&quot;</span
+      ><span
+      >
+</span
+      ><a name="line-27"
+      ></a
+      ></pre
+    ></body
+  ></html
+>

--- a/hypsrc-test/src/CPP.hs
+++ b/hypsrc-test/src/CPP.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP #-}
+module CPP where
+
+#define SOMETHING1
+
+foo :: String
+foo = {-  " single quotes are fine in block comments
+          {- nested block comments are fine -}
+       -} "foo"
+
+#define SOMETHING2
+
+bar :: String
+bar = "block comment in a string is not a comment {- "
+
+#define SOMETHING3
+
+-- " single quotes are fine in line comments
+-- {- unclosed block comments are fine in line comments
+
+-- Multiline CPP is also fine
+#define FOO\
+  1
+
+baz :: String
+baz = "line comment in a string is not a comment --"


### PR DESCRIPTION
`spanToNewline` is used to help break apart the source into lines which
can then be partioned into CPP and non-CPP chunks. It is important that
`spanToNewline` not break apart tokens, so it needs to properly handle
things like

  * block comments, possibly nested
  * string literals, possibly multi-line
  * CPP macros, possibly multi-line

Comments in string literals in particular were not being properly handled.
The fix is to to fall back on `Text.Read.lex` to help lex things that are not
comments.

Fixes #837.