### PR TITLE
Avoid "invalid argument (invalid character)" on non-unicode Windows

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -81,6 +81,7 @@ processModules
 processModules verbosity modules flags extIfaces = do
 #if defined(mingw32_HOST_OS)
   -- Avoid internal error: <stderr>: hPutChar: invalid argument (invalid character)' non UTF-8 Windows
+  liftIO $ hSetEncoding stdout $ mkLocaleEncoding TransliterateCodingFailure
   liftIO $ hSetEncoding stderr $ mkLocaleEncoding TransliterateCodingFailure
 #endif
 


### PR DESCRIPTION
Steps to reproduce and the error message
====

```
> stack haddock basement
... snip ...
    Warning: 'A' is out of scope.
    Warning: 'haddock: internal error: <stdout>: commitBuffer: invalid argument (invalid character)
```

Environment
====

OS: Windows 10 ver. 1709
haddock: [HEAD of ghc-8.4 when I reproduce the error](https://github.com/haskell/haddock/commit/532b209d127e4cecdbf7e9e3dcf4f653a5605b5a). (I had to use this version to avoid another probrem already fixed in HEAD)
GHC: 8.4.3
stack: Version 1.7.1, Git revision 681c800873816c022739ca7ed14755e85a579565 (5807 commits) x86_64 hpack-0.28.2
stack's resolver: nightly-2018-07-21

Related pull request
====

https://github.com/haskell/haddock/pull/566