### PR TITLE
Use new GHC artifact for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - os: linux
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head], sources: [hvr-ghc]}}
       env:
-        - GHC_ZIP='https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/download?job=validate-x86_64-linux-deb8'
+        - GHC_ZIP='https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/download?job=validate-x86_64-linux-deb9-hadrian'
 
 before_install:
  # Manually install GHC validate artifact


### PR DESCRIPTION
Previously validate-x86_64-linux-deb8 was used which no longer exists on
gitlab. Switch to validate-x86_64-linux-deb9-hadrian.