### PR TITLE
Clean up logic for guessing `-B` and `--lib`

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -43,7 +43,7 @@ library
 
   -- this package typically supports only single major versions
   build-depends: base            ^>= 4.12.0
-               , Cabal           ^>= 2.4.0
+               , Cabal           >= 2.4.0 && < 2.6.0
                , ghc             ^>= 8.7
                , ghc-paths       ^>= 0.1.0.9
                , haddock-library ^>= 1.8.0
@@ -167,7 +167,7 @@ test-suite spec
     Haddock.Backends.Hyperlinker.Parser
     Haddock.Backends.Hyperlinker.Types
 
-  build-depends: Cabal           ^>= 2.4
+  build-depends: Cabal           >= 2.4.0 && < 2.6.0
                , ghc             ^>= 8.7
                , ghc-paths       ^>= 0.1.0.9
                , haddock-library ^>= 1.8.0

--- a/haddock-api/test/Haddock/Backends/Hyperlinker/ParserSpec.hs
+++ b/haddock-api/test/Haddock/Backends/Hyperlinker/ParserSpec.hs
@@ -20,7 +20,7 @@ import Haddock.Backends.Hyperlinker.Types
 withDynFlags :: ((DynFlags, CompilerInfo) -> IO ()) -> IO ()
 withDynFlags cont = do
   libDir <- fmap snd (getGhcDirs [])
-  runGhc (Just libDir) $ do
+  runGhc libDir $ do
     dflags <- getSessionDynFlags
     cinfo <- liftIO $ getCompilerInfo' dflags
     liftIO $ cont (dflags, cinfo)

--- a/haddock-test/src/Test/Haddock.hs
+++ b/haddock-test/src/Test/Haddock.hs
@@ -42,6 +42,7 @@ checkFiles :: Config c -> Bool -> IO ()
 checkFiles cfg@(Config { .. }) somethingCrashed = do
     putStrLn "Testing output files..."
 
+    createDirectoryIfMissing True (cfgOutDir cfg)
     files <- ignore <$> getDirectoryTree (cfgOutDir cfg)
     failed <- liftM catMaybes . forM files $ \file -> do
         putStr $ "Checking \"" ++ file ++ "\"... "

--- a/haddock-test/src/Test/Haddock/Config.hs
+++ b/haddock-test/src/Test/Haddock/Config.hs
@@ -186,11 +186,9 @@ loadConfig ccfg dcfg flags files = do
           exitFailure
 
     -- Find GHC executable
-    systemGhcPath <- List.lookup "GHC_PATH" <$> getEnvironment
     ghcHaddock <- init <$> rawSystemStdout normal cfgHaddockPath ["--print-ghc-path"]
 
     let ghc_path = msum [ flagsGhcPath flags
-                        , systemGhcPath
                         , mfilter (/= "not available") (Just ghcHaddock)
                         ]
     ghcPath <- case ghc_path of


### PR DESCRIPTION
Haddock built with the `in-ghc-tree` flag tries harder to find the GHC lib folder and its own resources. This should make it possible to use `in-ghc-tree`-built Haddock without having to
specify the `-B` and `--lib` options.