### PR TITLE
Small change in to facilitate extended typed-holes

### DIFF
--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -135,10 +135,10 @@ sigNameNoLoc _                             = []
 
 -- | Was this signature given by the user?
 isUserLSig :: LSig name -> Bool
-isUserLSig (L _(TypeSig {}))    = True
-isUserLSig (L _(ClassOpSig {})) = True
-isUserLSig (L _(PatSynSig {}))  = True
-isUserLSig _                    = False
+isUserLSig (L _ (TypeSig {}))    = True
+isUserLSig (L _ (ClassOpSig {})) = True
+isUserLSig (L _ (PatSynSig {}))  = True
+isUserLSig _                     = False
 
 
 isClassD :: HsDecl a -> Bool


### PR DESCRIPTION
This change has no functional effect on haddock itself, it just changes one pattern to use `_ (` rather than `_(`, so that we may use `_(` as a token for extended typed-holes later (see [!1766 ](https://gitlab.haskell.org/ghc/ghc/merge_requests/1766) on GitLab)