### PR TITLE
Remove unnecessary backslashes from docs

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -762,14 +762,14 @@ Special Characters
 ~~~~~~~~~~~~~~~~~~
 
 The following characters have special meanings in documentation
-comments: ``\\``, ``/``, ``'``, ``\```, ``"``, ``@``, ``<``, ``$``, ``#``. To insert a
+comments: ``\``, ``/``, ``'``, `````, ``"``, ``@``, ``<``, ``$``, ``#``. To insert a
 literal occurrence of one of these special characters, precede it with a
-backslash (``\\``).
+backslash (``\``).
 
 Additionally, the character ``>`` has a special meaning at the beginning
 of a line, and the following characters have special meanings at the
 beginning of a paragraph: ``*``, ``-``. These characters can also be
-escaped using ``\\``.
+escaped using ``\``.
 
 Furthermore, the character sequence ``>>>`` has a special meaning at the
 beginning of a line. To escape it, just prefix the characters in the


### PR DESCRIPTION
At https://haskell-haddock.readthedocs.io/en/latest/markup.html#special-characters
the backslash and backtick special characters show up with an extra
backslash before them – I think the escaping is not (or is no longer)
needed for those characters in rst.

I don’t know that much about rst, so shout if these changes are incorrect! I have built the documentation locally and verified that these changes remove the extra backslashes as I expected. I have also verified this on github (https://github.com/undergroundquizscene/haddock/blob/remove-backslashes-from-docs/doc/markup.rst).