### PR TITLE
Refactor: better name handling, cleanup unused functions

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -1049,8 +1049,8 @@ ppr_mono_ty (HsAppTy _ fun_ty arg_ty) unicode
 ppr_mono_ty (HsOpTy _ ty1 op ty2) unicode
   = ppr_mono_lty ty1 unicode <+> ppr_op <+> ppr_mono_lty ty2 unicode
   where
-    ppr_op = if not (isSymOcc occName) then char '`' <> ppLDocName op <> char '`' else ppLDocName op
-    occName = nameOccName . getName . unLoc $ op
+    ppr_op | isSymOcc (getOccName op) = ppLDocName op
+           | otherwise = char '`' <> ppLDocName op <> char '`'
 
 ppr_mono_ty (HsParTy _ ty) unicode
   = parens (ppr_mono_lty ty unicode)
@@ -1079,16 +1079,13 @@ ppr_tylit (HsStrTy _ s) _ = text (show s)
 
 ppBinder :: OccName -> LaTeX
 ppBinder n
-  | isInfixName n = parens $ ppOccName n
-  | otherwise     = ppOccName n
+  | isSymOcc n = parens $ ppOccName n
+  | otherwise  = ppOccName n
 
 ppBinderInfix :: OccName -> LaTeX
 ppBinderInfix n
-  | isInfixName n = ppOccName n
-  | otherwise     = cat [ char '`', ppOccName n, char '`' ]
-
-isInfixName :: OccName -> Bool
-isInfixName n = isVarSym n || isConSym n
+  | isSymOcc n = ppOccName n
+  | otherwise  = cat [ char '`', ppOccName n, char '`' ]
 
 ppSymName :: Name -> LaTeX
 ppSymName name

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -39,7 +39,7 @@ import Haddock.GhcUtils
 import Control.Monad         ( when, unless )
 import qualified Data.ByteString.Builder as Builder
 import Data.Char             ( toUpper, isSpace )
-import Data.List             ( sortBy, isPrefixOf, intercalate, intersperse )
+import Data.List             ( sortBy, isPrefixOf, intersperse )
 import Data.Maybe
 import System.Directory
 import System.FilePath hiding ( (</>) )
