### PR TITLE
Fix standalone deriving docs

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -132,8 +132,8 @@ createInterface tm flags modMap instIfaceMap = do
       fixMap = mkFixMap group_
       (decls, _) = unzip declsWithDocs
       localInsts = filter (nameIsLocalOrFrom sem_mdl)
-                        $  map getName instances
-                        ++ map getName fam_instances
+                        $  map getName fam_instances
+                        ++ map getName instances
       -- Locations of all TH splices
       splices = [ l | L l (SpliceD _ _) <- hsmodDecls hsm ]
 

--- a/html-test/ref/Bug1033.html
+++ b/html-test/ref/Bug1033.html
@@ -1,0 +1,222 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
+     /><title
+    >Bug1033</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Linuwial"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script type="text/x-mathjax-config"
+    >MathJax.Hub.Config({ tex2jax: { processClass: &quot;mathjax&quot;, ignoreClass: &quot;.*&quot; } });</script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><span class="caption empty"
+      ></span
+      ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug1033</p
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >data</span
+	    > <a id="t:Foo" class="def"
+	    >Foo</a
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs constructors"
+	  ><p class="caption"
+	    >Constructors</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a id="v:Foo" class="def"
+		  >Foo</a
+		  ></td
+		><td class="doc empty"
+		></td
+		></tr
+	      ></table
+	    ></div
+	  ><div class="subs instances"
+	  ><h4 class="instances details-toggle-control details-toggle" data-details-id="i:Foo"
+	    >Instances</h4
+	    ><details id="i:Foo" open="open"
+	    ><summary class="hide-when-js-enabled"
+	      >Instances details</summary
+	      ><table
+	      ><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Foo:Generic:1"
+		      ></span
+		      > <a href="#" title="GHC.Generics"
+		      >Generic</a
+		      > <a href="#" title="Bug1033"
+		      >Foo</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc"
+		  ><p
+		    >This does some generic foos.</p
+		    ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Foo:Generic:1"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Bug1033</a
+			></p
+		      > <div class="subs associated-types"
+		      ><p class="caption"
+			>Associated Types</p
+			><p class="src"
+			><span class="keyword"
+			  >type</span
+			  > <a href="#" title="GHC.Generics"
+			  >Rep</a
+			  > <a href="#" title="Bug1033"
+			  >Foo</a
+			  > :: <a href="#" title="Data.Kind"
+			  >Type</a
+			  > -&gt; <a href="#" title="Data.Kind"
+			  >Type</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      > <div class="subs methods"
+		      ><p class="caption"
+			>Methods</p
+			><p class="src"
+			><a href="#"
+			  >from</a
+			  > :: <a href="#" title="Bug1033"
+			  >Foo</a
+			  > -&gt; <a href="#" title="GHC.Generics"
+			  >Rep</a
+			  > <a href="#" title="Bug1033"
+			  >Foo</a
+			  > x <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			><p class="src"
+			><a href="#"
+			  >to</a
+			  > :: <a href="#" title="GHC.Generics"
+			  >Rep</a
+			  > <a href="#" title="Bug1033"
+			  >Foo</a
+			  > x -&gt; <a href="#" title="Bug1033"
+			  >Foo</a
+			  > <a href="#" class="selflink"
+			  >#</a
+			  ></p
+			></div
+		      ></details
+		    ></td
+		  ></tr
+		><tr
+		><td class="src clearfix"
+		  ><span class="inst-left"
+		    ><span class="instance details-toggle-control details-toggle" data-details-id="i:id:Foo:Rep:2"
+		      ></span
+		      > <span class="keyword"
+		      >type</span
+		      > <a href="#" title="GHC.Generics"
+		      >Rep</a
+		      > <a href="#" title="Bug1033"
+		      >Foo</a
+		      ></span
+		    > <a href="#" class="selflink"
+		    >#</a
+		    ></td
+		  ><td class="doc empty"
+		  ></td
+		  ></tr
+		><tr
+		><td colspan="2"
+		  ><details id="i:id:Foo:Rep:2"
+		    ><summary class="hide-when-js-enabled"
+		      >Instance details</summary
+		      ><p
+		      >Defined in <a href="#"
+			>Bug1033</a
+			></p
+		      > <div class="src"
+		      ><span class="keyword"
+			>type</span
+			> <a href="#" title="GHC.Generics"
+			>Rep</a
+			> <a href="#" title="Bug1033"
+			>Foo</a
+			> = <a href="#" title="GHC.Generics"
+			>D1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaData</a
+			> &quot;Foo&quot; &quot;Bug1033&quot; &quot;main&quot; <a href="#" title="Data.Bool"
+			>False</a
+			>) (<a href="#" title="GHC.Generics"
+			>C1</a
+			> (<a href="#" title="GHC.Generics"
+			>MetaCons</a
+			> &quot;Foo&quot; <a href="#" title="GHC.Generics"
+			>PrefixI</a
+			> <a href="#" title="Data.Bool"
+			>False</a
+			>) (<a href="#" title="GHC.Generics"
+			>U1</a
+			> :: <a href="#" title="Data.Kind"
+			>Type</a
+			> -&gt; <a href="#" title="Data.Kind"
+			>Type</a
+			>))</div
+		      ></details
+		    ></td
+		  ></tr
+		></table
+	      ></details
+	    ></div
+	  ></div
+	></div
+      ></div
+    ><div id="footer"
+    ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug1033.hs
+++ b/html-test/src/Bug1033.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Bug1033 where
+
+import GHC.Generics
+
+data Foo = Foo
+
+-- | This does some generic foos.
+deriving instance Generic Foo


### PR DESCRIPTION
Docs on standalone deriving decls for classes with associated types
should be associated with the class instance, not the associated type
instance.

Fixes #1033