### PR TITLE
Replace the 'caption' class so that the collapsible sections are shown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 matrix:
   include:
-    - compiler: ghc-8.8.1
-      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.8.1","cabal-install-3.0"]}}
+    - compiler: ghc-8.8.3
+      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.8.3","cabal-install-3.0"]}}
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
   - WITHCOMPILER="-w $HC"

--- a/haddock-api/src/Haddock/Backends/Xhtml/DocMarkup.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/DocMarkup.hs
@@ -182,7 +182,7 @@ hackMarkup fmt' currPkg h' =
       UntouchedDoc d -> (markup fmt $ _doc d, [_meta d])
       CollapsingHeader (Header lvl titl) par n nm ->
         let id_ = makeAnchorId $ "ch:" ++ fromMaybe "noid:" nm ++ show n
-            col' = collapseControl id_ "caption"
+            col' = collapseControl id_ "subheading"
             summary = thesummary ! [ theclass "hide-when-js-enabled" ] << "Expand"
             instTable contents = collapseDetails id_ DetailsClosed (summary +++ contents)
             lvs = zip [1 .. ] [h1, h2, h3, h4, h5, h6]

--- a/html-test/ref/Bug335.html
+++ b/html-test/ref/Bug335.html
@@ -69,7 +69,7 @@
 	    >#</a
 	    ></p
 	  ><div class="doc"
-	  ><h3 class="caption details-toggle-control details-toggle" data-details-id="ch:f0"
+	  ><h3 class="subheading details-toggle-control details-toggle" data-details-id="ch:f0"
 	    >ExF:</h3
 	    ><details id="ch:f0"
 	    ><summary class="hide-when-js-enabled"
@@ -87,7 +87,7 @@
 	    >#</a
 	    ></p
 	  ><div class="doc"
-	  ><h3 class="caption details-toggle-control details-toggle" data-details-id="ch:g0"
+	  ><h3 class="subheading details-toggle-control details-toggle" data-details-id="ch:g0"
 	    >ExG:</h3
 	    ><details id="ch:g0"
 	    ><summary class="hide-when-js-enabled"

--- a/html-test/ref/Bug953.html
+++ b/html-test/ref/Bug953.html
@@ -81,7 +81,7 @@
 	  ><div class="doc"
 	  ><p
 	    >A foo</p
-	    ><h4 class="caption details-toggle-control details-toggle" data-details-id="ch:Foo0"
+	    ><h4 class="subheading details-toggle-control details-toggle" data-details-id="ch:Foo0"
 	    >Examples</h4
 	    ><details id="ch:Foo0"
 	    ><summary class="hide-when-js-enabled"
@@ -117,7 +117,7 @@
 	  ><div class="doc"
 	  ><p
 	    >A bar</p
-	    ><h4 class="caption details-toggle-control details-toggle" data-details-id="ch:Bar0"
+	    ><h4 class="subheading details-toggle-control details-toggle" data-details-id="ch:Bar0"
 	    >Examples</h4
 	    ><details id="ch:Bar0"
 	    ><summary class="hide-when-js-enabled"


### PR DESCRIPTION
This PR aims to close https://github.com/haskell/haddock/issues/1134 by replacing the `caption` class by a less harmful one.
Indeed, as helpfully pointed by @Lysxia, this class contains a `display: none`:

```css
/* linuwial.css */

#description .caption {
  display: none;
}
```

With this PR, module-level examples are now shown:

![Screenshot from 2020-03-19 16-00-39](https://user-images.githubusercontent.com/29253044/77082063-db967580-69fb-11ea-9e4f-ec50a11c2123.png)
