### PR TITLE
Don't warn about ambiguous identifiers when the candidate names…

### DIFF
--- a/haddock-api/src/Haddock/Interface/LexParseRn.hs
+++ b/haddock-api/src/Haddock/Interface/LexParseRn.hs
@@ -164,7 +164,9 @@ outOfScope dflags x =
     Exact name -> warnAndMonospace name  -- Shouldn't happen since x is out of scope
   where
     warnAndMonospace a = do
-      tell ["Warning: '" ++ showPpr dflags a ++ "' is out of scope."]
+      tell ["Warning: '" ++ showPpr dflags a ++ "' is out of scope.\n" ++
+            "    If you qualify the identifier, haddock can try to link it\n" ++
+            "    it anyway."]
       pure (monospaced a)
     monospaced a = DocMonospaced (DocString (showPpr dflags a))
 


### PR DESCRIPTION
… belong to the same type

This also changes the defaulting heuristic for ambiguous identifiers.
We now prefer local names primarily, and type constructors or class
names secondarily.

Also improve the out-of-scope warning.

Partially fixes #854.