### PR TITLE
Fix hyperlinker crash when there are no SrcSpans in the file due to CPP

### DIFF
--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -432,7 +432,7 @@ render dflags flags sinceQual qual ifaces installedIfaces extSrcMap = do
   when (Flag_HyperlinkedSource `elem` flags && not (null ifaces)) $ do
     withTiming (pure dflags') "ppHyperlinkedSource" (const ()) $ do
       _ <- {-# SCC ppHyperlinkedSource #-}
-           ppHyperlinkedSource odir libDir opt_source_css pretty srcMap ifaces
+           ppHyperlinkedSource (verbosity flags) odir libDir opt_source_css pretty srcMap ifaces
       return ()
 
 

--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Utils.hs
@@ -102,7 +102,7 @@ type PrintedType = String
 -- >       hieAst
 --
 -- However, this is very inefficient (both in time and space) because the
--- mutliple calls to 'recoverFullType' don't share intermediate results. This
+-- multiple calls to 'recoverFullType' don't share intermediate results. This
 -- function fixes that.
 recoverFullIfaceTypes
   :: DynFlags

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -46,6 +46,7 @@ extra-source-files:
   html-test/src/*.hs
   html-test/ref/*.html
   hypsrc-test/src/*.hs
+  hypsrc-test/src/*.h
   hypsrc-test/ref/src/*.html
   latex-test/src/**/*.hs
   latex-test/ref/**/*.tex

--- a/hypsrc-test/ref/src/Bug1091.html
+++ b/hypsrc-test/ref/src/Bug1091.html
@@ -1,0 +1,34 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><link rel="stylesheet" type="text/css" href="style.css"
+     /><script type="text/javascript" src="highlight.js"
+    ></script
+    ></head
+  ><body
+  ><pre
+    ><span class="hs-pragma"
+      >{-# LANGUAGE CPP #-}</span
+      ><span
+      >
+</span
+      ><span id="line-2"
+      ></span
+      ><span class="hs-keyword"
+      >module</span
+      ><span
+      > </span
+      ><span class="hs-identifier"
+      >Bug1091</span
+      ><span
+      > </span
+      ><span class="hs-keyword"
+      >where</span
+      ><span class="hs-cpp"
+      >
+
+#include &quot;Include1For1091.h&quot;
+</span
+      ></pre
+    ></body
+  ></html
+>

--- a/hypsrc-test/src/Bug1091.hs
+++ b/hypsrc-test/src/Bug1091.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE CPP #-}
+module Bug1091 where
+
+#include "Include1For1091.h"

--- a/hypsrc-test/src/Include1For1091.h
+++ b/hypsrc-test/src/Include1For1091.h
@@ -1,0 +1,6 @@
+/* Include1For1091.h */
+
+foo :: Int
+foo = 42
+
+#include "Include2For1091.h"

--- a/hypsrc-test/src/Include2For1091.h
+++ b/hypsrc-test/src/Include2For1091.h
@@ -1,0 +1,4 @@
+/* Include2For1091.h */
+
+bar :: Int
+bar = 27


### PR DESCRIPTION
This eliminates a call to `error` which gets hit in situations when the `.hie` file doesn't contain any `SrcSpan`s from the file we are actually hyperlinking. This can occur when the file is wholly composed of CPP `#include`s.

Fixes #1091 