### PR TITLE
Load plugins when compiling each module

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -76,7 +76,6 @@ import Packages
 import Panic (handleGhcException)
 import Module
 import FastString
-import qualified DynamicLoading
 
 --------------------------------------------------------------------------------
 -- * Exception handling
@@ -450,10 +449,7 @@ withGhc' libDir flags ghcActs = runGhc (Just libDir) $ do
   -- that may need to be re-linked: Haddock doesn't do any
   -- dynamic or static linking at all!
   _ <- setSessionDynFlags dynflags''
-  hscenv <- GHC.getSession
-  dynflags''' <- liftIO (DynamicLoading.initializePlugins hscenv dynflags'')
-  _ <- setSessionDynFlags dynflags'''
-  ghcActs dynflags'''
+  ghcActs dynflags''
   where
 
     -- ignore sublists of flags that start with "+RTS" and end in "-RTS"


### PR DESCRIPTION
The previous approach in 72d82e52f2a6225686d9668790ac33c1d1743193 was not working as reported in #900.

Fixes #900.

NB: this does _not_ fix the situation for local plugins (which have not historically worked either)