### PR TITLE
Perf improvements

### DIFF
--- a/haddock-api/src/Haddock/Interface/Specialize.hs
+++ b/haddock-api/src/Haddock/Interface/Specialize.hs
@@ -47,14 +47,13 @@ specialize specs = go spec_map0
     -- one by one, we should avoid infinite loops.
     spec_map0 = foldr (\(n,t) acc -> Map.insert n (go acc t) acc) mempty specs
 
+{-# SPECIALIZE specialize :: [(Name, HsType GhcRn)] -> HsType GhcRn -> HsType GhcRn #-}
 
 -- | Instantiate given binders with corresponding types.
 --
 -- Again, it is just a convenience function around 'specialize'. Note that
 -- length of type list should be the same as the number of binders.
-specializeTyVarBndrs :: Data a
-                     => LHsQTyVars GhcRn -> [HsType GhcRn]
-                     -> a -> a
+specializeTyVarBndrs :: LHsQTyVars GhcRn -> [HsType GhcRn] -> HsType GhcRn -> HsType GhcRn
 specializeTyVarBndrs bndrs typs =
     specialize $ zip bndrs' typs
   where
@@ -64,11 +63,12 @@ specializeTyVarBndrs bndrs typs =
     bname (XTyVarBndr _) = error "haddock:specializeTyVarBndrs"
 
 
+
 specializePseudoFamilyDecl :: LHsQTyVars GhcRn -> [HsType GhcRn]
                            -> PseudoFamilyDecl GhcRn
                            -> PseudoFamilyDecl GhcRn
 specializePseudoFamilyDecl bndrs typs decl =
-  decl {pfdTyVars = map (specializeTyVarBndrs bndrs typs) (pfdTyVars decl)}
+  decl {pfdTyVars = map (fmap (specializeTyVarBndrs bndrs typs)) (pfdTyVars decl)}
 
 specializeSig :: LHsQTyVars GhcRn -> [HsType GhcRn]
               -> Sig GhcRn

--- a/haddock-library/src/Documentation/Haddock/Parser/Util.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser/Util.hs
@@ -40,7 +40,7 @@ skipHorizontalSpace = Parsec.skipMany (Parsec.oneOf horizontalSpace)
 
 -- | Take leading horizontal space
 takeHorizontalSpace :: Parser Text 
-takeHorizontalSpace = takeWhile (Parsec.oneOf horizontalSpace)
+takeHorizontalSpace = takeWhile (`elem` horizontalSpace)
 
 makeLabeled :: (String -> Maybe String -> a) -> Text -> a
 makeLabeled f input = case T.break isSpace $ removeEscapes $ T.strip input of


### PR DESCRIPTION
Several miscellaneous performance improvements I've accumulated.

| Package | Allocations before  | Allocations after |
| ------------- | ------------- | ------------- |
| `array`  | 2,061,076,013 (σ = 1,769)  | 1,952,495,714 (σ = 1,721)  |
| `ghc`  | 64,926,594,779 (σ = 33,124)  | 62,205,208,258 (σ = 384,330) |

There is a corresponding drop in runtime, although variance is so high it doesn't seem to be worth more than a passing mention.

