### PR TITLE
Disallow qualified uses of reserved identifiers

### DIFF
--- a/html-test/ref/Bug952.html
+++ b/html-test/ref/Bug952.html
@@ -1,0 +1,76 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
+     /><title
+    >Bug952</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Linuwial"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script type="text/x-mathjax-config"
+    >MathJax.Hub.Config({ tex2jax: { processClass: "mathjax", ignoreClass: ".*" } });</script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><span class="caption empty"
+      >&nbsp;</span
+      ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe-Inferred</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug952</p
+	></div
+      ><div id="synopsis"
+      ><details id="syn"
+	><summary
+	  >Synopsis</summary
+	  ><ul class="details-toggle" data-details-id="syn"
+	  ><li class="src short"
+	    ><a href="#"
+	      >foo</a
+	      > :: ()</li
+	    ></ul
+	  ></details
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><a id="v:foo" class="def"
+	    >foo</a
+	    > :: () <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="doc"
+	  ><p
+	    >See 'case', 'of', '--' compared to 'Q.case', 'Q.of', 'Q.--'</p
+	    ></div
+	  ></div
+	></div
+      ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug952.hs
+++ b/html-test/src/Bug952.hs
@@ -1,0 +1,5 @@
+module Bug952 where
+
+-- | See 'case', 'of', '--' compared to 'Q.case', 'Q.of', 'Q.--'
+foo :: ()
+foo = ()


### PR DESCRIPTION
This a GHC bug (https://gitlab.haskell.org/ghc/ghc/issues/14109) too,
but it is a relatively easy fix in Haddock. Note that the fix must live
in `haddock-api` instead of `haddock-library` because we can only really
decide if an identifier is a reserved one by asking the GHC lexer.

Fixes #952