### PR TITLE
Fix build of haddock in stage1

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -13,6 +13,7 @@ bug-reports:          https://github.com/haskell/haddock/issues
 copyright:            (c) Simon Marlow, David Waern
 category:             Documentation
 build-type:           Simple
+tested-with:          GHC==8.10.*, GHC==8.8.1, GHC==8.6.5
 
 extra-source-files:
   CHANGES.md

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -82,7 +82,7 @@ binaryInterfaceMagic = 0xD0Cface
 -- (2) set `binaryInterfaceVersionCompatibility` to [binaryInterfaceVersion]
 --
 binaryInterfaceVersion :: Word16
-#if (__GLASGOW_HASKELL__ >= 811) && (__GLASGOW_HASKELL__ < 813)
+#if MIN_VERSION_ghc(8,11,0) && !MIN_VERSION_ghc(8,13,0)
 binaryInterfaceVersion = 34
 
 binaryInterfaceVersionCompatibility :: [Word16]

--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -17,6 +17,8 @@ maintainer:           Alec Theriault <alec.theriault@gmail.com>, Alex Biehl <ale
 homepage:             http://www.haskell.org/haddock/
 bug-reports:          https://github.com/haskell/haddock/issues
 category:             Documentation
+tested-with:          GHC==8.10.*, GHC==8.8.1, GHC==8.6.5
+
 extra-source-files:
   CHANGES.md
 

--- a/haddock-test/haddock-test.cabal
+++ b/haddock-test/haddock-test.cabal
@@ -1,3 +1,4 @@
+cabal-version:        >= 1.10
 name:                 haddock-test
 version:              0.0.1
 synopsis:             Test utilities for Haddock
@@ -9,8 +10,8 @@ bug-reports:          https://github.com/haskell/haddock/issues
 copyright:            (c) Simon Marlow, David Waern
 category:             Documentation
 build-type:           Simple
-cabal-version:        >= 1.10
 stability:            experimental
+tested-with:          GHC==8.10.*, GHC==8.8.1, GHC==8.6.5
 
 library
   default-language: Haskell2010

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -33,7 +33,7 @@ bug-reports:          https://github.com/haskell/haddock/issues
 copyright:            (c) Simon Marlow, David Waern
 category:             Documentation
 build-type:           Simple
-tested-with:          GHC==8.6.*
+tested-with:          GHC==8.10.*, GHC==8.8.1, GHC==8.6.5
 
 extra-source-files:
   CHANGES.md

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -64,7 +64,7 @@ executable haddock
 
   -- haddock typically only supports a single GHC major version
   build-depends:
-    base ^>= 4.14.0.0
+    base ^>= 4.12.0.0 || ^>= 4.13.0.0 || ^>= 4.14.0.0
 
   if flag(in-ghc-tree)
     hs-source-dirs: haddock-api/src,  haddock-library/src


### PR DESCRIPTION
We have to use the correct version of the GHC API, but the version of the compiler itself doesn't matter.