### PR TITLE
Default 'RuntimeRep' arguments unless otherwise specified

### DIFF
--- a/doc/cheatsheet/haddocks.md
+++ b/doc/cheatsheet/haddocks.md
@@ -115,7 +115,7 @@ definitions with "[thing]"
 {-# OPTIONS_HADDOCK show-extensions #-}
   Show all enabled LANGUAGE extensions
 {-# OPTIONS_HADDOCK print-explicit-runtime-reps #-}
-  Don't default 'RuntimeRep' type variables
+  Show all `RuntimeRep` type variables
 ```
 
 # Grid tables

--- a/doc/cheatsheet/haddocks.md
+++ b/doc/cheatsheet/haddocks.md
@@ -114,6 +114,8 @@ definitions with "[thing]"
   "home" of identifiers it exports
 {-# OPTIONS_HADDOCK show-extensions #-}
   Show all enabled LANGUAGE extensions
+{-# OPTIONS_HADDOCK print-explicit-runtime-reps #-}
+  Don't default 'RuntimeRep' type variables
 ```
 
 # Grid tables

--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -750,6 +750,12 @@ The following attributes are currently understood by Haddock:
     be rendered, including those implied by their more powerful
     versions.
 
+``print-explicit-runtime-reps``
+    Print type variables that have kind ``RuntimeRep``. By default, these
+    are defaulted to ``LiftedRep`` so that end users don't have to see the
+    underlying levity polymorphism. This flag is analogous to GHC's
+    ``-fprint-explicit-runtime-reps`` flag.
+
 .. _markup:
 
 Markup

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, FlexibleInstances, ViewPatterns #-}
+{-# LANGUAGE BangPatterns, StandaloneDeriving, FlexibleInstances, ViewPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -31,9 +31,12 @@ import HscTypes
 import GHC
 import Class
 import DynFlags
-import Var       ( TyVarBndr(..), TyVarBinder, tyVarKind )
+import Var       ( TyVarBndr(..), TyVarBinder, tyVarKind, updateTyVarKind,
+                   isInvisibleArgFlag )
 import VarSet    ( VarSet, emptyVarSet )
-import TyCoRep   ( Type(..) )
+import VarEnv    ( TyVarEnv, extendVarEnv, elemVarEnv, emptyVarEnv )
+import TyCoRep   ( Type(..), isRuntimeRepVar )
+import TysWiredIn( liftedRepDataConTyCon )
 
 import HsTypes (HsType(..))
 
@@ -498,4 +501,46 @@ tyCoFVsOfTypes' []       fv_cand in_scope acc = emptyFV fv_cand in_scope acc
 -- appearance.
 tyCoFVsBndr' :: TyVarBinder -> FV -> FV
 tyCoFVsBndr' (TvBndr tv _) fvs = FV.delFV tv fvs `unionFV` tyCoFVsOfType' (tyVarKind tv)
+
+
+-------------------------------------------------------------------------------
+-- * Defaulting RuntimeRep variables
+-------------------------------------------------------------------------------
+
+-- | Traverses the type, defaulting type variables of kind 'RuntimeRep' to
+-- 'LiftedType'. See 'defaultRuntimeRepVars' in IfaceType.hs the original such
+-- function working over `IfaceType`'s.
+defaultRuntimeRepVars :: Type -> Type
+defaultRuntimeRepVars = go emptyVarEnv
+  where
+    go :: TyVarEnv () -> Type -> Type
+    go subs (ForAllTy (TvBndr var flg) ty)
+      | isRuntimeRepVar var
+      , isInvisibleArgFlag flg
+      = let subs' = extendVarEnv subs var ()
+        in go subs' ty
+      | otherwise
+      = ForAllTy (TvBndr (updateTyVarKind (go subs) var) flg)
+                 (go subs ty)
+
+    go subs (TyVarTy tv)
+      | tv `elemVarEnv` subs
+      = TyConApp liftedRepDataConTyCon []
+      | otherwise
+      = TyVarTy (updateTyVarKind (go subs) tv)
+
+    go subs (TyConApp tc tc_args)
+      = TyConApp tc (map (go subs) tc_args)
+
+    go subs (FunTy arg res)
+      = FunTy (go subs arg) (go subs res)
+
+    go subs (AppTy t u)
+      = AppTy (go subs t) (go subs u)
+
+    go subs (CastTy x co)
+      = CastTy (go subs x) co
+
+    go _ ty@(LitTy {}) = ty
+    go _ ty@(CoercionTy {}) = ty
 

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -85,7 +85,8 @@ createInterface mod_iface flags modMap instIfaceMap = do
   let renamer = docIdEnvRenamer (docs_id_env mod_iface_docs)
 
   opts <- liftErrMsg $ mkDocOpts (docs_haddock_opts mod_iface_docs) flags mdl
-  let prr = OptPrintRuntimeRep `elem` opts
+  let prr | OptPrintRuntimeRep `elem` opts = ShowRuntimeRep
+          | otherwise = HideRuntimeRep
 
   -- Process the top-level module header documentation.
   (!info, mbDoc) <- processModuleHeader pkgName renamer safety

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -285,7 +285,6 @@ parseOption "hide"            = return (Just OptHide)
 parseOption "prune"           = return (Just OptPrune)
 parseOption "not-home"        = return (Just OptNotHome)
 parseOption "show-extensions" = return (Just OptShowExtensions)
-parseOption "print-runtime-reps" = return (Just OptPrintRuntimeRep)
 parseOption "print-explicit-runtime-reps" = return (Just OptPrintRuntimeRep)
 parseOption other = tell ["Unrecognised option: " ++ other] >> return Nothing
 

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -400,6 +400,8 @@ instance Binary DocOption where
             putByte bh 2
     put_ bh OptShowExtensions = do
             putByte bh 3
+    put_ bh OptPrintRuntimeRep = do
+            putByte bh 4
     get bh = do
             h <- getByte bh
             case h of
@@ -411,6 +413,8 @@ instance Binary DocOption where
                     return OptNotHome
               3 -> do
                     return OptShowExtensions
+              4 -> do
+                    return OptPrintRuntimeRep
               _ -> fail "invalid binary data found"
 
 

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -523,6 +523,8 @@ data DocOption
   | OptNotHome         -- ^ Not the best place to get docs for things
                        -- exported by this module.
   | OptShowExtensions  -- ^ Render enabled extensions for this module.
+  | OptPrintRuntimeRep -- ^ Render runtime reps for this module (see
+                       -- the GHC @-fprint-explicit-runtime-reps@ flag)
   deriving (Eq, Show)
 
 

--- a/html-test/ref/HideRuntimeReps.html
+++ b/html-test/ref/HideRuntimeReps.html
@@ -1,0 +1,152 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >HideRuntimeReps</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>HideRuntimeReps</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><a href="#"
+	      >($)</a
+	      > :: (a -&gt; b) -&gt; a -&gt; b</li
+	    ><li class="src short"
+	    ><a href="#"
+	      >error</a
+	      > :: <a href="#" title="GHC.Stack"
+	      >HasCallStack</a
+	      > =&gt; [<a href="#" title="Data.Char"
+	      >Char</a
+	      >] -&gt; a</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><a id="v:-36-" class="def"
+	    >($)</a
+	    > :: (a -&gt; b) -&gt; a -&gt; b <span class="fixity"
+	    >infixr 0</span
+	    ><span class="rightedge"
+	    ></span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >Application operator.  This operator is redundant, since ordinary
+ application <code
+	      >(f x)</code
+	      > means the same as <code
+	      >(f <code
+		><a href="#" title="HideRuntimeReps"
+		  >$</a
+		  ></code
+		> x)</code
+	      >. However, <code
+	      ><a href="#" title="HideRuntimeReps"
+		>$</a
+		></code
+	      > has
+ low, right-associative binding precedence, so it sometimes allows
+ parentheses to be omitted; for example:</p
+	    ><pre
+	    >f $ g $ h x  =  f (g (h x))</pre
+	    ><p
+	    >It is also useful in higher-order situations, such as <code
+	      ><code
+		><a href="#" title="GHC.List"
+		  >map</a
+		  ></code
+		> (<code
+		><a href="#" title="HideRuntimeReps"
+		  >$</a
+		  ></code
+		> 0) xs</code
+	      >,
+ or <code
+	      ><code
+		><a href="#" title="Data.List"
+		  >zipWith</a
+		  ></code
+		> (<code
+		><a href="#" title="HideRuntimeReps"
+		  >$</a
+		  ></code
+		>) fs xs</code
+	      >.</p
+	    ><p
+	    >Note that <code
+	      >($)</code
+	      > is levity-polymorphic in its result type, so that
+     foo $ True    where  foo :: Bool -&gt; Int#
+ is well-typed</p
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:error" class="def"
+	    >error</a
+	    > :: <a href="#" title="GHC.Stack"
+	    >HasCallStack</a
+	    > =&gt; [<a href="#" title="Data.Char"
+	    >Char</a
+	    >] -&gt; a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    ><code
+	      ><a href="#" title="HideRuntimeReps"
+		>error</a
+		></code
+	      > stops execution and displays an error message.</p
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/ref/PrintRuntimeReps.html
+++ b/html-test/ref/PrintRuntimeReps.html
@@ -1,0 +1,176 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><title
+    >PrintRuntimeReps</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Ocean"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ><p class="caption empty"
+      ></p
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>PrintRuntimeReps</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><a href="#"
+	      >($)</a
+	      > :: <span class="keyword"
+	      >forall</span
+	      > (r :: <a href="#" title="GHC.Exts"
+	      >RuntimeRep</a
+	      >) a (b :: <a href="#" title="GHC.Exts"
+	      >TYPE</a
+	      > r). (a -&gt; b) -&gt; a -&gt; b</li
+	    ><li class="src short"
+	    ><a href="#"
+	      >error</a
+	      > :: <span class="keyword"
+	      >forall</span
+	      > (r :: <a href="#" title="GHC.Exts"
+	      >RuntimeRep</a
+	      >) (a :: <a href="#" title="GHC.Exts"
+	      >TYPE</a
+	      > r). <a href="#" title="GHC.Stack"
+	      >HasCallStack</a
+	      > =&gt; [<a href="#" title="Data.Char"
+	      >Char</a
+	      >] -&gt; a</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><a id="v:-36-" class="def"
+	    >($)</a
+	    > :: <span class="keyword"
+	    >forall</span
+	    > (r :: <a href="#" title="GHC.Exts"
+	    >RuntimeRep</a
+	    >) a (b :: <a href="#" title="GHC.Exts"
+	    >TYPE</a
+	    > r). (a -&gt; b) -&gt; a -&gt; b <span class="fixity"
+	    >infixr 0</span
+	    ><span class="rightedge"
+	    ></span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >Application operator.  This operator is redundant, since ordinary
+ application <code
+	      >(f x)</code
+	      > means the same as <code
+	      >(f <code
+		><a href="#" title="PrintRuntimeReps"
+		  >$</a
+		  ></code
+		> x)</code
+	      >. However, <code
+	      ><a href="#" title="PrintRuntimeReps"
+		>$</a
+		></code
+	      > has
+ low, right-associative binding precedence, so it sometimes allows
+ parentheses to be omitted; for example:</p
+	    ><pre
+	    >f $ g $ h x  =  f (g (h x))</pre
+	    ><p
+	    >It is also useful in higher-order situations, such as <code
+	      ><code
+		><a href="#" title="GHC.List"
+		  >map</a
+		  ></code
+		> (<code
+		><a href="#" title="PrintRuntimeReps"
+		  >$</a
+		  ></code
+		> 0) xs</code
+	      >,
+ or <code
+	      ><code
+		><a href="#" title="Data.List"
+		  >zipWith</a
+		  ></code
+		> (<code
+		><a href="#" title="PrintRuntimeReps"
+		  >$</a
+		  ></code
+		>) fs xs</code
+	      >.</p
+	    ><p
+	    >Note that <code
+	      >($)</code
+	      > is levity-polymorphic in its result type, so that
+     foo $ True    where  foo :: Bool -&gt; Int#
+ is well-typed</p
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:error" class="def"
+	    >error</a
+	    > :: <span class="keyword"
+	    >forall</span
+	    > (r :: <a href="#" title="GHC.Exts"
+	    >RuntimeRep</a
+	    >) (a :: <a href="#" title="GHC.Exts"
+	    >TYPE</a
+	    > r). <a href="#" title="GHC.Stack"
+	    >HasCallStack</a
+	    > =&gt; [<a href="#" title="Data.Char"
+	    >Char</a
+	    >] -&gt; a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    ><code
+	      ><a href="#" title="PrintRuntimeReps"
+		>error</a
+		></code
+	      > stops execution and displays an error message.</p
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/HideRuntimeReps.hs
+++ b/html-test/src/HideRuntimeReps.hs
@@ -1,0 +1,2 @@
+module HideRuntimeReps (($), error) where
+-- Type variables of kind 'RuntimeRep' are hidden by default.

--- a/html-test/src/PrintRuntimeReps.hs
+++ b/html-test/src/PrintRuntimeReps.hs
@@ -1,2 +1,2 @@
-{-# OPTIONS_HADDOCK print-runtime-reps #-}
+{-# OPTIONS_HADDOCK print-explicit-runtime-reps #-}
 module PrintRuntimeReps (($), error) where

--- a/html-test/src/PrintRuntimeReps.hs
+++ b/html-test/src/PrintRuntimeReps.hs
@@ -1,0 +1,2 @@
+{-# OPTIONS_HADDOCK print-runtime-reps #-}
+module PrintRuntimeReps (($), error) where


### PR DESCRIPTION
This adds a module level Haddock option called `print-runtime-reps` which behaves like the GHC `-fprint-explicit-runtime-reps` flag. Hopefully this will let us restore beginner-friendliness to the `Prelude` types, without having to compromise for simplified types in `GHC.Prim`.

See the discussion in https://github.com/haskell/haddock/issues/838 for more.