### PR TITLE
Fix broken instance source links

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -572,9 +572,9 @@ ppInstances links origin instances splice unicode pkg qual
   -- force Splice = True to use line URLs
   where
     instName = getOccString origin
-    instDecl :: Int -> DocInstance DocNameI -> (SubDecl,Located DocName)
+    instDecl :: Int -> DocInstance DocNameI -> (SubDecl, Maybe Module, Located DocName)
     instDecl no (inst, mdoc, loc, mdl) =
-        ((ppInstHead links splice unicode qual mdoc origin False no inst mdl), loc)
+        ((ppInstHead links splice unicode qual mdoc origin False no inst mdl), mdl, loc)
 
 
 ppOrphanInstances :: LinksInfo
@@ -587,9 +587,9 @@ ppOrphanInstances links instances splice unicode pkg qual
     instOrigin :: InstHead name -> InstOrigin (IdP name)
     instOrigin inst = OriginClass (ihdClsName inst)
 
-    instDecl :: Int -> DocInstance DocNameI -> (SubDecl,Located DocName)
+    instDecl :: Int -> DocInstance DocNameI -> (SubDecl, Maybe Module, Located DocName)
     instDecl no (inst, mdoc, loc, mdl) =
-        ((ppInstHead links splice unicode qual mdoc (instOrigin inst) True no inst mdl), loc)
+        ((ppInstHead links splice unicode qual mdoc (instOrigin inst) True no inst Nothing), mdl, loc)
 
 
 ppInstHead :: LinksInfo -> Splice -> Unicode -> Qualification


### PR DESCRIPTION
The problem manifests itself in instances that are defined in modules other than the module where the class is defined. The fix is just to thread through the `Module` of the instance further along.

Since orphan instances appear to already have been working, I didn't do anything there.

Fixes #572.  

I'm in the progress of checking that cherry picking this onto my inplace GHC 8.6 fixes the source link of `(Ord a, Bounded a) => Monoid (Max a)`. I don't know how to add a test case for this though: the bugginess is in the source links from HTML to hyperlinked source (so neither `html-test` nor `hypsrc-test` is useful).

### Update

GHC with docs+hyperlinked-sources finished building. This does fix the problem for `(Ord a, Bounded a) => Monoid (Max a)`'s source link.