@@ -388,7 +388,7 @@ ppJsonIndex odir maybe_source_url maybe_wiki_url unicode pkg qual_opt ifaces = d
       | Just item_html <- processExport True links_info unicode pkg qual item
       = [ Object
             [ "display_html" .= String (showHtmlFragment item_html)
-            , "name"         .= String (intercalate " " (map nameString names))
+            , "name"         .= String (unwords (map getOccString names))
             , "module"       .= String (moduleString mdl)
             , "link"         .= String (fromMaybe "" (listToMaybe (map (nameLink mdl) names)))
             ]
@@ -405,9 +405,6 @@ ppJsonIndex odir maybe_source_url maybe_wiki_url unicode pkg qual_opt ifaces = d
     exportName ExportDecl { expItemDecl } = getMainDeclBinder (unLoc expItemDecl)
     exportName ExportNoDecl { expItemName } = [expItemName]
     exportName _ = []
-
-    nameString :: NamedThing name => name -> String
-    nameString = occNameString . nameOccName . getName
 
     nameLink :: NamedThing name => Module -> name -> String
     nameLink mdl = moduleNameUrl' (moduleName mdl) . nameOccName . getName

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -696,7 +696,7 @@ instanceId origin no orphan ihd = concat $
     [ "o:" | orphan ] ++
     [ qual origin
     , ":" ++ getOccString origin
-    , ":" ++ (occNameString . getOccName . ihdClsName) ihd
+    , ":" ++ getOccString (ihdClsName ihd)
     , ":" ++ show no
     ]
   where

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -25,7 +25,6 @@ import Exception
 import Outputable
 import Name
 import NameSet
-import Lexeme
 import Module
 import HscTypes
 import GHC
@@ -38,14 +37,6 @@ moduleString = moduleNameString . moduleName
 
 isNameSym :: Name -> Bool
 isNameSym = isSymOcc . nameOccName
-
-
-isVarSym :: OccName -> Bool
-isVarSym = isLexVarSym . occNameFS
-
-isConSym :: OccName -> Bool
-isConSym = isLexConSym . occNameFS
-
 
 getMainDeclBinder :: (SrcSpanLess (LPat p) ~ Pat p , HasSrcSpan (LPat p)) =>
                      HsDecl p -> [IdP p]
@@ -140,12 +131,6 @@ isClassD _ = False
 isValD :: HsDecl a -> Bool
 isValD (ValD _ _) = True
 isValD _ = False
-
-
-declATs :: HsDecl a -> [IdP a]
-declATs (TyClD _ d) | isClassDecl d = map (unL . fdLName . unL) $ tcdATs d
-declATs _ = []
-
 
 pretty :: Outputable a => DynFlags -> a -> String
 pretty = showPpr

--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, MagicHash, BangPatterns #-}
+{-# LANGUAGE MagicHash, BangPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
 -----------------------------------------------------------------------------
 -- |
@@ -32,7 +32,6 @@ import DynFlags
 import CoreSyn (isOrphan)
 import ErrUtils
 import FamInstEnv
-import FastString
 import GHC
 import InstEnv
 import Module ( ModuleSet, moduleSetElts )
@@ -40,13 +39,11 @@ import MonadUtils (liftIO)
 import Name
 import NameEnv
 import Outputable (text, sep, (<+>))
-import PrelNames
 import SrcLoc
 import TyCon
 import TyCoRep
-import TysPrim( funTyCon )
+import TysPrim( funTyConName )
 import Var hiding (varName)
-#define FSLIT(x) (mkFastString# (x#))
 
 type ExportedNames = Set.Set Name
 type Modules = Set.Set Module
@@ -223,13 +220,6 @@ instFam :: FamInst -> ([Int], Name, [SimpleType], Int, SimpleType)
 instFam FamInst { fi_fam = n, fi_tys = ts, fi_rhs = t }
   = (map argCount ts, n, map simplify ts, argCount t, simplify t)
 
-
-funTyConName :: Name
-funTyConName = mkWiredInName gHC_PRIM
-                        (mkOccNameFS tcName FSLIT("(->)"))
-                        funTyConKey
-                        (ATyCon funTyCon)       -- Relevant TyCon
-                        BuiltInSyntax
 
 --------------------------------------------------------------------------------
 -- Filtering hidden instances

--- a/haddock-api/src/Haddock/Parser.hs
+++ b/haddock-api/src/Haddock/Parser.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE StandaloneDeriving
-             , FlexibleInstances, UndecidableInstances
-             , IncoherentInstances #-}
-{-# LANGUAGE LambdaCase #-}
 -- |
 -- Module      :  Haddock.Parser
 -- Copyright   :  (c) Mateusz Kowalczyk 2013,
@@ -19,14 +14,15 @@ module Haddock.Parser ( parseParas
                       ) where
 
 import qualified Documentation.Haddock.Parser as P
-import DynFlags (DynFlags)
-import FastString (mkFastString)
 import Documentation.Haddock.Types
-import Lexer (mkPState, unP, ParseResult(POk))
-import Parser (parseIdentifier)
-import RdrName (RdrName)
-import SrcLoc (mkRealSrcLoc, unLoc)
-import StringBuffer (stringToStringBuffer)
+
+import DynFlags     ( DynFlags )
+import FastString   ( fsLit )
+import Lexer        ( mkPState, unP, ParseResult(POk) )
+import Parser       ( parseIdentifier )
+import RdrName      ( RdrName )
+import SrcLoc       ( mkRealSrcLoc, unLoc )
+import StringBuffer ( stringToStringBuffer )
 
 parseParas :: DynFlags -> Maybe Package -> String -> MetaDoc mod RdrName
 parseParas d p = overDoc (P.overIdentifier (parseIdent d)) . P.parseParas p
@@ -37,7 +33,7 @@ parseString d = P.overIdentifier (parseIdent d) . P.parseString
 parseIdent :: DynFlags -> String -> Maybe RdrName
 parseIdent dflags str0 =
   let buffer = stringToStringBuffer str0
-      realSrcLc = mkRealSrcLoc (mkFastString "<unknown file>") 0 0
+      realSrcLc = mkRealSrcLoc (fsLit "<unknown file>") 0 0
       pstate = mkPState dflags buffer realSrcLc
   in case unP parseIdentifier pstate of
     POk _ name -> Just (unLoc name)


### PR DESCRIPTION
This commit should not introduce any change in functionality!

  * consistently use `getOccString` to convert `Name`s to strings
  * compare names directly when possible (instead of comparing strings)
  * get rid of unused utility functions