### PR TITLE
Better data family rendering

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -33,7 +33,7 @@ module Haddock.Backends.Xhtml.Layout (
   subEquations,
   subFields,
   subInstances, subOrphanInstances,
-  subInstHead, subInstDetails, subFamInstDetails,
+  subInstHead, subInstDetails, subFamInstDetails, subDataFamInstDetails,
   subMethods,
   subMinimal,
 
@@ -238,10 +238,17 @@ subInstDetails iid ats mets mdl =
 
 subFamInstDetails :: String -- ^ Instance unique id (for anchor generation)
                   -> Html   -- ^ Type or data family instance
-                  -> Html   -- ^ Source module TODO: use this
+                  -> Html   -- ^ Source module
                   -> Html
 subFamInstDetails iid fi mdl =
     subInstSection iid << (p mdl <+> (thediv ! [theclass "src"] << fi))
+
+subDataFamInstDetails :: String -- ^ Instance unique id (for anchor generation)
+                  -> Html   -- ^ Type or data family instance
+                  -> Html   -- ^ Source module
+                  -> Html
+subDataFamInstDetails iid fi mdl =
+    subInstSection iid << (p mdl <+> (thediv << fi))
 
 subInstSection :: String -- ^ Instance unique id (for anchor generation)
                -> Html

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -239,7 +239,7 @@ synifyTyCon coax tc
   -- That seems like an acceptable compromise (they'll just be documented
   -- in prefix position), since, otherwise, the logic (at best) gets much more
   -- complicated. (would use dataConIsInfix.)
-  use_gadt_syntax = any (not . isVanillaDataCon) (tyConDataCons tc)
+  use_gadt_syntax = isGadtSyntaxTyCon tc
   consRaw = map (synifyDataCon use_gadt_syntax) (tyConDataCons tc)
   cons = rights consRaw
   -- "deriving" doesn't affect the signature, no need to specify any.
@@ -338,7 +338,7 @@ synifyDataCon use_gadt_syntax dc =
            then return $ noLoc $
               ConDeclGADT { con_g_ext  = noExt
                           , con_names  = [name]
-                          , con_forall = noLoc True
+                          , con_forall = noLoc False
                           , con_qvars  = synifyTyVars (univ_tvs ++ ex_tvs)
                           , con_mb_cxt = Just ctx
                           , con_args   =  hat
@@ -347,7 +347,7 @@ synifyDataCon use_gadt_syntax dc =
            else return $ noLoc $
               ConDeclH98 { con_ext    = noExt
                          , con_name   = name
-                         , con_forall = noLoc True
+                         , con_forall = noLoc False
                          , con_ex_tvs = map synifyTyVar ex_tvs
                          , con_mb_cxt = Just ctx
                          , con_args   = hat

--- a/hoogle-test/ref/Bug722/test.txt
+++ b/hoogle-test/ref/Bug722/test.txt
@@ -8,7 +8,7 @@ module Bug722
 class Foo a
 (!@#) :: Foo a => a -> a -> a
 infixl 4 !@#
-type family &* :: * -> * -> *
+type family (&*) :: * -> * -> *
 infixr 3 &*
 data a :-& b
 (:^&) :: a -> b -> (:-&) a b

--- a/html-test/ref/Bug294.html
+++ b/html-test/ref/Bug294.html
@@ -82,17 +82,23 @@
 		      >Defined in <a href="#"
 			>Bug294</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="Bug294"
-			>DP</a
-			> <a href="#" title="Bug294"
-			>A</a
-			> = <a id="v:ProblemCtor-39-" class="def"
-			>ProblemCtor'</a
-			> <a href="#" title="Bug294"
-			>A</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:ProblemCtor-39-" class="def"
+				>ProblemCtor'</a
+				> <a href="#" title="Bug294"
+				>A</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -124,17 +130,23 @@
 		      >Defined in <a href="#"
 			>Bug294</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="Bug294"
-			>TP</a
-			> <a href="#" title="Bug294"
-			>A</a
-			> = <a id="v:ProblemCtor" class="def"
-			>ProblemCtor</a
-			> <a href="#" title="Bug294"
-			>A</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:ProblemCtor" class="def"
+				>ProblemCtor</a
+				> <a href="#" title="Bug294"
+				>A</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -220,17 +232,23 @@
 		      >Defined in <a href="#"
 			>Bug294</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="Bug294"
-			>TP</a
-			> <a href="#" title="Bug294"
-			>A</a
-			> = <a id="v:ProblemCtor" class="def"
-			>ProblemCtor</a
-			> <a href="#" title="Bug294"
-			>A</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:ProblemCtor" class="def"
+				>ProblemCtor</a
+				> <a href="#" title="Bug294"
+				>A</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -280,17 +298,23 @@
 		      >Defined in <a href="#"
 			>Bug294</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="Bug294"
-			>DP</a
-			> <a href="#" title="Bug294"
-			>A</a
-			> = <a id="v:ProblemCtor-39-" class="def"
-			>ProblemCtor'</a
-			> <a href="#" title="Bug294"
-			>A</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:ProblemCtor-39-" class="def"
+				>ProblemCtor'</a
+				> <a href="#" title="Bug294"
+				>A</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -338,13 +362,21 @@
 		      >Defined in <a href="#"
 			>Bug294</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="Bug294"
-			>TO'</a
-			> a = <a id="v:PolyCtor" class="def"
-			>PolyCtor</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:PolyCtor" class="def"
+				>PolyCtor</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td

--- a/html-test/ref/DataFamily.html
+++ b/html-test/ref/DataFamily.html
@@ -1,0 +1,564 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >DataFamily</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>DataFamily</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><span class="keyword"
+	      >data family</span
+	      > <a href="#"
+	      >Foo</a
+	      > a</li
+	    ><li class="src short"
+	    ><span class="keyword"
+	      >type family</span
+	      > <a href="#"
+	      >Fam</a
+	      > a :: *</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data family</span
+	    > <a id="t:Foo" class="def"
+	    >Foo</a
+	    > a <span class="fixity"
+	    >infixl 3</span
+	    ><span class="rightedge"
+	    ></span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >some data family</p
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:Foo" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Foo:Eq:1"
+		      ></span
+		      > <a href="#" title="Data.Eq"
+		      >Eq</a
+		      > (<a href="#" title="DataFamily"
+		      >Foo</a
+		      > <a href="#" title="Data.Int"
+		      >Int</a
+		      >)</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Foo:Eq:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >(==)</a
+			  > :: <a href="#" title="DataFamily"
+			  >Foo</a
+			  > <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="DataFamily"
+			  >Foo</a
+			  > <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(/=)</a
+			  > :: <a href="#" title="DataFamily"
+			  >Foo</a
+			  > <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="DataFamily"
+			  >Foo</a
+			  > <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Foo:Foo:2"
+		      ></span
+		      > <span class="keyword"
+		      >data</span
+		      > <a href="#" title="DataFamily"
+		      >Foo</a
+		      > <a href="#" title="Data.Int"
+		      >Int</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >A plain ADT instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Foo:Foo:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Foo_Int" class="def"
+				>Foo_Int</a
+				> <a href="#" title="Data.Int"
+				>Int</a
+				> <span class="fixity"
+				>infixr 5</span
+				><span class="rightedge"
+				></span
+				></td
+			      ><td class="doc"
+			      ><p
+				>Int</p
+				></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:Foo_Zero" class="def"
+				>Foo_Zero</a
+				></td
+			      ><td class="doc"
+			      ><p
+				>Zero</p
+				></td
+			      ></tr
+			    ></table
+			  ></div
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Foo:Fam:3"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="DataFamily"
+		      >Fam</a
+		      > (<a href="#" title="DataFamily"
+		      >Foo</a
+		      > <a href="#" title="Data.Int"
+		      >Int</a
+		      >)</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >one type instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Foo:Fam:3"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="DataFamily"
+			>Fam</a
+			> (<a href="#" title="DataFamily"
+			>Foo</a
+			> <a href="#" title="Data.Int"
+			>Int</a
+			>) = <a href="#" title="Data.Int"
+			>Int</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Foo:Fam:4"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="DataFamily"
+		      >Fam</a
+		      > (<a href="#" title="DataFamily"
+		      >Foo</a
+		      > [a])</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >another type instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Foo:Fam:4"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="DataFamily"
+			>Fam</a
+			> (<a href="#" title="DataFamily"
+			>Foo</a
+			> [a]) = a</div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Foo:Foo:5"
+		      ></span
+		      > <span class="keyword"
+		      >newtype</span
+		      > <a href="#" title="DataFamily"
+		      >Foo</a
+		      > [a]</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >A newtype instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Foo:Foo:5"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Foo_List" class="def"
+				>Foo_List</a
+				> [a]</td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Foo:Foo:6"
+		      ></span
+		      > <span class="keyword"
+		      >data</span
+		      > <a href="#" title="DataFamily"
+		      >Foo</a
+		      > (a, b)</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >A GADT like instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Foo:Foo:6"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Foo_Eq" class="def"
+				>Foo_Eq</a
+				> <span class="fixity"
+				>infixl 2</span
+				><span class="rightedge"
+				></span
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td colspan="2"
+			      ><div class="subs fields"
+				><p class="caption"
+				  >Fields</p
+				  ><ul
+				  ><li
+				    ><dfn class="src"
+				      >:: a</dfn
+				      ><div class="doc"
+				      ><p
+					>lhs</p
+					></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      >-&gt; a</dfn
+				      ><div class="doc"
+				      ><p
+					>rhs</p
+					></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      >-&gt; <a href="#" title="DataFamily"
+					>Foo</a
+					> (a, a)</dfn
+				      ><div class="doc"
+				      ><p
+					>output</p
+					></div
+				      ></li
+				    ></ul
+				  ></div
+				></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:Foo_MaybeEq" class="def"
+				>Foo_MaybeEq</a
+				> :: a -&gt; b -&gt; <a href="#" title="DataFamily"
+				>Foo</a
+				> (a, b)</td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >type family</span
+	    > <a id="t:Fam" class="def"
+	    >Fam</a
+	    > a :: * <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >some type family</p
+	    ></div
+	  ><div class="subs instances"
+	  ><details id="i:Fam" open="open"
+	    ><summary
+	      >Instances</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Fam:Fam:1"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="DataFamily"
+		      >Fam</a
+		      > (<a href="#" title="DataFamily"
+		      >Foo</a
+		      > <a href="#" title="Data.Int"
+		      >Int</a
+		      >)</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >one type instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Fam:Fam:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="DataFamily"
+			>Fam</a
+			> (<a href="#" title="DataFamily"
+			>Foo</a
+			> <a href="#" title="Data.Int"
+			>Int</a
+			>) = <a href="#" title="Data.Int"
+			>Int</a
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:if:Fam:Fam:2"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="DataFamily"
+		      >Fam</a
+		      > (<a href="#" title="DataFamily"
+		      >Foo</a
+		      > [a])</span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >another type instance</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:if:Fam:Fam:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>DataFamily</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="DataFamily"
+			>Fam</a
+			> (<a href="#" title="DataFamily"
+			>Foo</a
+			> [a]) = a</div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -1898,29 +1898,33 @@
 		      >Defined in <a href="#"
 			>Instances</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="Instances"
-			>Thud</a
-			> <a href="#" title="Data.Int"
-			>Int</a
-			> (<a href="#" title="Instances"
-			>Quux</a
-			> a [a] c) <ul class="inst"
-			><li class="inst"
-			  >= <a id="v:Thuud" class="def"
-			    >Thuud</a
-			    > a</li
-			  ><li class="inst"
-			  >| <a id="v:Thuuud" class="def"
-			    >Thuuud</a
-			    > <a href="#" title="Data.Int"
-			    >Int</a
-			    > <a href="#" title="Data.Int"
-			    >Int</a
-			    ></li
-			  ></ul
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Thuud" class="def"
+				>Thuud</a
+				> a</td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:Thuuud" class="def"
+				>Thuuud</a
+				> <a href="#" title="Data.Int"
+				>Int</a
+				> <a href="#" title="Data.Int"
+				>Int</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td

--- a/html-test/ref/TypeFamilies.html
+++ b/html-test/ref/TypeFamilies.html
@@ -444,15 +444,21 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>AssocD</a
-			> <a href="#" title="TypeFamilies"
-			>X</a
-			> = <a id="v:AssocX" class="def"
-			>AssocX</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:AssocX" class="def"
+				>AssocX</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -530,39 +536,61 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>Bat</a
-			> <a href="#" title="TypeFamilies"
-			>X</a
-			> <ul class="inst"
-			><li class="inst"
-			  >= <a id="v:BatX" class="def"
-			    >BatX</a
-			    > <a href="#" title="TypeFamilies"
-			    >X</a
-			    ></li
-			  ><li class="inst"
-			  >| <a id="v:BatXX" class="def"
-			    >BatXX</a
-			    > { <ul class="subs"
-			    ><li
-			      ><a id="v:aaa" class="def"
-				>aaa</a
-				> :: <a href="#" title="TypeFamilies"
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BatX" class="def"
+				>BatX</a
+				> <a href="#" title="TypeFamilies"
 				>X</a
-				></li
-			      ><li
-			      ><a id="v:bbb" class="def"
-				>bbb</a
-				> :: <a href="#" title="TypeFamilies"
-				>Y</a
-				></li
-			      ></ul
-			    > }</li
-			  ></ul
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:BatXX" class="def"
+				>BatXX</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td colspan="2"
+			      ><div class="subs fields"
+				><p class="caption"
+				  >Fields</p
+				  ><ul
+				  ><li
+				    ><dfn class="src"
+				      ><a id="v:aaa" class="def"
+					>aaa</a
+					> :: <a href="#" title="TypeFamilies"
+					>X</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      ><a id="v:bbb" class="def"
+					>bbb</a
+					> :: <a href="#" title="TypeFamilies"
+					>Y</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ></ul
+				  ></div
+				></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -790,14 +818,8 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies2"
-			>Bar</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
-			></div
+		      > <div
+		      ></div
 		      ></details
 		    ></td
 		  ></tr
@@ -828,15 +850,21 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>AssocD</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
-			> = <a id="v:AssocY" class="def"
-			>AssocY</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:AssocY" class="def"
+				>AssocY</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -912,17 +940,23 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>Bat</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
-			> = <a id="v:BatY" class="def"
-			>BatY</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BatY" class="def"
+				>BatY</a
+				> <a href="#" title="TypeFamilies"
+				>Y</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -1084,43 +1118,75 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>Bat</a
-			> (z :: <a href="#" title="TypeFamilies"
-			>Z</a
-			>) <span class="keyword"
-			>where</span
-			><ul class="inst"
-			><li class="inst"
-			  ><a id="v:BatZ1" class="def"
-			    >BatZ1</a
-			    > :: <span class="keyword"
-			    >forall</span
-			    > (z :: <a href="#" title="TypeFamilies"
-			    >Z</a
-			    >). <a href="#" title="TypeFamilies"
-			    >Z</a
-			    > -&gt; <a href="#" title="TypeFamilies"
-			    >Bat</a
-			    > <a href="#" title="TypeFamilies"
-			    >ZA</a
-			    ></li
-			  ><li class="inst"
-			  ><a id="v:BatZ2" class="def"
-			    >BatZ2</a
-			    > :: <span class="keyword"
-			    >forall</span
-			    > (z :: <a href="#" title="TypeFamilies"
-			    >Z</a
-			    >). {..} -&gt; <a href="#" title="TypeFamilies"
-			    >Bat</a
-			    > <a href="#" title="TypeFamilies"
-			    >ZB</a
-			    ></li
-			  ></ul
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BatZ1" class="def"
+				>BatZ1</a
+				> :: <a href="#" title="TypeFamilies"
+				>Z</a
+				> -&gt; <a href="#" title="TypeFamilies"
+				>Bat</a
+				> <a href="#" title="TypeFamilies"
+				>ZA</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:BatZ2" class="def"
+				>BatZ2</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td colspan="2"
+			      ><div class="subs fields"
+				><p class="caption"
+				  >Fields</p
+				  ><ul
+				  ><li
+				    ><dfn class="src"
+				      >:: { <a id="v:batx" class="def"
+					>batx</a
+					> :: <a href="#" title="TypeFamilies"
+					>X</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      >, <a id="v:baty" class="def"
+					>baty</a
+					> :: <a href="#" title="TypeFamilies"
+					>Y</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      >} -&gt; <a href="#" title="TypeFamilies"
+					>Bat</a
+					> <a href="#" title="TypeFamilies"
+					>ZB</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ></ul
+				  ></div
+				></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -1364,43 +1430,75 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>Bat</a
-			> (z :: <a href="#" title="TypeFamilies"
-			>Z</a
-			>) <span class="keyword"
-			>where</span
-			><ul class="inst"
-			><li class="inst"
-			  ><a id="v:BatZ1" class="def"
-			    >BatZ1</a
-			    > :: <span class="keyword"
-			    >forall</span
-			    > (z :: <a href="#" title="TypeFamilies"
-			    >Z</a
-			    >). <a href="#" title="TypeFamilies"
-			    >Z</a
-			    > -&gt; <a href="#" title="TypeFamilies"
-			    >Bat</a
-			    > <a href="#" title="TypeFamilies"
-			    >ZA</a
-			    ></li
-			  ><li class="inst"
-			  ><a id="v:BatZ2" class="def"
-			    >BatZ2</a
-			    > :: <span class="keyword"
-			    >forall</span
-			    > (z :: <a href="#" title="TypeFamilies"
-			    >Z</a
-			    >). {..} -&gt; <a href="#" title="TypeFamilies"
-			    >Bat</a
-			    > <a href="#" title="TypeFamilies"
-			    >ZB</a
-			    ></li
-			  ></ul
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BatZ1" class="def"
+				>BatZ1</a
+				> :: <a href="#" title="TypeFamilies"
+				>Z</a
+				> -&gt; <a href="#" title="TypeFamilies"
+				>Bat</a
+				> <a href="#" title="TypeFamilies"
+				>ZA</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:BatZ2" class="def"
+				>BatZ2</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ><tr
+			    ><td colspan="2"
+			      ><div class="subs fields"
+				><p class="caption"
+				  >Fields</p
+				  ><ul
+				  ><li
+				    ><dfn class="src"
+				      >:: { <a id="v:batx" class="def"
+					>batx</a
+					> :: <a href="#" title="TypeFamilies"
+					>X</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      >, <a id="v:baty" class="def"
+					>baty</a
+					> :: <a href="#" title="TypeFamilies"
+					>Y</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      >} -&gt; <a href="#" title="TypeFamilies"
+					>Bat</a
+					> <a href="#" title="TypeFamilies"
+					>ZB</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ></ul
+				  ></div
+				></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -1434,17 +1532,25 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>Bat</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
-			> = <a id="v:BatY" class="def"
-			>BatY</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BatY" class="def"
+				>BatY</a
+				> <a href="#" title="TypeFamilies"
+				>Y</a
+				></td
+			      ><td class="doc"
+			      ><p
+				>Doc for: BatY Y</p
+				></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -1478,39 +1584,65 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies"
-			>Bat</a
-			> <a href="#" title="TypeFamilies"
-			>X</a
-			> <ul class="inst"
-			><li class="inst"
-			  >= <a id="v:BatX" class="def"
-			    >BatX</a
-			    > <a href="#" title="TypeFamilies"
-			    >X</a
-			    ></li
-			  ><li class="inst"
-			  >| <a id="v:BatXX" class="def"
-			    >BatXX</a
-			    > { <ul class="subs"
-			    ><li
-			      ><a id="v:aaa" class="def"
-				>aaa</a
-				> :: <a href="#" title="TypeFamilies"
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BatX" class="def"
+				>BatX</a
+				> <a href="#" title="TypeFamilies"
 				>X</a
-				></li
-			      ><li
-			      ><a id="v:bbb" class="def"
-				>bbb</a
-				> :: <a href="#" title="TypeFamilies"
-				>Y</a
-				></li
-			      ></ul
-			    > }</li
-			  ></ul
+				></td
+			      ><td class="doc"
+			      ><p
+				>Doc for: BatX X</p
+				></td
+			      ></tr
+			    ><tr
+			    ><td class="src"
+			      ><a id="v:BatXX" class="def"
+				>BatXX</a
+				></td
+			      ><td class="doc"
+			      ><p
+				>Doc for: BatXX { ... }</p
+				></td
+			      ></tr
+			    ><tr
+			    ><td colspan="2"
+			      ><div class="subs fields"
+				><p class="caption"
+				  >Fields</p
+				  ><ul
+				  ><li
+				    ><dfn class="src"
+				      ><a id="v:aaa" class="def"
+					>aaa</a
+					> :: <a href="#" title="TypeFamilies"
+					>X</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ><li
+				    ><dfn class="src"
+				      ><a id="v:bbb" class="def"
+					>bbb</a
+					> :: <a href="#" title="TypeFamilies"
+					>Y</a
+					></dfn
+				      ><div class="doc empty"
+				      ></div
+				      ></li
+				    ></ul
+				  ></div
+				></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td

--- a/html-test/ref/TypeFamilies2.html
+++ b/html-test/ref/TypeFamilies2.html
@@ -114,16 +114,22 @@
 		      >Defined in <a href="#"
 			>TypeFamilies2</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies2"
-			>Bar</a
-			> <a href="#" title="TypeFamilies2"
-			>W</a
-			> = <a id="v:BarX" class="def"
-			>BarX</a
-			> Z</div
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BarX" class="def"
+				>BarX</a
+				> Z</td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
+			></div
 		      ></details
 		    ></td
 		  ></tr
@@ -322,16 +328,22 @@
 		      >Defined in <a href="#"
 			>TypeFamilies2</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies2"
-			>Bar</a
-			> <a href="#" title="TypeFamilies2"
-			>W</a
-			> = <a id="v:BarX" class="def"
-			>BarX</a
-			> Z</div
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:BarX" class="def"
+				>BarX</a
+				> Z</td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
+			></div
 		      ></details
 		    ></td
 		  ></tr
@@ -362,14 +374,8 @@
 		      >Defined in <a href="#"
 			>TypeFamilies</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies2"
-			>Bar</a
-			> <a href="#" title="TypeFamilies"
-			>Y</a
-			></div
+		      > <div
+		      ></div
 		      ></details
 		    ></td
 		  ></tr

--- a/html-test/ref/TypeFamilies3.html
+++ b/html-test/ref/TypeFamilies3.html
@@ -250,17 +250,23 @@
 		      >Defined in <a href="#"
 			>TypeFamilies3</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>newtype</span
-			> <a href="#" title="TypeFamilies3"
-			>Baz</a
-			> <a href="#" title="Prelude"
-			>Double</a
-			> = <a id="v:Baz3" class="def"
-			>Baz3</a
-			> <a href="#" title="Prelude"
-			>Float</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Baz3" class="def"
+				>Baz3</a
+				> <a href="#" title="Prelude"
+				>Float</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -292,17 +298,23 @@
 		      >Defined in <a href="#"
 			>TypeFamilies3</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies3"
-			>Baz</a
-			> <a href="#" title="Data.Int"
-			>Int</a
-			> = <a id="v:Baz2" class="def"
-			>Baz2</a
-			> <a href="#" title="Data.Bool"
-			>Bool</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Baz2" class="def"
+				>Baz2</a
+				> <a href="#" title="Data.Bool"
+				>Bool</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td
@@ -332,13 +344,21 @@
 		      >Defined in <a href="#"
 			>TypeFamilies3</a
 			></p
-		      > <div class="src"
-		      ><span class="keyword"
-			>data</span
-			> <a href="#" title="TypeFamilies3"
-			>Baz</a
-			> () = <a id="v:Baz1" class="def"
-			>Baz1</a
+		      > <div
+		      ><div class="subs constructors"
+			><p class="caption"
+			  >Constructors</p
+			  ><table
+			  ><tr
+			    ><td class="src"
+			      ><a id="v:Baz1" class="def"
+				>Baz1</a
+				></td
+			      ><td class="doc empty"
+			      ></td
+			      ></tr
+			    ></table
+			  ></div
 			></div
 		      ></details
 		    ></td

--- a/html-test/src/DataFamily.hs
+++ b/html-test/src/DataFamily.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TypeFamilies, GADTs, FlexibleInstances #-}
+module DataFamily where
+
+-- | some data family
+data family Foo a
+infixl 3 `Foo`
+
+-- | some type family
+type family Fam a :: *
+
+-- | one type instance
+type instance Fam (Foo Int) = Int
+
+-- | another type instance
+type instance Fam (Foo [a]) = a
+
+-- | A newtype instance
+newtype instance Foo [a] = Foo_List [a]
+
+-- | A plain ADT instance
+data instance Foo Int
+  = Foo_Int Int -- ^ Int
+  | Foo_Zero    -- ^ Zero
+infixr 5 `Foo_Int`
+
+-- | A GADT like instance
+data instance Foo (a, b) where
+  Foo_Eq :: a         -- ^ lhs
+         -> a         -- ^ rhs
+         -> Foo (a,a) -- ^ output
+  Foo_MaybeEq :: a -> b -> Foo (a,b)
+infixl 2 `Foo_Eq`
+
+instance Eq (Foo Int) where
+  Foo_Zero == Foo_Zero = True
+  Foo_Zero == Foo_Int n = 0 == n
+  Foo_Int n == Foo_Zero = n == 0
+  Foo_Int n == Foo_Int m = n == m


### PR DESCRIPTION
This changes the HTML backend to render the constructors of data families in the same way as other constructors (from regular data declarations) are rendered. One pleasant side effect of this is that docs/fixities on data family constructors end up in the final HTML output.

See [this comment](https://github.com/haskell/haddock/issues/300#issuecomment-402349593) for a preview of what this looks like. I added that example as a test case in `html-test/src/DataFamily.hs`.