### PR TITLE
Keep forall on H98 existential data constructors

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -758,9 +758,9 @@ ppSideBySideConstr subdocs unicode leader (L _ con) =
     decl = case con of
       ConDeclH98{ con_args = det
                 , con_ex_tvs = tyVars
+                , con_forall = L _ forall_
                 , con_mb_cxt = cxt
                 } -> let context = unLoc (fromMaybe (noLoc []) cxt)
-                         forall_ = False
                          header_ = ppConstrHdr forall_ tyVars context unicode
                      in case det of
         -- Prefix constructor, e.g. 'Just a'

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -800,9 +800,9 @@ ppShortConstrParts summary dataInst con unicode qual
   = case con of
       ConDeclH98{ con_args = det
                 , con_ex_tvs = tyVars
+                , con_forall = L _ forall_
                 , con_mb_cxt = cxt
                 } -> let context = unLoc (fromMaybe (noLoc []) cxt)
-                         forall_ = False
                          header_ = ppConstrHdr forall_ tyVars context unicode qual
                      in case det of
 
@@ -873,9 +873,9 @@ ppSideBySideConstr subdocs fixities unicode pkg qual (L _ con)
     decl = case con of
       ConDeclH98{ con_args = det
                 , con_ex_tvs = tyVars
+                , con_forall = L _ forall_
                 , con_mb_cxt = cxt
                 } -> let context = unLoc (fromMaybe (noLoc []) cxt)
-                         forall_ = False
                          header_ = ppConstrHdr forall_ tyVars context unicode qual
                      in case det of
         -- Prefix constructor, e.g. 'Just a'

--- a/html-test/ref/PatternSyns.html
+++ b/html-test/ref/PatternSyns.html
@@ -104,7 +104,9 @@
 	      >data</span
 	      > <a href="#"
 	      >BlubType</a
-	      > = <a href="#" title="Text.Show"
+	      > = <span class="keyword"
+	      >forall</span
+	      > x.<a href="#" title="Text.Show"
 	      >Show</a
 	      > x =&gt;  <a href="#"
 	      >BlubCtor</a
@@ -274,7 +276,9 @@
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="#" title="Text.Show"
+		><span class="keyword"
+		  >forall</span
+		  > x.<a href="#" title="Text.Show"
 		  >Show</a
 		  > x =&gt;  <a id="v:BlubCtor" class="def"
 		  >BlubCtor</a

--- a/html-test/ref/Test.html
+++ b/html-test/ref/Test.html
@@ -579,17 +579,23 @@
 	      >Ex</a
 	      > a<ul class="subs"
 	      ><li
-		>= <a href="#" title="Test"
+		>= <span class="keyword"
+		  >forall</span
+		  > b.<a href="#" title="Test"
 		  >C</a
 		  > b =&gt;  <a href="#"
 		  >Ex1</a
 		  > b</li
 		><li
-		>| <a href="#"
+		>| <span class="keyword"
+		  >forall</span
+		  > b. <a href="#"
 		  >Ex2</a
 		  > b</li
 		><li
-		>| <a href="#" title="Test"
+		>| <span class="keyword"
+		  >forall</span
+		  > b.<a href="#" title="Test"
 		  >C</a
 		  > a =&gt;  <a href="#"
 		  >Ex3</a
@@ -2069,7 +2075,9 @@ is at the beginning of the line).</pre
 	    ><table
 	    ><tr
 	      ><td class="src"
-		><a href="#" title="Test"
+		><span class="keyword"
+		  >forall</span
+		  > b.<a href="#" title="Test"
 		  >C</a
 		  > b =&gt;  <a id="v:Ex1" class="def"
 		  >Ex1</a
@@ -2079,7 +2087,9 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a id="v:Ex2" class="def"
+		><span class="keyword"
+		  >forall</span
+		  > b. <a id="v:Ex2" class="def"
 		  >Ex2</a
 		  > b</td
 		><td class="doc empty"
@@ -2087,7 +2097,9 @@ is at the beginning of the line).</pre
 		></tr
 	      ><tr
 	      ><td class="src"
-		><a href="#" title="Test"
+		><span class="keyword"
+		  >forall</span
+		  > b.<a href="#" title="Test"
 		  >C</a
 		  > a =&gt;  <a id="v:Ex3" class="def"
 		  >Ex3</a


### PR DESCRIPTION
The information about whether or not there is a source-level `forall`
is already available on a `ConDecl` (as `con_forall`), so we should use
it instead of always assuming `False`!

Fixes #1002.