### PR TITLE
Use the Ghc monad to emit warnings

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -81,7 +81,7 @@ logHaddockWarnings dflags msgs =
 
 haddockWarningToGhcWarning :: DynFlags -> ErrMsg -> WarnMsg
 haddockWarningToGhcWarning dflags (L loc doc) =
-  makeIntoWarning (Reason Opt_NoReason) $
+  makeIntoWarning NoReason $
   mkWarnMsg dflags loc alwaysQualify $ O.text doc
 
 -- | Create 'Interface's and a link environment by typechecking the list of

--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -126,10 +126,11 @@ attachToExportItem index expInfo getInstDoc getFixity export =
                         ]
               -- fam_insts but with failing type fams filtered out
             cleanFamInsts = [ (fi, n, L l r, m) | (Right fi, n, L l (Right r), m) <- fam_insts ]
-            famInstErrs = [ errm | (Left errm, _, _, _) <- fam_insts ]
+            famInstErrs = concat [ errm | (Left errm, _, _, _) <- fam_insts ]
         in do
           dfs <- getDynFlags
-          let mkBug = (text "haddock-bug:" <+>) . text
+          let mkBug (L loc msg) =
+                mkLocMessage SevInfo loc $ text "haddock-bug:" <+> text msg
           liftIO $ putMsg dfs (sep $ map mkBug famInstErrs)
           return $ cls_insts ++ cleanFamInsts
       return $ e { expItemInstances = insts }

--- a/haddock-api/src/Haddock/Interface/LexParseRn.hs
+++ b/haddock-api/src/Haddock/Interface/LexParseRn.hs
@@ -164,8 +164,8 @@ outOfScope dflags x =
     Exact name -> warnAndMonospace name  -- Shouldn't happen since x is out of scope
   where
     warnAndMonospace a = do
