### PR TITLE
Fix #1015 with dataConUserTyVars

### DIFF
--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -353,7 +353,8 @@ synifyDataCon use_gadt_syntax dc =
   use_named_field_syntax = not (null field_tys)
   name = synifyName dc
   -- con_qvars means a different thing depending on gadt-syntax
-  (univ_tvs, ex_tvs, _eq_spec, theta, arg_tys, res_ty) = dataConFullSig dc
+  (_univ_tvs, ex_tvs, _eq_spec, theta, arg_tys, res_ty) = dataConFullSig dc
+  user_tvs = dataConUserTyVars dc -- Used for GADT data constructors
 
   -- skip any EqTheta, use 'orig'inal syntax
   ctx | null theta = Nothing
@@ -385,8 +386,8 @@ synifyDataCon use_gadt_syntax dc =
            then return $ noLoc $
               ConDeclGADT { con_g_ext  = noExt
                           , con_names  = [name]
-                          , con_forall = noLoc False
-                          , con_qvars  = synifyTyVars (univ_tvs ++ ex_tvs)
+                          , con_forall = noLoc $ not $ null user_tvs
+                          , con_qvars  = synifyTyVars user_tvs
                           , con_mb_cxt = ctx
                           , con_args   = hat
                           , con_res_ty = synifyType WithinType [] res_ty


### PR DESCRIPTION
(This is a second attempt at #1016, but targeted against `ghc-head` this time.)

The central trick in this patch is to use `dataConUserTyVars` instead of `univ_tvs ++ ex_tvs`, which displays the `forall`s in a GADT constructor in a way that's more faithful to how the user originally wrote it. With these changes, the example from #1015 now renders as:

![haddock](https://user-images.githubusercontent.com/2364661/52166242-c320aa00-26d8-11e9-9d83-80683a883ba0.png)

Along the way, I simplified some code that tried to calculate where a data constructor should use GADT syntax in an _ad hoc_ fashion. Luckily, this information is cached as `isGadtSyntaxTyCon`, so I just used that instead.

Thankfully, there's already a test case in `html-test` that stress-tests this code path, so I didn't need to add the test case from #1015 (since it relies on code from `base` which might change in the future).