### PR TITLE
Make a fixture of weird parsing of lists

### DIFF
--- a/haddock-library/fixtures/examples/list-blocks1.input
+++ b/haddock-library/fixtures/examples/list-blocks1.input
@@ -1,0 +1,15 @@
+* Something about foo
+
+    @
+    foo :: a -> b -> c
+    foo a b = bar c b
+    @
+
+* Something about bar
+
+    @
+    bar :: a -> b -> c
+    bar a b = foo b a
+    @
+
+* And then we continue

--- a/haddock-library/fixtures/examples/list-blocks1.parsed
+++ b/haddock-library/fixtures/examples/list-blocks1.parsed
@@ -1,0 +1,12 @@
+DocUnorderedList
+  [DocAppend
+     (DocParagraph (DocString "Something about foo"))
+     (DocCodeBlock
+        (DocString
+           (concat ["foo :: a -> b -> c\n", "foo a b = bar c b\n"]))),
+   DocAppend
+     (DocParagraph (DocString "Something about bar"))
+     (DocCodeBlock
+        (DocString
+           (concat ["bar :: a -> b -> c\n", "bar a b = foo b a\n"]))),
+   DocParagraph (DocString "And then we continue")]

--- a/haddock-library/fixtures/examples/list-blocks2.input
+++ b/haddock-library/fixtures/examples/list-blocks2.input
@@ -1,0 +1,10 @@
+=== Title
+
+* List directly
+* after the title
+
+    @
+    with some inline things
+    @
+
+* is parsed weirdly

--- a/haddock-library/fixtures/examples/list-blocks2.parsed
+++ b/haddock-library/fixtures/examples/list-blocks2.parsed
@@ -1,0 +1,10 @@
+DocAppend
+  (DocAppend
+     (DocHeader
+        Header {headerLevel = 3, headerTitle = DocString "Title"})
+     (DocUnorderedList
+        [DocParagraph (DocString "List directly"),
+         DocAppend
+           (DocParagraph (DocString "after the title"))
+           (DocCodeBlock (DocString "with some inline things\n"))]))
+  (DocUnorderedList [DocParagraph (DocString "is parsed weirdly")])

--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -91,7 +91,6 @@ test-suite fixtures
   main-is:          Fixtures.hs
   ghc-options:      -Wall -O0
   hs-source-dirs:   fixtures
-  buildable:        False
   build-depends:
       base         >= 4.5     && < 4.13
     , base-compat  >= 0.9.3   && < 0.11


### PR DESCRIPTION
Add list blocks fixtures  …
The second example is interesting.
If there's a list directly after the header, and that list has
deeper structure, the parser is confused: It finds two lists:
- One with the first nested element,
- everything after it

I'm not trying to fix this, as I'm not even sure this is a bug,
and not a feature.