### PR TITLE
More synify-ing improvements

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -974,7 +974,7 @@ tupleParens _              = parenList
 
 
 sumParens :: [LaTeX] -> LaTeX
-sumParens = ubxparens . hsep . punctuate (text " | ")
+sumParens = ubxparens . hsep . punctuate (text " |")
 
 
 -------------------------------------------------------------------------------
@@ -1335,7 +1335,7 @@ ubxParenList = ubxparens . hsep . punctuate comma
 
 
 ubxparens :: LaTeX -> LaTeX
-ubxparens h = text "(#" <> h <> text "#)"
+ubxparens h = text "(#" <+> h <+> text "#)"
 
 
 nl :: LaTeX

--- a/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
@@ -175,7 +175,7 @@ ubxSumList = ubxparens . hsep . punctuate (toHtml " | ")
 
 
 ubxparens :: Html -> Html
-ubxparens h = toHtml "(#" +++ h +++ toHtml "#)"
+ubxparens h = toHtml "(#" <+> h <+> toHtml "#)"
 
 
 dcolon, arrow, darrow, forallSymbol :: Bool -> Html

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -51,7 +51,7 @@ import Haddock.Types
 import Haddock.Interface.Specialize
 import Haddock.GhcUtils                      ( orderedFVs )
 
-import Data.Maybe                            ( maybeToList )
+import Data.Maybe                            ( catMaybes, maybeToList )
 
 
 -- the main function here! yay!
@@ -71,16 +71,32 @@ tyThingToLHsDecl t = case t of
   -- later in the file (also it's used for class associated-types too.)
   ATyCon tc
     | Just cl <- tyConClass_maybe tc -- classes are just a little tedious
-    -> let extractFamilyDecl :: TyClDecl a -> Either ErrMsg (LFamilyDecl a)
-           extractFamilyDecl (FamDecl _ d) = return $ noLoc d
+    -> let extractFamilyDecl :: TyClDecl a -> Either ErrMsg (FamilyDecl a)
+           extractFamilyDecl (FamDecl _ d) = return d
            extractFamilyDecl _           =
              Left "tyThingToLHsDecl: impossible associated tycon"
 
-           atTyClDecls = [synifyTyCon Nothing at_tc | ATI at_tc _ <- classATItems cl]
-           atFamDecls  = map extractFamilyDecl (rights atTyClDecls)
-           tyClErrors = lefts atTyClDecls
-           famDeclErrors = lefts atFamDecls
-       in withErrs (tyClErrors ++ famDeclErrors) . TyClD noExt $ ClassDecl
+           extractFamDefDecl :: FamilyDecl GhcRn -> Type -> TyFamDefltEqn GhcRn
+           extractFamDefDecl fd rhs = FamEqn
+             { feqn_ext = noExt
+             , feqn_tycon = fdLName fd
+             , feqn_pats = fdTyVars fd
+             , feqn_fixity = fdFixity fd
+             , feqn_rhs = synifyType WithinType [] rhs }
+
+           extractAtItem
+             :: ClassATItem
+             -> Either ErrMsg (LFamilyDecl GhcRn, Maybe (LTyFamDefltEqn GhcRn))
+           extractAtItem (ATI at_tc def) = do
+             tyDecl <- synifyTyCon Nothing at_tc
+             famDecl <- extractFamilyDecl tyDecl
+             let defEqnTy = fmap (noLoc . extractFamDefDecl famDecl . fst) def
+             pure (noLoc famDecl, defEqnTy)
+
+           atTyClDecls = map extractAtItem (classATItems cl)
+           (atFamDecls, atDefFamDecls) = unzip (rights atTyClDecls)
+
+       in withErrs (lefts atTyClDecls) . TyClD noExt $ ClassDecl
          { tcdCtxt = synifyCtx (classSCTheta cl)
          , tcdLName = synifyName cl
          , tcdTyVars = synifyTyVars (tyConVisibleTyVars (classTyCon cl))
@@ -94,8 +110,8 @@ tyThingToLHsDecl t = case t of
                       , tcdSig <- synifyTcIdSig DeleteTopLevelQuantification clsOp ]
          , tcdMeths = emptyBag --ignore default method definitions, they don't affect signature
          -- class associated-types are a subset of TyCon:
-         , tcdATs = rights atFamDecls
-         , tcdATDefs = [] --ignore associated type defaults
+         , tcdATs = atFamDecls
+         , tcdATDefs = catMaybes atDefFamDecls
          , tcdDocs = [] --we don't have any docs at this point
          , tcdCExt = placeHolderNamesTc }
     | otherwise

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -467,6 +467,10 @@ synifyType _ (TyConApp tc tys)
                               UnboxedTuple    -> HsUnboxedTuple)
                            (map (synifyType WithinType) vis_tys)
       | isUnboxedSumTyCon tc = noLoc $ HsSumTy noExt (map (synifyType WithinType) vis_tys)
