### PR TITLE
Add # as a special character

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -762,7 +762,7 @@ Special Characters
 ~~~~~~~~~~~~~~~~~~
 
 The following characters have special meanings in documentation
-comments: ``\\``, ``/``, ``'``, ``\```, ``"``, ``@``, ``<``, ``$``. To insert a
+comments: ``\\``, ``/``, ``'``, ``\```, ``"``, ``@``, ``<``, ``$``, ``#``. To insert a
 literal occurrence of one of these special characters, precede it with a
 backslash (``\\``).
 


### PR DESCRIPTION
'#' has special meaning used for anchors and can be escaped using backslash.
Therefore it would be nice to be listed as special characters.