### PR TITLE
Add some more unicode related tests

### DIFF
--- a/html-test/ref/Unicode2.html
+++ b/html-test/ref/Unicode2.html
@@ -1,0 +1,100 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >Unicode2</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Unicode2</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><a href="#"
+	      >&#252;</a
+	      > :: ()</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><a id="v:-252-" class="def"
+	    >&#252;</a
+	    > :: () <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >All of the following work with a unicode character &#252;:</p
+	    ><ul
+	    ><li
+	      >an italicized <em
+		>&#252;</em
+		></li
+	      ><li
+	      >inline code <code
+		>&#252;</code
+		></li
+	      ><li
+	      >a code block:</li
+	      ></ul
+	    ><pre
+	    >&#252;</pre
+	    ><ul
+	    ><li
+	      >a url <a href="#"
+		>https://www.google.com/search?q=&#252;</a
+		></li
+	      ><li
+	      >a link to <code
+		><a href="#" title="Unicode2"
+		  >&#252;</a
+		  ></code
+		></li
+	      ></ul
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Unicode2.hs
+++ b/html-test/src/Unicode2.hs
@@ -1,0 +1,18 @@
+module Unicode2 where
+
+-- | All of the following work with a unicode character ü:
+--
+--   * an italicized /ü/
+--   
+--   * inline code @ü@
+--
+--   * a code block:
+--
+--   > ü
+--
+--   * a url <https://www.google.com/search?q=ü>
+-- 
+--   * a link to 'ü'
+--
+ü :: ()
+ü = ()


### PR DESCRIPTION
This has been fixed for sure ever since we switched from attoparsec to
parsec. Parts of it may have been working before that, but there was a
point where this would have failed (see #191).

A regression test never hurt anyone. :)