### PR TITLE
Output better debug infromation on internal error in extractDecl

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -1112,7 +1112,9 @@ extractDecl declMap name decl
             in case matches of
               [d0] -> extractDecl declMap name (noLoc . InstD noExt $ DataFamInstD noExt d0)
               _ -> error "internal: extractDecl (ClsInstD)"
-      _ -> error "internal: extractDecl"
+      _ -> O.pprPanic "extractDecl" $
+        O.text "Unhandled decl for" O.<+> O.ppr name O.<> O.text ":"
+        O.$$ O.nest 4 (O.ppr decl)
 
 
 extractPatternSyn :: Name -> Name -> [LHsType GhcRn] -> [LConDecl GhcRn] -> LSig GhcRn


### PR DESCRIPTION
This will make investigation of #979 easier, following the same idea as https://github.com/haskell/haddock/commit/c03dad1c5d4ab7c44234d145ba9c13f17a918201

haddock used to print

```
haddock: internal error: internal: extractDecl
CallStack (from HasCallStack):
  error, called at src/Haddock/Interface/Create.hs:1116:12 in haddock-api-2.22.0-inplace:Haddock.Interface.Create
```

for the repro in #979 and now prints

```
haddock: panic! (the 'impossible' happened)
  (GHC version 8.7.20181213 for x86_64-unknown-linux):
        extractDecl

Unhandled decl for TI:
    data family T a :: Type
Call stack:
    CallStack (from HasCallStack):
      callStackDoc, called at compiler/utils/Outputable.hs:1159:37 in ghc:Outputable
      pprPanic, called at utils/haddock/haddock-api/src/Haddock/Interface/Create.hs:1116:12 in main:Haddock.Interface.Create
```