+      | Just dc <- isPromotedDataCon_maybe tc
+      , isTupleDataCon dc
+      , dataConSourceArity dc == length vis_tys
+      = noLoc $ HsExplicitTupleTy noExt (map (synifyType WithinType) vis_tys)
       -- ditto for lists
       | getName tc == listTyConName, [ty] <- tys =
          noLoc $ HsListTy noExt (synifyType WithinType ty)

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -472,7 +472,7 @@ synifyType _ (TyConApp tc tys)
       , dataConSourceArity dc == length vis_tys
       = noLoc $ HsExplicitTupleTy noExt (map (synifyType WithinType) vis_tys)
       -- ditto for lists
-      | getName tc == listTyConName, [ty] <- tys =
+      | getName tc == listTyConName, [ty] <- vis_tys =
          noLoc $ HsListTy noExt (synifyType WithinType ty)
       | tc == promotedNilDataCon, [] <- vis_tys
       = noLoc $ HsExplicitListTy noExt Promoted []

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -37,7 +37,7 @@ import Type
 import TyCoRep
 import TysPrim ( alphaTyVars )
 import TysWiredIn ( eqTyConName, listTyConName, liftedTypeKindTyConName
-                  , unitTy )
+                  , unitTy, promotedNilDataCon, promotedConsDataCon )
 import PrelNames ( hasKey, eqTyConKey, ipClassKey, tYPETyConKey
                  , liftedRepDataConKey )
 import Unique ( getUnique )
@@ -474,6 +474,16 @@ synifyType _ (TyConApp tc tys)
       -- ditto for lists
       | getName tc == listTyConName, [ty] <- tys =
          noLoc $ HsListTy noExt (synifyType WithinType ty)
