### PR TITLE
Hard-code some exports with built-in syntax

### DIFF
--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -21,12 +21,14 @@ import Control.Arrow
 import Haddock.Types( DocNameI )
 
 import Exception
+import FastString ( fsLit )
 import FV
 import Outputable
 import Name
 import NameSet
 import Lexeme
 import Module
+import PrelNames ( mkBaseModule )
 import HscTypes
 import GHC
 import Class
@@ -164,6 +166,9 @@ nubByName f ns = go emptyNameSet ns
                             in x : go s' xs
       where
         y = f x
+
+dATA_LIST :: Module
+dATA_LIST = mkBaseModule (fsLit "Data.List")
 
 -- ---------------------------------------------------------------------
 

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -204,7 +204,9 @@ createInterface mod_iface flags modMap instIfaceMap = do
     --   * "GHC.Prim" should export @(->)@
     --   * "GHC.Types" should export @[]([], (:))@ and @(~)@
     --   * "Prelude" should export @(->)@ and @[]([], (:))@
-    --   * "Data.Tuple" should export tuples up to arity 15
+    --   * "Data.Tuple" should export tuples up to arity 15 (that is the number
+    --     that Haskell98 guarantees exist and that it also the point at which
+    --     GHC stops providing instances)
     --
     listAvail = [ AvailTC listTyConName
                           [listTyConName, nilDataConName, consDataConName]

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -86,6 +86,7 @@ createInterface mod_iface flags modMap instIfaceMap = do
         | mdl == gHC_PRIM   = funAvail
         | mdl == pRELUDE    = listAvail <> funAvail
         | mdl == dATA_TUPLE = tupsAvail
+        | mdl == dATA_LIST  = listAvail
         | otherwise         = []
       !exportedNames = concatMap availNamesWithSelectors
                                  (special_exports <> mi_exports mod_iface)
@@ -143,6 +144,7 @@ createInterface mod_iface flags modMap instIfaceMap = do
         | mdl == pRELUDE    = let (hs, rest) = splitAt 2 mods
                               in hs <> [ DsiExports (listAvail <> funAvail) ] <> rest
         | mdl == dATA_TUPLE = mods <> [ DsiExports tupsAvail ]
+        | mdl == dATA_LIST  = [ DsiExports listAvail ] <> mods
         | otherwise = mods
 
   -- The MAIN functionality: compute the export items which will

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -13,8 +13,6 @@
 module Haddock.Interface.Rename (renameInterface) where
 
 
-import Data.Traversable (mapM)
-
 import Haddock.GhcUtils
 import Haddock.Types
 
@@ -22,11 +20,12 @@ import Bag (emptyBag)
 import GHC hiding (NoLink)
 import Name
 import Outputable ( panic )
-import RdrName (RdrName(Exact))
-import TysWiredIn (eqTyCon_RDR)
+import RdrName    ( RdrName(Exact) )
+import TysPrim    ( eqPrimTyCon )
+import TysWiredIn ( eqTyCon_RDR )
 
 import Control.Applicative
-import Control.Monad hiding (mapM)
+import Control.Monad
 import Data.List
 import qualified Data.Map as Map hiding ( Map )
 import Prelude hiding (mapM)
@@ -72,7 +71,8 @@ renameInterface dflags renamingEnv warnings iface =
                 | n <- missingNames
                 , not (isSystemName n)
                 , not (isBuiltInSyntax n)
-                , Exact n /= eqTyCon_RDR
+                , Exact n /= eqTyCon_RDR   -- (~)
+                , n /= getName eqPrimTyCon -- (~#)
                 ]
 
   in do


### PR DESCRIPTION
This means that `[]`, `(~)`, `(->)` will show up in generated documentation.
This is a gross patch to work around the fact that Haskell lacks the
concrete syntax to put these things in export lists. As far as gross
patches go, it is pretty short.

  * Docs for `GHC.Prim` now include `(->)` (morally it should, since its interface does)
  * Docs for `GHC.Types` now include `[]([], (:))` and `(~)` (as per the comments in its export list)
  * Docs for `Prelude` now include `(->)` and `[]([], (:))` (at the top of the "Basic data types" section)
  * Docs for `Data.Tuple` now include boxed tuples of arity 0 to 15 (I'm capping at 15 since that's what the report gives)
  * Docs for `Data.List` now include `[]([], (:))`

Fixes #368.