### PR TITLE
Fix #1004 with a pinch of dropForAlls

### DIFF
--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -274,7 +274,7 @@ synifyTyCon coax tc
 -- which this function obtains.
 synifyDataTyConReturnKind :: TyCon -> Maybe (LHsKind GhcRn)
 synifyDataTyConReturnKind tc
-  = case splitFunTys (tyConKind tc) of
+  = case splitFunTys (dropForAlls (tyConKind tc)) of
       (_, ret_kind)
         | isLiftedTypeKind ret_kind -> Nothing -- Don't bother displaying :: *
         | otherwise                 -> Just (synifyKindSig ret_kind)

--- a/html-test/ref/Bug1004.html
+++ b/html-test/ref/Bug1004.html
@@ -1,0 +1,2072 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
+     /><title
+    >Bug1004</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Linuwial"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script type="text/x-mathjax-config"
+    >MathJax.Hub.Config({ tex2jax: { processClass: &quot;mathjax&quot;, ignoreClass: &quot;.*&quot; } });</script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><span class="caption empty"
+      ></span
+      ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug1004</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><span class="keyword"
+	      >data</span
+	      > <a href="#"
+	      >Product</a
+	      > (f :: k -&gt; <a href="#" title="Data.Kind"
+	      >Type</a
+	      >) (g :: k -&gt; <a href="#" title="Data.Kind"
+	      >Type</a
+	      >) (a :: k) = <a href="#"
+	      >Pair</a
+	      > (f a) (g a)</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Product" class="def"
+	    >Product</a
+	    > (f :: k -&gt; <a href="#" title="Data.Kind"
+	    >Type</a
+	    >) (g :: k -&gt; <a href="#" title="Data.Kind"
+	    >Type</a
+	    >) (a :: k) <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >Lifted product of functors.</p
+	    ></div
+	  ><div class="subs constructors"
+	  ><p class="caption"
+	    >Constructors</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a id="v:Pair" class="def"
+		  >Pair</a
+		  > (f a) (g a)</td
+		><td class="doc empty"
+		></td
+		></tr
+	      ></table
+	    ></div
+	  ><div class="subs instances"
+	  ><h4 class="instances details-toggle-control details-toggle" data-details-id="i:Product"
+	    >Instances</h4
+	    ><details id="i:Product" open="open"
+	    ><summary class="hide-when-js-enabled"
+	      >Instances details</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Generic1:1"
+		      ></span
+		      > <a href="#" title="GHC.Generics"
+		      >Generic1</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g :: k -&gt; <a href="#" title="Data.Kind"
+		      >Type</a
+		      >)</span
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Generic1:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href="#" title="GHC.Generics"
+			  >Rep1</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g) :: k -&gt; <a href="#" title="Data.Kind"
+			  >Type</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >from1</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="GHC.Generics"
+			  >Rep1</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g) a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >to1</a
+			  > :: <a href="#" title="GHC.Generics"
+			  >Rep1</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g) a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Monad:2"
+		      ></span
+		      > (<a href="#" title="Control.Monad"
+		      >Monad</a
+		      > f, <a href="#" title="Control.Monad"
+		      >Monad</a
+		      > g) =&gt; <a href="#" title="Control.Monad"
+		      >Monad</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Monad:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >(&gt;&gt;=)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; (a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&gt;&gt;)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >return</a
+			  > :: a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >fail</a
+			  > :: <a href="#" title="Data.String"
+			  >String</a
+			  > -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Functor:3"
+		      ></span
+		      > (<a href="#" title="Data.Functor"
+		      >Functor</a
+		      > f, <a href="#" title="Data.Functor"
+		      >Functor</a
+		      > g) =&gt; <a href="#" title="Data.Functor"
+		      >Functor</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Functor:3"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >fmap</a
+			  > :: (a -&gt; b) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;$)</a
+			  > :: a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:MonadFix:4"
+		      ></span
+		      > (<a href="#" title="Control.Monad.Fix"
+		      >MonadFix</a
+		      > f, <a href="#" title="Control.Monad.Fix"
+		      >MonadFix</a
+		      > g) =&gt; <a href="#" title="Control.Monad.Fix"
+		      >MonadFix</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:MonadFix:4"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >mfix</a
+			  > :: (a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Applicative:5"
+		      ></span
+		      > (<a href="#" title="Control.Applicative"
+		      >Applicative</a
+		      > f, <a href="#" title="Control.Applicative"
+		      >Applicative</a
+		      > g) =&gt; <a href="#" title="Control.Applicative"
+		      >Applicative</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Applicative:5"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >pure</a
+			  > :: a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;*&gt;)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g (a -&gt; b) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >liftA2</a
+			  > :: (a -&gt; b -&gt; c) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g c <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(*&gt;)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;*)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Foldable:6"
+		      ></span
+		      > (<a href="#" title="Data.Foldable"
+		      >Foldable</a
+		      > f, <a href="#" title="Data.Foldable"
+		      >Foldable</a
+		      > g) =&gt; <a href="#" title="Data.Foldable"
+		      >Foldable</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Foldable:6"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >fold</a
+			  > :: <a href="#" title="Data.Monoid"
+			  >Monoid</a
+			  > m =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g m -&gt; m <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldMap</a
+			  > :: <a href="#" title="Data.Monoid"
+			  >Monoid</a
+			  > m =&gt; (a -&gt; m) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; m <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldr</a
+			  > :: (a -&gt; b -&gt; b) -&gt; b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldr'</a
+			  > :: (a -&gt; b -&gt; b) -&gt; b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldl</a
+			  > :: (b -&gt; a -&gt; b) -&gt; b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldl'</a
+			  > :: (b -&gt; a -&gt; b) -&gt; b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; b <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldr1</a
+			  > :: (a -&gt; a -&gt; a) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >foldl1</a
+			  > :: (a -&gt; a -&gt; a) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >toList</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; [a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >null</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >length</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Int"
+			  >Int</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >elem</a
+			  > :: <a href="#" title="Data.Eq"
+			  >Eq</a
+			  > a =&gt; a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >maximum</a
+			  > :: <a href="#" title="Data.Ord"
+			  >Ord</a
+			  > a =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >minimum</a
+			  > :: <a href="#" title="Data.Ord"
+			  >Ord</a
+			  > a =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >sum</a
+			  > :: <a href="#" title="Prelude"
+			  >Num</a
+			  > a =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >product</a
+			  > :: <a href="#" title="Prelude"
+			  >Num</a
+			  > a =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Traversable:7"
+		      ></span
+		      > (<a href="#" title="Data.Traversable"
+		      >Traversable</a
+		      > f, <a href="#" title="Data.Traversable"
+		      >Traversable</a
+		      > g) =&gt; <a href="#" title="Data.Traversable"
+		      >Traversable</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Traversable:7"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >traverse</a
+			  > :: <a href="#" title="Control.Applicative"
+			  >Applicative</a
+			  > f0 =&gt; (a -&gt; f0 b) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; f0 (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >sequenceA</a
+			  > :: <a href="#" title="Control.Applicative"
+			  >Applicative</a
+			  > f0 =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g (f0 a) -&gt; f0 (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >mapM</a
+			  > :: <a href="#" title="Control.Monad"
+			  >Monad</a
+			  > m =&gt; (a -&gt; m b) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; m (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >sequence</a
+			  > :: <a href="#" title="Control.Monad"
+			  >Monad</a
+			  > m =&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g (m a) -&gt; m (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Eq1:8"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Eq1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Eq1</a
+		      > g) =&gt; <a href="#" title="Data.Functor.Classes"
+		      >Eq1</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Eq1:8"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >liftEq</a
+			  > :: (a -&gt; b -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  >) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Ord1:9"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Ord1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Ord1</a
+		      > g) =&gt; <a href="#" title="Data.Functor.Classes"
+		      >Ord1</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Ord1:9"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >liftCompare</a
+			  > :: (a -&gt; b -&gt; <a href="#" title="Data.Ord"
+			  >Ordering</a
+			  >) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Data.Ord"
+			  >Ordering</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Read1:10"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Read1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Read1</a
+		      > g) =&gt; <a href="#" title="Data.Functor.Classes"
+		      >Read1</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Read1:10"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >liftReadsPrec</a
+			  > :: (<a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > a) -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > [a] -&gt; <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >liftReadList</a
+			  > :: (<a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > a) -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > [a] -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > [<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >liftReadPrec</a
+			  > :: <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > a -&gt; <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > [a] -&gt; <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >liftReadListPrec</a
+			  > :: <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > a -&gt; <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > [a] -&gt; <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > [<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Show1:11"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Show1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Show1</a
+		      > g) =&gt; <a href="#" title="Data.Functor.Classes"
+		      >Show1</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Show1:11"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >liftShowsPrec</a
+			  > :: (<a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; a -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  >) -&gt; ([a] -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  >) -&gt; <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >liftShowList</a
+			  > :: (<a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; a -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  >) -&gt; ([a] -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  >) -&gt; [<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a] -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:MonadZip:12"
+		      ></span
+		      > (<a href="#" title="Control.Monad.Zip"
+		      >MonadZip</a
+		      > f, <a href="#" title="Control.Monad.Zip"
+		      >MonadZip</a
+		      > g) =&gt; <a href="#" title="Control.Monad.Zip"
+		      >MonadZip</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:MonadZip:12"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >mzip</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g (a, b) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >mzipWith</a
+			  > :: (a -&gt; b -&gt; c) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g c <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >munzip</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g (a, b) -&gt; (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a, <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g b) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Alternative:13"
+		      ></span
+		      > (<a href="#" title="Control.Applicative"
+		      >Alternative</a
+		      > f, <a href="#" title="Control.Applicative"
+		      >Alternative</a
+		      > g) =&gt; <a href="#" title="Control.Applicative"
+		      >Alternative</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Alternative:13"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >empty</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;|&gt;)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >some</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g [a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >many</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g [a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:MonadPlus:14"
+		      ></span
+		      > (<a href="#" title="Control.Monad"
+		      >MonadPlus</a
+		      > f, <a href="#" title="Control.Monad"
+		      >MonadPlus</a
+		      > g) =&gt; <a href="#" title="Control.Monad"
+		      >MonadPlus</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:MonadPlus:14"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >mzero</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >mplus</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Eq:15"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Eq1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Eq1</a
+		      > g, <a href="#" title="Data.Eq"
+		      >Eq</a
+		      > a) =&gt; <a href="#" title="Data.Eq"
+		      >Eq</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Eq:15"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >(==)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(/=)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Data:16"
+		      ></span
+		      > (<a href="#" title="Type.Reflection"
+		      >Typeable</a
+		      > a, <a href="#" title="Type.Reflection"
+		      >Typeable</a
+		      > f, <a href="#" title="Type.Reflection"
+		      >Typeable</a
+		      > g, <a href="#" title="Type.Reflection"
+		      >Typeable</a
+		      > k, <a href="#" title="Data.Data"
+		      >Data</a
+		      > (f a), <a href="#" title="Data.Data"
+		      >Data</a
+		      > (g a)) =&gt; <a href="#" title="Data.Data"
+		      >Data</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Data:16"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >gfoldl</a
+			  > :: (<span class="keyword"
+			  >forall</span
+			  > d b. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; c (d -&gt; b) -&gt; d -&gt; c b) -&gt; (<span class="keyword"
+			  >forall</span
+			  > g0. g0 -&gt; c g0) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; c (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gunfold</a
+			  > :: (<span class="keyword"
+			  >forall</span
+			  > b r. <a href="#" title="Data.Data"
+			  >Data</a
+			  > b =&gt; c (b -&gt; r) -&gt; c r) -&gt; (<span class="keyword"
+			  >forall</span
+			  > r. r -&gt; c r) -&gt; <a href="#" title="Data.Data"
+			  >Constr</a
+			  > -&gt; c (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >toConstr</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Data"
+			  >Constr</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >dataTypeOf</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Data"
+			  >DataType</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >dataCast1</a
+			  > :: <a href="#" title="Type.Reflection"
+			  >Typeable</a
+			  > t =&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; c (t d)) -&gt; <a href="#" title="GHC.Maybe"
+			  >Maybe</a
+			  > (c (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a)) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >dataCast2</a
+			  > :: <a href="#" title="Type.Reflection"
+			  >Typeable</a
+			  > t =&gt; (<span class="keyword"
+			  >forall</span
+			  > d e. (<a href="#" title="Data.Data"
+			  >Data</a
+			  > d, <a href="#" title="Data.Data"
+			  >Data</a
+			  > e) =&gt; c (t d e)) -&gt; <a href="#" title="GHC.Maybe"
+			  >Maybe</a
+			  > (c (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a)) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapT</a
+			  > :: (<span class="keyword"
+			  >forall</span
+			  > b. <a href="#" title="Data.Data"
+			  >Data</a
+			  > b =&gt; b -&gt; b) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapQl</a
+			  > :: (r -&gt; r' -&gt; r) -&gt; r -&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; r') -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; r <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapQr</a
+			  > :: (r' -&gt; r -&gt; r) -&gt; r -&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; r') -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; r <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapQ</a
+			  > :: (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; u) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; [u] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapQi</a
+			  > :: <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; u) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; u <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapM</a
+			  > :: <a href="#" title="Control.Monad"
+			  >Monad</a
+			  > m =&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; m d) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; m (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapMp</a
+			  > :: <a href="#" title="Control.Monad"
+			  >MonadPlus</a
+			  > m =&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; m d) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; m (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >gmapMo</a
+			  > :: <a href="#" title="Control.Monad"
+			  >MonadPlus</a
+			  > m =&gt; (<span class="keyword"
+			  >forall</span
+			  > d. <a href="#" title="Data.Data"
+			  >Data</a
+			  > d =&gt; d -&gt; m d) -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; m (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Ord:17"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Ord1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Ord1</a
+		      > g, <a href="#" title="Data.Ord"
+		      >Ord</a
+		      > a) =&gt; <a href="#" title="Data.Ord"
+		      >Ord</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Ord:17"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >compare</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Ord"
+			  >Ordering</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&lt;=)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&gt;)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >(&gt;=)</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.Bool"
+			  >Bool</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >max</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >min</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Read:18"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Read1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Read1</a
+		      > g, <a href="#" title="Text.Read"
+		      >Read</a
+		      > a) =&gt; <a href="#" title="Text.Read"
+		      >Read</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Read:18"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >readsPrec</a
+			  > :: <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >readList</a
+			  > :: <a href="#" title="Text.ParserCombinators.ReadP"
+			  >ReadS</a
+			  > [<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >readPrec</a
+			  > :: <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >readListPrec</a
+			  > :: <a href="#" title="Text.ParserCombinators.ReadPrec"
+			  >ReadPrec</a
+			  > [<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a] <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Show:19"
+		      ></span
+		      > (<a href="#" title="Data.Functor.Classes"
+		      >Show1</a
+		      > f, <a href="#" title="Data.Functor.Classes"
+		      >Show1</a
+		      > g, <a href="#" title="Text.Show"
+		      >Show</a
+		      > a) =&gt; <a href="#" title="Text.Show"
+		      >Show</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Show:19"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >showsPrec</a
+			  > :: <a href="#" title="Data.Int"
+			  >Int</a
+			  > -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >show</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="Data.String"
+			  >String</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >showList</a
+			  > :: [<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a] -&gt; <a href="#" title="Text.Show"
+			  >ShowS</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Generic:20"
+		      ></span
+		      > <a href="#" title="GHC.Generics"
+		      >Generic</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Generic:20"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href="#" title="GHC.Generics"
+			  >Rep</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) :: <a href="#" title="Data.Kind"
+			  >Type</a
+			  > -&gt; <a href="#" title="Data.Kind"
+			  >Type</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >from</a
+			  > :: <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a -&gt; <a href="#" title="GHC.Generics"
+			  >Rep</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) x <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >to</a
+			  > :: <a href="#" title="GHC.Generics"
+			  >Rep</a
+			  > (<a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a) x -&gt; <a href="#" title="Bug1004"
+			  >Product</a
+			  > f g a <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Rep1:21"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="GHC.Generics"
+		      >Rep1</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g :: k -&gt; <a href="#" title="Data.Kind"
+		      >Type</a
+		      >)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Rep1:21"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="GHC.Generics"
+			>Rep1</a
+			> (<a href="#" title="Bug1004"
+			>Product</a
+			> f g :: k -&gt; <a href="#" title="Data.Kind"
+			>Type</a
+			>) = <a href="#" title="GHC.Generics"
+			>D1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaData</a
+			> &quot;Product&quot; &quot;Data.Functor.Product&quot; &quot;base&quot; <a href="#" title="Data.Bool"
+			>False</a
+			>) (<a href="#" title="GHC.Generics"
+			>C1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaCons</a
+			> &quot;Pair&quot; <a href="#" title="GHC.Generics"
+			>PrefixI</a
+			> <a href="#" title="Data.Bool"
+			>False</a
+			>) (<a href="#" title="GHC.Generics"
+			>S1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaSel</a
+			> (<a href="#" title="GHC.Maybe"
+			>Nothing</a
+			> :: <a href="#" title="GHC.Maybe"
+			>Maybe</a
+			> <a href="#" title="GHC.TypeLits"
+			>Symbol</a
+			>) <a href="#" title="GHC.Generics"
+			>NoSourceUnpackedness</a
+			> <a href="#" title="GHC.Generics"
+			>NoSourceStrictness</a
+			> <a href="#" title="GHC.Generics"
+			>DecidedLazy</a
+			>) (<a href="#" title="GHC.Generics"
+			>Rec1</a
+			> f) <a href="#" title="GHC.Generics"
+			>:*:</a
+			> <a href="#" title="GHC.Generics"
+			>S1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaSel</a
+			> (<a href="#" title="GHC.Maybe"
+			>Nothing</a
+			> :: <a href="#" title="GHC.Maybe"
+			>Maybe</a
+			> <a href="#" title="GHC.TypeLits"
+			>Symbol</a
+			>) <a href="#" title="GHC.Generics"
+			>NoSourceUnpackedness</a
+			> <a href="#" title="GHC.Generics"
+			>NoSourceStrictness</a
+			> <a href="#" title="GHC.Generics"
+			>DecidedLazy</a
+			>) (<a href="#" title="GHC.Generics"
+			>Rec1</a
+			> g)))</div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Product:Rep:22"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="GHC.Generics"
+		      >Rep</a
+		      > (<a href="#" title="Bug1004"
+		      >Product</a
+		      > f g a)</span
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    ><em
+		      >Since: base-4.9.0.0</em
+		      ></p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Product:Rep:22"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Data.Functor.Product</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="GHC.Generics"
+			>Rep</a
+			> (<a href="#" title="Bug1004"
+			>Product</a
+			> f g a) = <a href="#" title="GHC.Generics"
+			>D1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaData</a
+			> &quot;Product&quot; &quot;Data.Functor.Product&quot; &quot;base&quot; <a href="#" title="Data.Bool"
+			>False</a
+			>) (<a href="#" title="GHC.Generics"
+			>C1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaCons</a
+			> &quot;Pair&quot; <a href="#" title="GHC.Generics"
+			>PrefixI</a
+			> <a href="#" title="Data.Bool"
+			>False</a
+			>) (<a href="#" title="GHC.Generics"
+			>S1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaSel</a
+			> (<a href="#" title="GHC.Maybe"
+			>Nothing</a
+			> :: <a href="#" title="GHC.Maybe"
+			>Maybe</a
+			> <a href="#" title="GHC.TypeLits"
+			>Symbol</a
+			>) <a href="#" title="GHC.Generics"
+			>NoSourceUnpackedness</a
+			> <a href="#" title="GHC.Generics"
+			>NoSourceStrictness</a
+			> <a href="#" title="GHC.Generics"
+			>DecidedLazy</a
+			>) (<a href="#" title="GHC.Generics"
+			>Rec0</a
+			> (f a)) <a href="#" title="GHC.Generics"
+			>:*:</a
+			> <a href="#" title="GHC.Generics"
+			>S1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaSel</a
+			> (<a href="#" title="GHC.Maybe"
+			>Nothing</a
+			> :: <a href="#" title="GHC.Maybe"
+			>Maybe</a
+			> <a href="#" title="GHC.TypeLits"
+			>Symbol</a
+			>) <a href="#" title="GHC.Generics"
+			>NoSourceUnpackedness</a
+			> <a href="#" title="GHC.Generics"
+			>NoSourceStrictness</a
+			> <a href="#" title="GHC.Generics"
+			>DecidedLazy</a
+			>) (<a href="#" title="GHC.Generics"
+			>Rec0</a
+			> (g a))))</div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug1004.hs
+++ b/html-test/src/Bug1004.hs
@@ -1,0 +1,3 @@
+module Bug1004 (Product(..)) where
+
+import Data.Functor.Product


### PR DESCRIPTION
#1004 occurred because `splitFunTys` wouldn't work on a data type return kind that was headed by a `forall`, so let's drop those `forall`s before attempting to split it.