### PR TITLE
increase contrast of linuwal theme

### DIFF
--- a/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
+++ b/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
@@ -11,7 +11,7 @@ html {
 
 body {
   background: #fefefe;
-  color: #333;
+  color: #111;
   text-align: left;
   min-height: 100vh;
   position: relative;

--- a/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
+++ b/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
@@ -11,7 +11,7 @@ html {
 
 body {
   background: #fefefe;
-  color: #333;
+  color: #111;
   text-align: left;
   min-height: 100vh;
   position: relative;
@@ -388,7 +388,7 @@ summary {
 pre {
   padding: 0.5rem 1rem;
   margin: 1em 0 0 0;
-  background-color: #f7f7f7;
+  background-color: #eee;
   overflow: auto;
 }
 
@@ -408,7 +408,7 @@ blockquote {
 }
 
 .src {
-  background: #f4f4f4;
+  background: #eee;
   padding: 0.2em 0.5em;
 }
 
@@ -533,7 +533,7 @@ div#style-menu-holder {
 }
 
 #contents-list {
-  background:  #f7f7f7;
+  background:  #eee;
   padding: 1em;
   margin: 0;
 }

--- a/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
+++ b/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
@@ -11,7 +11,7 @@ html {
 
 body {
   background: #fefefe;
-  color: #111;
+  color: #333;
   text-align: left;
   min-height: 100vh;
   position: relative;
@@ -234,7 +234,7 @@ Display the package name on top of the menu links and center both elements:
  */
 
  body, button {
-   font: 400 15px/1.4 'PT Sans',
+   font: 400 14px/1.4 'PT Sans',
      /* Fallback Font Stack */
      -apple-system,
 	  BlinkMacSystemFont,
@@ -388,8 +388,10 @@ summary {
 pre {
   padding: 0.5rem 1rem;
   margin: 1em 0 0 0;
-  background-color: #eee;
+  background-color: #f7f7f7;
   overflow: auto;
+  border: 1px solid #ddd;
+  border-radius: 0.3em;
 }
 
 pre + p {
@@ -408,7 +410,7 @@ blockquote {
 }
 
 .src {
-  background: #eee;
+  background: #f2f2f2;
   padding: 0.2em 0.5em;
 }
 
@@ -533,7 +535,7 @@ div#style-menu-holder {
 }
 
 #contents-list {
-  background:  #eee;
+  background: #f4f4f4;
   padding: 1em;
   margin: 0;
 }


### PR DESCRIPTION
Simplest possible patch to improve the contrast as requested in https://github.com/haskell/haddock/issues/1032

There might be better solutions, but I think this is modest, straightforward, and should help. If someone wants to propose something else or further tweaks before the cutoff I'm open, but wanted to have at least this in the pipeline.