### PR TITLE
Loosen 'QuickCheck' and 'hspec' bounds

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -173,8 +173,8 @@ test-suite spec
                , ghc-paths       ^>= 0.1.0.9
                , haddock-library ^>= 1.7.0
                , xhtml           ^>= 3000.2.2
-               , hspec           >= 2.4.4 && < 2.6
-               , QuickCheck      ^>= 2.11
+               , hspec           >= 2.4.4 && < 2.7
+               , QuickCheck      >= 2.11  && < 2.13
 
   -- Versions for the dependencies below are transitively pinned by
   -- the non-reinstallable `ghc` package and hence need no version
@@ -190,7 +190,7 @@ test-suite spec
                , transformers
 
   build-tool-depends:
-    hspec-discover:hspec-discover >= 2.4.4 && < 2.6
+    hspec-discover:hspec-discover >= 2.4.4 && < 2.7
 
 source-repository head
   type:     git

--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -76,8 +76,8 @@ test-suite spec
     , bytestring   >= 0.9.2.1 && < 0.11
     , containers   >= 0.4.2.1 && < 0.7
     , transformers   >= 0.3.0   && < 0.6
-    , hspec        >= 2.4.4   && < 2.6
-    , QuickCheck    ^>= 2.11
+    , hspec        >= 2.4.4    && < 2.7
+    , QuickCheck   >= 2.11     && < 2.13
     , text         >= 1.2.3.0  && < 1.3
     , parsec       >= 3.1.13.0 && < 3.2
     , deepseq      >= 1.3     && < 1.5


### PR DESCRIPTION
It looks like the new versions don't cause any breakage
and loosening the bounds helps deps fit in one stack resolver.

Fixes #1008.