+      | tc == promotedNilDataCon, [] <- vis_tys
+      = noLoc $ HsExplicitListTy noExt Promoted []
+      | tc == promotedConsDataCon
+      , [ty1, ty2] <- vis_tys
+      = let hTy = synifyType WithinType ty1
+        in case synifyType WithinType ty2 of
+             tTy | L _ (HsExplicitListTy _ Promoted tTy') <- stripKindSig tTy
+                 -> noLoc $ HsExplicitListTy noExt Promoted (hTy : tTy')
+                 | otherwise
+                 -> noLoc $ HsOpTy noExt hTy (noLoc $ getName tc) tTy
       -- ditto for implicit parameter tycons
       | tc `hasKey` ipClassKey
       , [name, ty] <- tys
@@ -641,6 +651,10 @@ synifyTyLit (StrTyLit s) = HsStrTy NoSourceText s
 
 synifyKindSig :: Kind -> LHsKind GhcRn
 synifyKindSig k = synifyType WithinType k
+
+stripKindSig :: LHsType GhcRn -> LHsType GhcRn
+stripKindSig (L _ (HsKindSig _ t _)) = t
+stripKindSig t = t
 
 synifyInstHead :: ([TyVar], [PredType], Class, [Type]) -> InstHead GhcRn
 synifyInstHead (_, preds, cls, types) = specializeInstHead $ InstHead

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -49,6 +49,7 @@ import VarSet
 
 import Haddock.Types
 import Haddock.Interface.Specialize
+import Haddock.GhcUtils                      ( orderedFVs )
 
 
 
@@ -595,10 +596,7 @@ synifyForAllType s vs ty =
 
       -- Figure out what the type variable order would be inferred in the
       -- absence of an explicit forall
-      ctxTvs = tyCoVarsOfTypesWellScoped ctx
-      restTvs = filter (\tv -> not (tv `elemVarSet` mkVarSet ctxTvs))
-                       (tyCoVarsOfTypeWellScoped tau)
-      tvs' = filter (`notElem` vs) (ctxTvs ++ restTvs)
+      tvs' = orderedFVs (mkVarSet vs) (ctx ++ [tau])
 
   in case s of
     DeleteTopLevelQuantification -> synifyType ImplicitizeForAll tvs' tau
@@ -638,10 +636,7 @@ implicitForAll vs tvs ctx synInner tau
 
   -- Figure out what the type variable order would be inferred in the
   -- absence of an explicit forall
-  ctxTvs = tyCoVarsOfTypesWellScoped ctx
-  restTvs = filter (\tv -> not (tv `elemVarSet` mkVarSet ctxTvs))
-                   (tyCoVarsOfTypeWellScoped tau)
-  tvs' = filter (`notElem` vs) (ctxTvs ++ restTvs)
+  tvs' = orderedFVs (mkVarSet vs) (ctx ++ [tau])
 
 
 

--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -466,6 +466,7 @@ synifyType _ (TyConApp tc tys)
                               ConstraintTuple -> HsConstraintTuple
                               UnboxedTuple    -> HsUnboxedTuple)
                            (map (synifyType WithinType) vis_tys)
+      | isUnboxedSumTyCon tc = noLoc $ HsSumTy noExt (map (synifyType WithinType) vis_tys)
       -- ditto for lists
       | getName tc == listTyConName, [ty] <- tys =
          noLoc $ HsListTy noExt (synifyType WithinType ty)

--- a/hoogle-test/ref/Bug722/test.txt
+++ b/hoogle-test/ref/Bug722/test.txt
@@ -8,7 +8,7 @@ module Bug722
 class Foo a
 (!@#) :: Foo a => a -> a -> a
 infixl 4 !@#
-type family &* :: * -> * -> *
+type family (&*) :: * -> * -> *
 infixr 3 &*
 data a :-& b
 (:^&) :: a -> b -> (:-&) a b

--- a/html-test/ref/UnboxedStuff.html
+++ b/html-test/ref/UnboxedStuff.html
@@ -1,0 +1,196 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >UnboxedStuff</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>UnboxedStuff</p
+	></div
+      ><div id="table-of-contents"
+      ><p class="caption"
+	>Contents</p
+	><ul
+	><li
+	  ><a href="#"
+	    >Unboxed type constructors</a
+	    ></li
+	  ></ul
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><span class="keyword"
+	      >data</span
+	      > <a href="#"
+	      >X</a
+	      ></li
+	    ><li class="src short"
+	    ><span class="keyword"
+	      >data</span
+	      > <a href="#"
+	      >Y</a
+	      ></li
+	    ><li class="src short"
+	    ><span class="keyword"
+	      >data</span
+	      > <a href="#"
+	      >Z</a
+	      ></li
+	    ><li class="src short"
+	    ><a href="#"
+	      >unboxedUnit</a
+	      > :: (# #) -&gt; (# #)</li
+	    ><li class="src short"
+	    ><a href="#"
+	      >unboxedTuple</a
+	      > :: (# <a href="#" title="UnboxedStuff"
+	      >X</a
+	      >, <a href="#" title="UnboxedStuff"
+	      >Y</a
+	      > #) -&gt; (# <a href="#" title="UnboxedStuff"
+	      >X</a
+	      >, <a href="#" title="UnboxedStuff"
+	      >Y</a
+	      >, <a href="#" title="UnboxedStuff"
+	      >Z</a
+	      > #)</li
+	    ><li class="src short"
+	    ><a href="#"
+	      >unboxedSum</a
+	      > :: (# <a href="#" title="UnboxedStuff"
+	      >X</a
+	      > |  <a href="#" title="UnboxedStuff"
+	      >Y</a
+	      > #) -&gt; (# <a href="#" title="UnboxedStuff"
+	      >X</a
+	      > |  <a href="#" title="UnboxedStuff"
+	      >Y</a
+	      > |  <a href="#" title="UnboxedStuff"
+	      >Z</a
+	      > #)</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:X" class="def"
+	    >X</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Y" class="def"
+	    >Y</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Z" class="def"
+	    >Z</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	><a href="#" id="g:1"
+	><h1
+	  >Unboxed type constructors</h1
+	  ></a
+	><div class="top"
+	><p class="src"
+	  ><a id="v:unboxedUnit" class="def"
+	    >unboxedUnit</a
+	    > :: (# #) -&gt; (# #) <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:unboxedTuple" class="def"
+	    >unboxedTuple</a
+	    > :: (# <a href="#" title="UnboxedStuff"
+	    >X</a
+	    >, <a href="#" title="UnboxedStuff"
+	    >Y</a
+	    > #) -&gt; (# <a href="#" title="UnboxedStuff"
+	    >X</a
+	    >, <a href="#" title="UnboxedStuff"
+	    >Y</a
+	    >, <a href="#" title="UnboxedStuff"
+	    >Z</a
+	    > #) <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:unboxedSum" class="def"
+	    >unboxedSum</a
+	    > :: (# <a href="#" title="UnboxedStuff"
+	    >X</a
+	    > |  <a href="#" title="UnboxedStuff"
+	    >Y</a
+	    > #) -&gt; (# <a href="#" title="UnboxedStuff"
+	    >X</a
+	    > |  <a href="#" title="UnboxedStuff"
+	    >Y</a
+	    > |  <a href="#" title="UnboxedStuff"
+	    >Z</a
+	    > #) <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/UnboxedStuff.hs
+++ b/html-test/src/UnboxedStuff.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE UnboxedSums, UnboxedTuples #-}
+module UnboxedStuff where
+
+data X
+data Y
+data Z
+
+-- * Unboxed type constructors
+
+unboxedUnit :: (# #) -> (# #)
+unboxedUnit  = undefined
+
+unboxedTuple :: (# X, Y #) -> (# X, Y, Z #)
+unboxedTuple = undefined 
+
+unboxedSum :: (# X | Y #) -> (# X | Y | Z #)
+unboxedSum = undefined 
+

--- a/latex-test/ref/UnboxedStuff/UnboxedStuff.tex
+++ b/latex-test/ref/UnboxedStuff/UnboxedStuff.tex
@@ -1,0 +1,36 @@
+\haddockmoduleheading{UnboxedStuff}
+\label{module:UnboxedStuff}
+\haddockbeginheader
+{\haddockverb\begin{verbatim}
+module UnboxedStuff (
+    X,  Y,  Z,  unboxedUnit,  unboxedTuple,  unboxedSum
+  ) where\end{verbatim}}
+\haddockendheader
+
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+data\ X
+\end{tabular}]
+\end{haddockdesc}
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+data\ Y
+\end{tabular}]
+\end{haddockdesc}
+\begin{haddockdesc}
+\item[\begin{tabular}{@{}l}
+data\ Z
+\end{tabular}]
+\end{haddockdesc}
+\section{Unboxed type constructors}
+\begin{haddockdesc}
+\item[
+unboxedUnit\ ::\ ({\char '43}\ {\char '43})\ ->\ ({\char '43}\ {\char '43})
+]
+\item[
+unboxedTuple\ ::\ ({\char '43}\ X,\ Y\ {\char '43})\ ->\ ({\char '43}\ X,\ Y,\ Z\ {\char '43})
+]
+\item[
+unboxedSum\ ::\ ({\char '43}\ X\ |\ Y\ {\char '43})\ ->\ ({\char '43}\ X\ |\ Y\ |\ Z\ {\char '43})
+]
+\end{haddockdesc}

--- a/latex-test/ref/UnboxedStuff/haddock.sty
+++ b/latex-test/ref/UnboxedStuff/haddock.sty
@@ -1,0 +1,57 @@
+% Default Haddock style definitions.  To use your own style, invoke
+% Haddock with the option --latex-style=mystyle.
+
+\usepackage{tabulary} % see below
+
+% make hyperlinks in the PDF, and add an expandabale index
+\usepackage[pdftex,bookmarks=true]{hyperref}
+
+\newenvironment{haddocktitle}
+  {\begin{center}\bgroup\large\bfseries}
+  {\egroup\end{center}}
+\newenvironment{haddockprologue}{\vspace{1in}}{}
+
+\newcommand{\haddockmoduleheading}[1]{\chapter{\texttt{#1}}}
+
+\newcommand{\haddockbeginheader}{\hrulefill}
+\newcommand{\haddockendheader}{\noindent\hrulefill}
+
+% a little gap before the ``Methods'' header
+\newcommand{\haddockpremethods}{\vspace{2ex}}
+
+% inserted before \\begin{verbatim}
+\newcommand{\haddockverb}{\small}
+
+% an identifier: add an index entry
+\newcommand{\haddockid}[1]{\haddocktt{#1}\index{#1@\texttt{#1}}}
+
+% The tabulary environment lets us have a column that takes up ``the
+% rest of the space''.  Unfortunately it doesn't allow
+% the \end{tabulary} to be in the expansion of a macro, it must appear
+% literally in the document text, so Haddock inserts
+% the \end{tabulary} itself.
+\newcommand{\haddockbeginconstrs}{\begin{tabulary}{\linewidth}{@{}llJ@{}}}
+\newcommand{\haddockbeginargs}{\begin{tabulary}{\linewidth}{@{}llJ@{}}}
+
+\newcommand{\haddocktt}[1]{{\small \texttt{#1}}}
+\newcommand{\haddockdecltt}[1]{{\small\bfseries \texttt{#1}}}
+
+\makeatletter
+\newenvironment{haddockdesc}
+               {\list{}{\labelwidth\z@ \itemindent-\leftmargin
+                        \let\makelabel\haddocklabel}}
+               {\endlist}
+\newcommand*\haddocklabel[1]{\hspace\labelsep\haddockdecltt{#1}}
+\makeatother
+
+% after a declaration, start a new line for the documentation.
+% Otherwise, the documentation starts right after the declaration,
+% because we're using the list environment and the declaration is the
+% ``label''.  I tried making this newline part of the label, but
+% couldn't get that to work reliably (the space seemed to stretch
+% sometimes).
+\newcommand{\haddockbegindoc}{\hfill\\[1ex]}
+
+% spacing between paragraphs and no \parindent looks better
+\parskip=10pt plus2pt minus2pt
+\setlength{\parindent}{0cm}

--- a/latex-test/ref/UnboxedStuff/main.tex
+++ b/latex-test/ref/UnboxedStuff/main.tex
@@ -1,0 +1,11 @@
+\documentclass{book}
+\usepackage{haddock}
+\begin{document}
+\begin{titlepage}
+\begin{haddocktitle}
+
+\end{haddocktitle}
+\end{titlepage}
+\tableofcontents
+\input{UnboxedStuff}
+\end{document}

--- a/latex-test/src/UnboxedStuff/UnboxedStuff.hs
+++ b/latex-test/src/UnboxedStuff/UnboxedStuff.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE UnboxedSums, UnboxedTuples #-}
+module UnboxedStuff where
+
+data X
+data Y
+data Z
+
+-- * Unboxed type constructors
+
+unboxedUnit :: (# #) -> (# #)
+unboxedUnit  = undefined
+
+unboxedTuple :: (# X, Y #) -> (# X, Y, Z #)
+unboxedTuple = undefined 
+
+unboxedSum :: (# X | Y #) -> (# X | Y | Z #)
+unboxedSum = undefined 
+


### PR DESCRIPTION
This cherry-picks from `ghc-head` some of the recent changes in `haddock-api/src/Haddock/Convert.hs`, then goes on to fix some more stuff on top of that:

  * filter almost all `forall`s on class methods and instance methods (visible improvements in `Bug548`, `Bug613`, and `SpuriousSuperclassConstraints`)
  * filter almost all `forall`s on pattern synonyms (visible improvements in `BundledPatterns` and `BundledPatterns2`)
  * fix a bug when computing the inferred type variable order (visible improvements in `Test`, but also all over the docs for the `Prelude`)
  * synify default methods (looks like handling these is now quite within reach since GHC internally gives these distinct names)
  * synify associated type defaults