### PR TITLE
Let `haddock-test` bypass interface version check

### DIFF
--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -190,8 +190,9 @@ readInterfaceFile :: forall m.
                      MonadIO m
                   => NameCacheAccessor m
                   -> FilePath
+                  -> Bool  -- ^ Disable version check. Can cause runtime crash.
                   -> m (Either String InterfaceFile)
-readInterfaceFile (get_name_cache, set_name_cache) filename = do
+readInterfaceFile (get_name_cache, set_name_cache) filename bypass_checks = do
   bh0 <- liftIO $ readBinMem filename
 
   magic   <- liftIO $ get bh0
@@ -200,7 +201,8 @@ readInterfaceFile (get_name_cache, set_name_cache) filename = do
   case () of
     _ | magic /= binaryInterfaceMagic -> return . Left $
       "Magic number mismatch: couldn't load interface file: " ++ filename
-      | version `notElem` binaryInterfaceVersionCompatibility -> return . Left $
+      | not bypass_checks
+      , (version `notElem` binaryInterfaceVersionCompatibility) -> return . Left $
       "Interface file is of wrong version: " ++ filename
       | otherwise -> with_name_cache $ \update_nc -> do
 

--- a/haddock-api/src/Haddock/Options.hs
+++ b/haddock-api/src/Haddock/Options.hs
@@ -84,6 +84,7 @@ data Flag
   | Flag_Version
   | Flag_CompatibleInterfaceVersions
   | Flag_InterfaceVersion
+  | Flag_BypassInterfaceVersonCheck
   | Flag_UseContents String
   | Flag_GenContents
   | Flag_UseIndex String
@@ -175,6 +176,8 @@ options backwardsCompat =
       "output compatible interface file versions and exit",
     Option []  ["interface-version"]  (NoArg Flag_InterfaceVersion)
       "output interface file version and exit",
+    Option []  ["bypass-interface-version-check"] (NoArg Flag_BypassInterfaceVersonCheck)
+      "bypass the interface file version check (dangerous)",
     Option ['v']  ["verbosity"]  (ReqArg Flag_Verbosity "VERBOSITY")
       "set verbosity level",
     Option [] ["use-contents"] (ReqArg Flag_UseContents "URL")

--- a/haddock-test/src/Test/Haddock/Config.hs
+++ b/haddock-test/src/Test/Haddock/Config.hs
@@ -196,6 +196,7 @@ loadConfig ccfg dcfg flags files = do
 
     cfgHaddockArgs <- liftM concat . sequence $
         [ pure ["--no-warnings"]
+        , pure ["--bypass-interface-version-check"]
         , pure ["--odir=" ++ dcfgOutDir dcfg]
         , pure ["--optghc=-w"]
         , pure ["--optghc=-hide-all-packages"]


### PR DESCRIPTION
Partially alleviates #255 by disabling the interface version check for `haddock-test`. This means `haddock-test` might

  * crash during deserialization
  * deserialize incorrectly

Still - it means things _might_ work where they were previously guaranteed not to. For example, this is enough to keep tests fully green when bumping the interface version in #875.