### PR TITLE
Improve error messages with context information

### DIFF
--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -36,6 +36,7 @@ import qualified Data.Map as Map
 import Documentation.Haddock.Types
 import BasicTypes (Fixity(..))
 
+import Exception (ExceptionMonad(..), ghandle)
 import GHC hiding (NoLink)
 import DynFlags (Language)
 import qualified GHC.LanguageExtensions as LangExt
@@ -620,17 +621,28 @@ tell w = Writer ((), w)
 
 
 -- | Haddock's own exception type.
-data HaddockException = HaddockException String deriving Typeable
+data HaddockException
+  = HaddockException String
+  | WithContext [String] SomeException
+  deriving Typeable
 
 
 instance Show HaddockException where
   show (HaddockException str) = str
-
+  show (WithContext ctxts se)  = unlines $ ["While " ++ ctxt ++ ":\n" | ctxt <- reverse ctxts] ++ [show se]
 
 throwE :: String -> a
 instance Exception HaddockException
 throwE str = throw (HaddockException str)
 
+withExceptionContext :: ExceptionMonad m => String -> m a -> m a
+withExceptionContext ctxt =
+  ghandle (\ex ->
+      case ex of
+        HaddockException e -> throw $ WithContext [ctxt] (toException ex)
+        WithContext ctxts se -> throw $ WithContext (ctxt:ctxts) se
+          ) .
+  ghandle (throw . WithContext [ctxt])
 
 -- In "Haddock.Interface.Create", we need to gather
 -- @Haddock.Types.ErrMsg@s a lot, like @ErrMsgM@ does,
@@ -664,6 +676,12 @@ instance Monad ErrMsgGhc where
 
 instance MonadIO ErrMsgGhc where
   liftIO m = WriterGhc (fmap (\x -> (x, [])) (liftIO m))
+
+instance ExceptionMonad ErrMsgGhc where
+  gcatch act hand = WriterGhc $
+    runWriterGhc act `gcatch` (runWriterGhc . hand)
+  gmask act = WriterGhc $ gmask $ \mask ->
+    runWriterGhc $ act (WriterGhc . mask . runWriterGhc)
 
 -----------------------------------------------------------------------------
 -- * Pass sensitive types


### PR DESCRIPTION
Haddock started failing for a large project of ours.  It's likely caused by a missing type signature or similar, but unfortunately the error message did not contain a module or data type name to help diagnose the issue. 

Error before:
```
 haddock: internal error: extractPatternSyn: constructor pattern not found                                                                                                                                                             
    CallStack (from HasCallStack):                                                                                                                                                                                                        
        error, called at utils/haddock/haddock-api/src/Haddock/Interface/Create.hs:1122:11 in main:Haddock.Interface.Create                                                                                                               
 ```
Error now:
```
haddock: While creating Haddock interface for Strats.Service.Pricing.CM.FuturesOption:

haddock: panic! (the 'impossible' happened)
  (GHC version 8.6.2 for x86_64-unknown-linux):
	extractPatternSyn

constructor pattern  TradeInput not found in type TradeInput
Call stack:
    CallStack (from HasCallStack):
      callStackDoc, called at compiler/utils/Outputable.hs:1160:37 in ghc:Outputable
      pprPanic, called at src/Haddock/Interface/Create.hs:1129:11 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface.Create
      extractPatternSyn, called at src/Haddock/Interface/Create.hs:1087:32 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface.Create
      extractDecl, called at src/Haddock/Interface/Create.hs:818:43 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface.Create
      availExportDecl, called at src/Haddock/Interface/Create.hs:762:24 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface.Create
      availExportItem, called at src/Haddock/Interface/Create.hs:699:7 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface.Create
      mkExportItems, called at src/Haddock/Interface/Create.hs:155:18 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface.Create
      createInterface, called at src/Haddock/Interface.hs:193:42 in haddock-api-2.22.1-EKeb0YKljx1FKocDSu56k7:Haddock.Interface

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```