### PR TITLE
Load plugins when starting a GHC session

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -75,6 +75,7 @@ import Packages
 import Panic (handleGhcException)
 import Module
 import FastString
+import qualified DynamicLoading
 
 --------------------------------------------------------------------------------
 -- * Exception handling
@@ -448,7 +449,10 @@ withGhc' libDir flags ghcActs = runGhc (Just libDir) $ do
   -- that may need to be re-linked: Haddock doesn't do any
   -- dynamic or static linking at all!
   _ <- setSessionDynFlags dynflags''
-  ghcActs dynflags''
+  hscenv <- GHC.getSession
+  dynflags''' <- liftIO (DynamicLoading.initializePlugins hscenv dynflags'')
+  _ <- setSessionDynFlags dynflags'''
+  ghcActs dynflags'''
   where
 
     -- ignore sublists of flags that start with "+RTS" and end in "-RTS"


### PR DESCRIPTION
Fixes #900 

This also needs to be backported to the `ghc-8.6` branch.