### PR TITLE
Remove `haddock-test`'s dep. on `syb`

### DIFF
--- a/haddock-test/haddock-test.cabal
+++ b/haddock-test/haddock-test.cabal
@@ -16,7 +16,7 @@ library
   default-language: Haskell2010
   ghc-options: -Wall
   hs-source-dirs:   src
-  build-depends:    base >= 4.3 && < 4.13, bytestring, directory, process, filepath, Cabal, xml, xhtml, syb
+  build-depends:    base >= 4.3 && < 4.13, bytestring, directory, process, filepath, Cabal, xml, xhtml
 
   exposed-modules:
     Test.Haddock


### PR DESCRIPTION
The functionality is easily inlined into one short function: `gmapEverywhere`.
This doesn't warrant pulling in another package dependency.