### PR TITLE
Remove the `HasSrcSpan (LPat DocNameI)` instance

### DIFF
--- a/haddock-api/src/Haddock/Types.hs
+++ b/haddock-api/src/Haddock/Types.hs
@@ -748,19 +748,4 @@ type instance XHsQTvs        DocNameI = NoExtField
 type instance XConDeclField  DocNameI = NoExtField
 type instance XXConDeclField DocNameI = NoExtCon
 
-type instance XXPat DocNameI = Located (Pat DocNameI)
-
-type instance SrcSpanLess (LPat DocNameI) = Pat DocNameI
-instance HasSrcSpan (LPat DocNameI) where
-  -- NB: The following chooses the behaviour of the outer location
-  --     wrapper replacing the inner ones.
-  composeSrcSpan (L sp p) =  if sp == noSrcSpan
-                             then p
-                             else XPat (L sp (stripSrcSpanPat p))
-   -- NB: The following only returns the top-level location, if any.
-  decomposeSrcSpan (XPat (L sp p)) = L sp (stripSrcSpanPat p)
-  decomposeSrcSpan p               = L noSrcSpan  p
-
-stripSrcSpanPat :: LPat DocNameI -> Pat DocNameI
-stripSrcSpanPat (XPat (L _ p)) = stripSrcSpanPat p
-stripSrcSpanPat p              = p
+type instance XXPat DocNameI = NoExtCon


### PR DESCRIPTION
It was just unfortunate duplication before. More importantly it is
incompatible with https://gitlab.haskell.org/ghc/ghc/merge_requests/1925
after which we will just have one shared `HasSrcSpan (LPat p)` instance
again.