-      tell $ fmap (rdrNameErrMsg x)
-        ["Warning: '" ++ showPpr dflags a ++ "' is out of scope.\n" ++
+      tell $ fmap dislocatedErrMsg
+        ["'" ++ showPpr dflags a ++ "' is out of scope.\n" ++
          "    If you qualify the identifier, haddock can try to link it anyway."]
       pure (monospaced a)
     monospaced a = DocMonospaced (DocString (showPpr dflags a))
@@ -182,7 +182,7 @@ ambiguous :: DynFlags
 ambiguous dflags x gres = do
   let noChildren = map availName (gresToAvailInfo gres)
       dflt = maximumBy (comparing (isLocalName &&& isTyConName)) noChildren
-      msg = "Warning: " ++ x_str ++ " is ambiguous. It is defined\n" ++
+      msg = x_str ++ " is ambiguous. It is defined\n" ++
             concatMap (\n -> "    * " ++ defnLoc n ++ "\n") (map gre_name gres) ++
             "    You may be able to disambiguate the identifier by qualifying it or\n" ++
             "    by hiding some imports.\n" ++

--- a/haddock-api/src/Haddock/Interface/LexParseRn.hs
+++ b/haddock-api/src/Haddock/Interface/LexParseRn.hs
@@ -164,8 +164,9 @@ outOfScope dflags x =
     Exact name -> warnAndMonospace name  -- Shouldn't happen since x is out of scope
   where
     warnAndMonospace a = do
-      tell ["Warning: '" ++ showPpr dflags a ++ "' is out of scope.\n" ++
-            "    If you qualify the identifier, haddock can try to link it anyway."]
+      tell $ fmap (rdrNameErrMsg x)
+        ["Warning: '" ++ showPpr dflags a ++ "' is out of scope.\n" ++
+         "    If you qualify the identifier, haddock can try to link it anyway."]
       pure (monospaced a)
     monospaced a = DocMonospaced (DocString (showPpr dflags a))
 
@@ -191,7 +192,7 @@ ambiguous dflags x gres = do
   -- of the same name, but not the only constructor.
   -- For example, for @data D = C | D@, someone may want to reference the @D@
   -- constructor.
-  when (length noChildren > 1) $ tell [msg]
+  when (length noChildren > 1) $ tell $ [rdrNameErrMsg x msg]
   pure (DocIdentifier dflt)
   where
     isLocalName (nameSrcLoc -> RealSrcLoc {}) = True

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -68,23 +68,20 @@ renameInterface dflags renamingEnv warnings iface =
       -- Note that since the renamed AST represents equality constraints as
       -- @HasOpTy t1 eqTyCon_RDR t2@ (and _not_ as @HsEqTy t1 t2@), we need to
       -- manually filter out 'eqTyCon_RDR' (aka @~@).
-      msgs = [ (n, pretty dflags n)
-             | n <- missingNames
-             , not (isSystemName n)
-             , not (isBuiltInSyntax n)
-             , Exact n /= eqTyCon_RDR
-             ]
-
-      warnMsg (name, msg) =
-        L (nameSrcSpan name) $
-        "Warning: " ++ moduleString (ifaceMod iface) ++
-        ": could not find link destinations for: " ++ msg
+      strings = [ pretty dflags n
+                | n <- missingNames
+                , not (isSystemName n)
+                , not (isBuiltInSyntax n)
+                , Exact n /= eqTyCon_RDR
+                ]
 
   in do
     -- report things that we couldn't link to. Only do this for non-hidden
     -- modules.
-    unless (OptHide `elem` ifaceOptions iface || null msgs || not warnings) $
-      tell $ fmap warnMsg msgs
+    unless (OptHide `elem` ifaceOptions iface || null strings || not warnings) $
+      tell [L (ifaceSrcSpan iface) $
+            "Could not find link destinations for:\n"++
+            unwords ("   " : strings) ]
 
     return $ iface { ifaceRnDoc         = finalModuleDoc,
                      ifaceRnDocMap      = rnDocMap,

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -145,6 +145,9 @@ data Interface = Interface
     -- | Tokenized source code of module (avaliable if Haddock is invoked with
     -- source generation flag).
   , ifaceTokenizedSrc :: !(Maybe [RichToken])
+
+    -- | the 'SrcSpan' for the module, so we can report it to the user
+  , ifaceSrcSpan :: !SrcSpan
   }
 
 type WarningMap = Map Name (Doc Name)

--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -40,6 +40,7 @@ import GHC hiding (NoLink)
 import DynFlags (Language)
 import qualified GHC.LanguageExtensions as LangExt
 import OccName
+import RdrName (RdrName(..))
 import Outputable
 import Control.Applicative (Applicative(..))
 import Control.Monad (ap)
@@ -593,7 +594,21 @@ data SinceQual
 -- A monad which collects error messages, locally defined to avoid a dep on mtl
 
 
-type ErrMsg = String
+type ErrMsg = Located String
+
+-- | Create an error message referring to the given instance of 'NamedThing'.
+namedThingErrMsg :: NamedThing t => t -> String -> ErrMsg
+namedThingErrMsg thing = L (nameSrcSpan $ getName thing)
+
+dislocatedErrMsg :: String -> ErrMsg
+dislocatedErrMsg = noLoc
+
+rdrNameErrMsg :: RdrName -> String -> ErrMsg
+rdrNameErrMsg (Exact nm) = L (nameSrcSpan nm)
+rdrNameErrMsg (Qual _ _) = noLoc
+rdrNameErrMsg (Orig _ _) = noLoc
+rdrNameErrMsg (Unqual _) = noLoc
+
 newtype ErrMsgM a = Writer { runWriter :: (a, [ErrMsg]) }
 
 
@@ -741,4 +756,3 @@ type instance XHsWC      DocNameI _ = NoExt
 
 type instance XHsQTvs        DocNameI = NoExt
 type instance XConDeclField  DocNameI = NoExt
-


### PR DESCRIPTION
Previously Haddock warnings were emitted directly to `stdout` via
`putStrLn`.  This commit changes the output to go via the `Ghc` monad
as a new type of Haddock warning.  To take advantage of using `Ghc` in
this way, source locations are now tracked and emitted as part of most
warning messages.

This is an attempt to address #927.

The corresponding GHC commits are [here](https://github.com/peddie/ghc/commit/a80ea5d11da07d20207f1137b5f11113fd3dba9c) and [here](https://github.com/peddie/ghc/commit/d4d7adaa17a4b8123e93731d376003d54cda6d00).