### PR TITLE
Add Stack.yaml to test for Stackage compatibility

### DIFF
--- a/haddock-api/Stack.yaml
+++ b/haddock-api/Stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-11.19
+packages:
+- '.'
+extra-deps: []

--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -19,7 +19,7 @@ module Haddock.Backends.Hoogle (
 import BasicTypes (OverlapFlag(..), OverlapMode(..), SourceText(..))
 import InstEnv (ClsInst(..))
 import Haddock.GhcUtils
-import Haddock.Types hiding (Version)
+import Haddock.Types
 import Haddock.Utils hiding (out)
 
 import HsBinds (emptyLHsBinds)

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -34,7 +34,19 @@ import Data.Typeable
 import Data.Map (Map)
 import Data.Data (Data)
 import qualified Data.Map as Map
-import Documentation.Haddock.Types
+import Documentation.Haddock.Types ( Example
+                                   , Header
+                                   , Hyperlink
+                                   , Picture
+                                   , DocH(..)
+                                   , Example(..)
+                                   , Header(..)
+                                   , Hyperlink(..)
+                                   , MetaDoc(..)
+                                   , Picture(..)
+                                   , Meta(..)
+                                   , overDoc )
+
 import BasicTypes (Fixity(..))
 
 import GHC hiding (NoLink)


### PR DESCRIPTION
I'm fairly new to Haskell and packaging, so I'll state my situation and thinking fully in case I've gone wrong somewhere.

I'm writing a package, whose dependencies I want to fix to a Stackage LTS version. I use Sublime Text to edit files. I use the SublimeHaskell plugin, for linting. This plugin uses the hsdev package to analyse code. This package isn't available on Stackage later than LTS 9.21. I want to use a later version of Stackage than this.

The latest LTS I can use to build hsdev is 11.19. I must add 'hsdev-0.3.1.3' to 'extra-deps' in my package's stack.yaml. This feels fragile: I wouldn't know how to fix things if I need a non-Stackage package whose dependencies conflict with my Stackage packages. I figure the way to fix this is to make a version of hsdev-0.3.1.3 that can be built with LTS 11.19, then add it to the next release of Stackage LTS 11, that is to say, LTS 11.20.

So I've tried to build hsdev with 11.19. I can't build it with solely LTS 11.19 dependencies; I need to add some extra-deps:

- haddock-api-2.18.1
- haddock-library-1.4.4
- hdocs-0.5.2.1

I seem to have recursed into the same situation, and need to get versions of these guys into Stackage 11.20.

So that's my current plan. With the attached changes, I can build haddock-api without extra-deps. (I don't actually understand why the changes are needed, but I get namespace conflicts between Haddock packages without them.) In my mental model, this means that when they're merged, I can bump the version, and add that new version of haddock-api to Stackage LTS 11.

Does my workflow make sense? Is this how people usually fix such situations? I might be entirely wrong at many stages; corrections would be much appreciated.