### PR TITLE
Preserve docs on type family instances

### DIFF
--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -28,6 +28,7 @@ module Haddock.Types (
 import Control.Exception
 import Control.Arrow hiding ((<+>))
 import Control.DeepSeq
+import Control.Monad.IO.Class (MonadIO(..))
 import Data.Typeable
 import Data.Map (Map)
 import Data.Data (Data)
@@ -661,6 +662,8 @@ instance Monad ErrMsgGhc where
   m >>= k = WriterGhc $ runWriterGhc m >>= \ (a, msgs1) ->
                fmap (second (msgs1 ++)) (runWriterGhc (k a))
 
+instance MonadIO ErrMsgGhc where
+  liftIO m = WriterGhc (fmap (\x -> (x, [])) (liftIO m))
 
 -----------------------------------------------------------------------------
 -- * Pass sensitive types

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -352,8 +352,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >External instance</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"
@@ -586,8 +588,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >Doc for: type instance Foo X = Y</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"
@@ -944,8 +948,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >Doc for: type instance Foo Y = X</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"
@@ -1234,8 +1240,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >Doc for: type instance Foo Y = X</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"
@@ -1274,8 +1282,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >Doc for: type instance Foo X = Y</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -142,8 +142,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >Should be visible, but with a hidden right hand side</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"
@@ -202,8 +204,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >Should be visible, but with a hidden right hand side</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"
@@ -240,8 +244,10 @@
 		    > <a href="#" class="selflink"
 		    >#</a
 		    ></td
-		  ><td class="doc empty"
-		  ></td
+		  ><td class="doc"
+		  ><p
+		    >External instance</p
+		    ></td
 		  ></tr
 		><tr
 		><td colspan="2"


### PR DESCRIPTION
The only problem was that the instance location was slightly off
for type family instances. This fixes #726.

Example:

```
{-# LANGUAGE TypeFamilies #-}
module Lib where

data Bar = Bar

-- | A 'Foo'
type family Foo a :: *

-- | 'Foo' of 'Bar'
type instance Foo Bar = Bar

-- | 'Eq' of 'Bar'
instance Eq Bar where _ == _ = True
```

now produces

<img width="331" alt="screen shot 2018-07-01 at 9 31 35 am" src="https://user-images.githubusercontent.com/10766081/42134901-b92056e8-7d11-11e8-80ec-0f4ab67f5f41.png">
