### PR TITLE
Remove spaces around @-patterns

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
@@ -148,7 +148,7 @@ parse dflags fpath bs = case unP (go False []) initState of
 
 -- | Get the input
 getInput :: P (StringBuffer, RealSrcLoc)
-getInput = P $ \p @ PState { buffer = buf, loc = srcLoc } -> POk p (buf, srcLoc)
+getInput = P $ \p@PState { buffer = buf, loc = srcLoc } -> POk p (buf, srcLoc)
 
 -- | Set the input
 setInput :: (StringBuffer, RealSrcLoc) -> P ()

--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Renderer.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Renderer.hs
@@ -88,14 +88,14 @@ renderWithAst srcs Node{..} toks = anchored $ case toks of
     -- order to make sure these get hyperlinked properly, we intercept these
     -- special sequences of tokens and merge them into just one identifier or
     -- operator token.
-    [BacktickTok s1, tok @ Token{ tkType = TkIdentifier }, BacktickTok s2]
+    [BacktickTok s1, tok@Token{ tkType = TkIdentifier }, BacktickTok s2]
           | realSrcSpanStart s1 == realSrcSpanStart nodeSpan
           , realSrcSpanEnd s2   == realSrcSpanEnd nodeSpan
           -> richToken srcs nodeInfo
                        (Token{ tkValue = "`" <> tkValue tok <> "`"
                              , tkType = TkOperator
                              , tkSpan = nodeSpan })
-    [OpenParenTok s1, tok @ Token{ tkType = TkOperator }, CloseParenTok s2]
+    [OpenParenTok s1, tok@Token{ tkType = TkOperator }, CloseParenTok s2]
           | realSrcSpanStart s1 == realSrcSpanStart nodeSpan
           , realSrcSpanEnd s2   == realSrcSpanEnd nodeSpan
           -> richToken srcs nodeInfo


### PR DESCRIPTION
This is needed to compile `haddock` when [GHC Proposal #229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst) is implemented.