### PR TITLE
Update README instructions for Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ cabal test
 
 ```bash
 stack init
-stack install
+stack build
 # run the test suite
-export HADDOCK_PATH="$HOME/.local/bin/haddock"
+export HADDOCK_PATH="$(stack exec which haddock)"
 stack test
 ```
 


### PR DESCRIPTION
No need to `stack install` Haddock to test it. Indeed, `stack install` changes the `haddock` on user's `PATH` if `~/.local/bin` is on user's `PATH` which may not be desirable when hacking on Haddock.