### PR TITLE
Namespaces on identifier links

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -41,6 +41,7 @@ import Haddock.Options
 import Haddock.Utils
 
 import Control.Monad hiding (forM_)
+import Data.Bifunctor (second)
 import Data.Foldable (forM_, foldl')
 import Data.Traversable (for)
 import Data.List (isPrefixOf)
@@ -620,7 +621,8 @@ getPrologue dflags flags =
       h <- openFile filename ReadMode
       hSetEncoding h utf8
       str <- hGetContents h -- semi-closes the handle
-      return . Just $! parseParas dflags Nothing str
+      let stripNs (NsRdrName _ rdrName) = rdrName
+      return . Just $! second stripNs $ parseParas dflags Nothing str
     _ -> throwE "multiple -p/--prologue options"
 
 

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -621,8 +621,7 @@ getPrologue dflags flags =
       h <- openFile filename ReadMode
       hSetEncoding h utf8
       str <- hGetContents h -- semi-closes the handle
-      let stripNs (NsRdrName _ rdrName) = rdrName
-      return . Just $! second stripNs $ parseParas dflags Nothing str
+      return . Just $! second rdrName $ parseParas dflags Nothing str
     _ -> throwE "multiple -p/--prologue options"
 
 

--- a/haddock-api/src/Haddock/Interface/LexParseRn.hs
+++ b/haddock-api/src/Haddock/Interface/LexParseRn.hs
@@ -196,7 +196,7 @@ ambiguous dflags x gres = do
       msg = "Warning: " ++ x_str ++ " is ambiguous. It is defined\n" ++
             concatMap (\n -> "    * " ++ defnLoc n ++ "\n") (map gre_name gres) ++
             "    You may be able to disambiguate the identifier by qualifying it or\n" ++
-            "    by hiding some imports.\n" ++
+            "    by specifying the type/value namespace explicitly.\n" ++
             "    Defaulting to " ++ x_str ++ " defined " ++ defnLoc dflt
   -- TODO: Once we have a syntax for namespace qualification (#667) we may also
   -- want to emit a warning when an identifier is a data constructor for a type

--- a/haddock-api/src/Haddock/Interface/ParseModuleHeader.hs
+++ b/haddock-api/src/Haddock/Interface/ParseModuleHeader.hs
@@ -16,7 +16,6 @@ import Data.Char
 import DynFlags
 import Haddock.Parser
 import Haddock.Types
-import RdrName
 
 -- -----------------------------------------------------------------------------
 -- Parsing module headers
@@ -24,7 +23,7 @@ import RdrName
 -- NB.  The headers must be given in the order Module, Description,
 -- Copyright, License, Maintainer, Stability, Portability, except that
 -- any or all may be omitted.
-parseModuleHeader :: DynFlags -> Maybe Package -> String -> (HaddockModInfo RdrName, MDoc RdrName)
+parseModuleHeader :: DynFlags -> Maybe Package -> String -> (HaddockModInfo NsRdrName, MDoc NsRdrName)
 parseModuleHeader dflags pkgName str0 =
    let
       getKey :: String -> String -> (Maybe String,String)

--- a/haddock-api/src/Haddock/Parser.hs
+++ b/haddock-api/src/Haddock/Parser.hs
@@ -22,23 +22,23 @@ import qualified Documentation.Haddock.Parser as P
 import DynFlags (DynFlags)
 import FastString (mkFastString)
 import Documentation.Haddock.Types
+import Haddock.Types (NsRdrName(..))
 import Lexer (mkPState, unP, ParseResult(POk))
 import Parser (parseIdentifier)
-import RdrName (RdrName)
-import SrcLoc (mkRealSrcLoc, unLoc)
+import SrcLoc (mkRealSrcLoc, GenLocated(L))
 import StringBuffer (stringToStringBuffer)
 
-parseParas :: DynFlags -> Maybe Package -> String -> MetaDoc mod RdrName
+parseParas :: DynFlags -> Maybe Package -> String -> MetaDoc mod NsRdrName
 parseParas d p = overDoc (P.overIdentifier (parseIdent d)) . P.parseParas p
 
-parseString :: DynFlags -> String -> DocH mod RdrName
+parseString :: DynFlags -> String -> DocH mod NsRdrName
 parseString d = P.overIdentifier (parseIdent d) . P.parseString
 
-parseIdent :: DynFlags -> String -> Maybe RdrName
-parseIdent dflags str0 =
+parseIdent :: DynFlags -> Namespace -> String -> Maybe NsRdrName
+parseIdent dflags ns str0 =
   let buffer = stringToStringBuffer str0
       realSrcLc = mkRealSrcLoc (mkFastString "<unknown file>") 0 0
       pstate = mkPState dflags buffer realSrcLc
   in case unP parseIdentifier pstate of
-    POk _ name -> Just (unLoc name)
+    POk _ (L _ name) -> Just (NsRdrName ns name)
     _ -> Nothing

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -285,6 +285,9 @@ noDocForDecl = (Documentation Nothing Nothing, Map.empty)
 -- | Type of environment used to cross-reference identifiers in the syntax.
 type LinkEnv = Map Name Module
 
+-- | An 'RdrName' tagged with some type/value namespace information.
+data NsRdrName = NsRdrName Namespace RdrName
+
 -- | Extends 'Name' with cross-reference information.
 data DocName
   = Documented Name Module

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -286,7 +286,10 @@ noDocForDecl = (Documentation Nothing Nothing, Map.empty)
 type LinkEnv = Map Name Module
 
 -- | An 'RdrName' tagged with some type/value namespace information.
-data NsRdrName = NsRdrName Namespace RdrName
+data NsRdrName = NsRdrName
+  { namespace :: !Namespace
+  , rdrName :: !RdrName
+  }
 
 -- | Extends 'Name' with cross-reference information.
 data DocName

--- a/haddock-library/src/Documentation/Haddock/Parser.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser.hs
@@ -858,4 +858,4 @@ identifier = do
   e <- idDelim
   return $ DocIdentifier (Identifier ns o vid e)
   where
-    idDelim = Parsec.oneOf "\'`"
+    idDelim = Parsec.oneOf "'`"

--- a/haddock-library/src/Documentation/Haddock/Types.hs
+++ b/haddock-library/src/Documentation/Haddock/Types.hs
@@ -203,6 +203,9 @@ instance Bitraversable DocH where
   bitraverse f g (DocTable (Table header body)) = (\h b -> DocTable (Table h b)) <$> traverse (traverse (bitraverse f g)) header <*> traverse (traverse (bitraverse f g)) body
 #endif
 
+-- | The namespace qualification for an identifier.
+data Namespace = Value | Type | None deriving (Eq, Ord, Enum, Show)
+
 -- | 'DocMarkupH' is a set of instructions for marking up documentation.
 -- In fact, it's really just a mapping from 'Doc' to some other
 -- type [a], where [a] is usually the type of the output (HTML, say).

--- a/haddock-library/src/Documentation/Haddock/Types.hs
+++ b/haddock-library/src/Documentation/Haddock/Types.hs
@@ -206,6 +206,13 @@ instance Bitraversable DocH where
 -- | The namespace qualification for an identifier.
 data Namespace = Value | Type | None deriving (Eq, Ord, Enum, Show)
 
+-- | Render the a namespace into the same format it was initially parsed.
+renderNs :: Namespace -> String
+renderNs Value = "v"
+renderNs Type = "t"
+renderNs None = ""
+
+
 -- | 'DocMarkupH' is a set of instructions for marking up documentation.
 -- In fact, it's really just a mapping from 'Doc' to some other
 -- type [a], where [a] is usually the type of the output (HTML, say).

--- a/haddock-library/test/Documentation/Haddock/ParserSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/ParserSpec.hs
@@ -132,6 +132,12 @@ spec = do
       it "can parse an identifier that starts with an underscore" $ do
         "'_x'" `shouldParseTo` DocIdentifier "_x"
 
+      it "can parse value-namespaced identifiers" $ do
+        "v'foo'" `shouldParseTo` DocIdentifier "foo"
+
+      it "can parse type-namespaced identifiers" $ do
+        "t'foo'" `shouldParseTo` DocIdentifier "foo"
+    
     context "when parsing operators" $ do
       it "can parse an operator enclosed within single quotes" $ do
         "'.='" `shouldParseTo` DocIdentifier ".="

--- a/html-test/Main.hs
+++ b/html-test/Main.hs
@@ -45,7 +45,7 @@ stripIfRequired mdl =
 
 -- | List of modules in which we don't 'stripLinks'
 preserveLinksModules :: [String]
-preserveLinksModules = ["Bug253"]
+preserveLinksModules = ["Bug253.html", "NamespacedIdentifiers.html"]
 
 ingoredTests :: [FilePath]
 ingoredTests =

--- a/html-test/ref/Bug253.html
+++ b/html-test/ref/Bug253.html
@@ -3,8 +3,8 @@
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
      /><title
     >Bug253</title
-    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
-     /><link rel="stylesheet" type="text/css" href="#"
+    ><link href="ocean.css" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="quick-jump.css"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
@@ -14,11 +14,11 @@
   ><div id="package-header"
     ><ul class="links" id="page-menu"
       ><li
-	><a href="#"
+	><a href="index.html"
 	  >Contents</a
 	  ></li
 	><li
-	><a href="#"
+	><a href="doc-index.html"
 	  >Index</a
 	  ></li
 	></ul
@@ -60,7 +60,7 @@
 	  >Synopsis</summary
 	  ><ul class="details-toggle" data-details-id="syn"
 	  ><li class="src short"
-	    ><a href="#"
+	    ><a href="#v:foo"
 	      >foo</a
 	      > :: ()</li
 	    ></ul
@@ -73,7 +73,7 @@
 	><p class="src"
 	  ><a id="v:foo" class="def"
 	    >foo</a
-	    > :: () <a href="#" class="selflink"
+	    > :: () <a href="#v:foo" class="selflink"
 	    >#</a
 	    ></p
 	  ><div class="doc"
@@ -81,7 +81,7 @@
 	    >This link should generate <code
 	      >#v</code
 	      > anchor: <code
-	      ><a href="#" title="DoesNotExist"
+	      ><a href="DoesNotExist.html#v:fakeFakeFake" title="DoesNotExist"
 		>fakeFakeFake</a
 		></code
 	      ></p

--- a/html-test/ref/NamespacedIdentifiers.html
+++ b/html-test/ref/NamespacedIdentifiers.html
@@ -3,8 +3,8 @@
   ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
      /><title
     >NamespacedIdentifiers</title
-    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
-     /><link rel="stylesheet" type="text/css" href="#"
+    ><link href="ocean.css" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="quick-jump.css"
      /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
     ></script
     ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
@@ -14,11 +14,11 @@
   ><div id="package-header"
     ><ul class="links" id="page-menu"
       ><li
-	><a href="#"
+	><a href="index.html"
 	  >Contents</a
 	  ></li
 	><li
-	><a href="#"
+	><a href="doc-index.html"
 	  >Index</a
 	  ></li
 	></ul
@@ -46,15 +46,15 @@
 	  ><li class="src short"
 	    ><span class="keyword"
 	      >data</span
-	      > <a href="#"
+	      > <a href="#t:Foo"
 	      >Foo</a
-	      > = <a href="#"
+	      > = <a href="#v:Bar"
 	      >Bar</a
 	      ></li
 	    ><li class="src short"
 	    ><span class="keyword"
 	      >data</span
-	      > <a href="#"
+	      > <a href="#t:Bar"
 	      >Bar</a
 	      ></li
 	    ></ul
@@ -69,7 +69,7 @@
 	    >data</span
 	    > <a id="t:Foo" class="def"
 	    >Foo</a
-	    > <a href="#" class="selflink"
+	    > <a href="#t:Foo" class="selflink"
 	    >#</a
 	    ></p
 	  ><div class="doc"
@@ -78,13 +78,13 @@
 	    ><ul
 	    ><li
 	      >the type <code
-		><a href="#" title="NamespacedIdentifiers"
+		><a href="NamespacedIdentifiers.html#t:Bar" title="NamespacedIdentifiers"
 		  >Bar</a
 		  ></code
 		></li
 	      ><li
 	      >the constructor <code
-		><a href="#" title="NamespacedIdentifiers"
+		><a href="NamespacedIdentifiers.html#v:Bar" title="NamespacedIdentifiers"
 		  >Bar</a
 		  ></code
 		></li
@@ -111,7 +111,7 @@
 	    >data</span
 	    > <a id="t:Bar" class="def"
 	    >Bar</a
-	    > <a href="#" class="selflink"
+	    > <a href="#t:Bar" class="selflink"
 	    >#</a
 	    ></p
 	  ><div class="doc"

--- a/html-test/ref/NamespacedIdentifiers.html
+++ b/html-test/ref/NamespacedIdentifiers.html
@@ -1,0 +1,130 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >NamespacedIdentifiers</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>NamespacedIdentifiers</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><span class="keyword"
+	      >data</span
+	      > <a href="#"
+	      >Foo</a
+	      > = <a href="#"
+	      >Bar</a
+	      ></li
+	    ><li class="src short"
+	    ><span class="keyword"
+	      >data</span
+	      > <a href="#"
+	      >Bar</a
+	      ></li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Foo" class="def"
+	    >Foo</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >A link to:</p
+	    ><ul
+	    ><li
+	      >the type <code
+		><a href="#" title="NamespacedIdentifiers"
+		  >Bar</a
+		  ></code
+		></li
+	      ><li
+	      >the constructor <code
+		><a href="#" title="NamespacedIdentifiers"
+		  >Bar</a
+		  ></code
+		></li
+	      ></ul
+	    ></div
+	  ><div class="subs constructors"
+	  ><p class="caption"
+	    >Constructors</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a id="v:Bar" class="def"
+		  >Bar</a
+		  ></td
+		><td class="doc empty"
+		></td
+		></tr
+	      ></table
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Bar" class="def"
+	    >Bar</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >A link to the value <code
+	      >Foo</code
+	      > (which shouldn't exist).</p
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/ref/NamespacedIdentifiers.html
+++ b/html-test/ref/NamespacedIdentifiers.html
@@ -88,6 +88,18 @@
 		  >Bar</a
 		  ></code
 		></li
+	      ><li
+	      >the unimported but qualified type <code
+		><a href="A.html#t:A" title="A"
+		  >A</a
+		  ></code
+		></li
+	      ><li
+	      >the unimported but qualified value <code
+		><a href="A.html#v:A" title="A"
+		  >A</a
+		  ></code
+		></li
 	      ></ul
 	    ></div
 	  ><div class="subs constructors"

--- a/html-test/src/NamespacedIdentifiers.hs
+++ b/html-test/src/NamespacedIdentifiers.hs
@@ -1,0 +1,11 @@
+module NamespacedIdentifiers where
+
+-- | A link to:
+--
+--   * the type t'Bar'
+--   * the constructor v'Bar'
+--
+data Foo = Bar
+
+-- | A link to the value v'Foo' (which shouldn't exist).
+data Bar

--- a/html-test/src/NamespacedIdentifiers.hs
+++ b/html-test/src/NamespacedIdentifiers.hs
@@ -4,8 +4,11 @@ module NamespacedIdentifiers where
 --
 --   * the type t'Bar'
 --   * the constructor v'Bar'
+--   * the unimported but qualified type t'A.A'
+--   * the unimported but qualified value v'A.A'
 --
 data Foo = Bar
 
 -- | A link to the value v'Foo' (which shouldn't exist).
 data Bar
+


### PR DESCRIPTION
Identifier links can be prefixed with a `v` or `t` to indicate the value or type namespace of the desired identifier. For example:

```haskell
-- | Some link to a value: v'Data.Functor.Identity'
--
-- Some link to a type: t'Data.Functor.Identity'
```

The default is still the type (with a warning about the ambiguity). Perhaps the warning should mention namespacing as a way of disambiguating?

Fixes #667 with the suggestion from [this comment](https://github.com/haskell/haddock/issues/667#issuecomment-400238387).