### PR TITLE
Dead code-paths in Hi Haddock

### DIFF
--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -58,7 +58,6 @@ type InstIfaceMap  = Map Module InstalledInterface  -- TODO: rename
 type DocMap a      = Map Name (MDoc a)
 type ArgMap a      = Map Name (Map Int (MDoc a))
 type SubMap        = Map Name [Name]
-type DeclMap       = Map Name [LHsDecl GhcRn]
 type InstMap       = Map SrcSpan Name
 type FixMap        = Map Name Fixity
 type DocPaths      = (FilePath, Maybe FilePath) -- paths to HTML and sources


### PR DESCRIPTION
Removing this code has no impact on the output (try accepting before and after the commit). Offhand, it doesn't seem to impact any of the docs for libraries bundled with GHC either. We should either:

  * add test cases exercising the code paths this PR removes (I can't think of any such cases)
  * add test cases which used to (before Hi Haddock) exercise these code paths and are now broken
  * merge this

