### PR TITLE
Match changes for "Stop inferring over-polymorphic kinds"

### DIFF
--- a/haddock-api/src/Haddock/Convert.hs
+++ b/haddock-api/src/Haddock/Convert.hs
@@ -187,9 +187,7 @@ synifyTyCon prr _coax tc
   | isFunTyCon tc || isPrimTyCon tc
   = return $
     DataDecl { tcdLName = synifyName tc
-             , tcdTyVars = HsQTvs { hsq_ext =
-                                       HsQTvsRn { hsq_implicit = []   -- No kind polymorphism
-                                                , hsq_dependent = emptyNameSet }
+             , tcdTyVars = HsQTvs  { hsq_ext = []   -- No kind polymorphism
                                    , hsq_explicit = zipWith mk_hs_tv
                                                             tyVarKinds
                                                             alphaTyVars --a, b, c... which are unfortunately all kind *
@@ -436,8 +434,7 @@ synifyCtx = noLoc . map (synifyType WithinType [])
 
 
 synifyTyVars :: [TyVar] -> LHsQTyVars GhcRn
-synifyTyVars ktvs = HsQTvs { hsq_ext = HsQTvsRn { hsq_implicit = []
-                                                , hsq_dependent = emptyNameSet }
+synifyTyVars ktvs = HsQTvs { hsq_ext = []
                            , hsq_explicit = map synifyTyVar ktvs }
 
 synifyTyVar :: TyVar -> LHsTyVarBndr GhcRn

--- a/haddock-api/src/Haddock/Utils.hs
+++ b/haddock-api/src/Haddock/Utils.hs
@@ -217,9 +217,7 @@ emptyHsQTvs :: LHsQTyVars GhcRn
 -- This function is here, rather than in HsTypes, because it *renamed*, but
 -- does not necessarily have all the rigt kind variables.  It is used
 -- in Haddock just for printing, so it doesn't matter
-emptyHsQTvs = HsQTvs { hsq_ext = HsQTvsRn
-                       { hsq_implicit = error "haddock:emptyHsQTvs"
-                       , hsq_dependent = error "haddock:emptyHsQTvs" }
+emptyHsQTvs = HsQTvs { hsq_ext = error "haddock:emptyHsQTvs"
                      , hsq_explicit = [] }
 
 


### PR DESCRIPTION
The `hsq_ext` field of `HsQTvs` is now just the implicit variables
(instead of also including information about which of these variables
are dependent).

This commit shouldn't change any functionality in Haddock.