### PR TITLE
Fix #1050 by filtering out invisible AppTy arguments

### DIFF
--- a/html-test/ref/Bug1050.html
+++ b/html-test/ref/Bug1050.html
@@ -1,0 +1,110 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+><head
+  ><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"
+     /><meta name="viewport" content="width=device-width, initial-scale=1"
+     /><title
+    >Bug1050</title
+    ><link href="#" rel="stylesheet" type="text/css" title="Linuwial"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><link rel="stylesheet" type="text/css" href="#"
+     /><script src="haddock-bundle.min.js" async="async" type="text/javascript"
+    ></script
+    ><script type="text/x-mathjax-config"
+    >MathJax.Hub.Config({ tex2jax: { processClass: "mathjax", ignoreClass: ".*" } });</script
+    ><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"
+    ></script
+    ></head
+  ><body
+  ><div id="package-header"
+    ><span class="caption empty"
+      >&nbsp;</span
+      ><ul class="links" id="page-menu"
+      ><li
+	><a href="#"
+	  >Contents</a
+	  ></li
+	><li
+	><a href="#"
+	  >Index</a
+	  ></li
+	></ul
+      ></div
+    ><div id="content"
+    ><div id="module-header"
+      ><table class="info"
+	><tr
+	  ><th
+	    >Safe Haskell</th
+	    ><td
+	    >Safe-Inferred</td
+	    ></tr
+	  ></table
+	><p class="caption"
+	>Bug1050</p
+	></div
+      ><div id="interface"
+      ><h1
+	>Documentation</h1
+	><div class="top"
+	><p class="src"
+	  ><span class="keyword"
+	    >newtype</span
+	    > <a id="t:T" class="def"
+	    >T</a
+	    > :: (<span class="keyword"
+	    >forall</span
+	    > k. k -&gt; <a href="#" title="Data.Kind"
+	    >Type</a
+	    >) -&gt; <span class="keyword"
+	    >forall</span
+	    > k. k -&gt; <a href="#" title="Data.Kind"
+	    >Type</a
+	    > <span class="keyword"
+	    >where</span
+	    > <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ><div class="subs constructors"
+	  ><p class="caption"
+	    >Constructors</p
+	    ><table
+	    ><tr
+	      ><td class="src"
+		><a id="v:MkT" class="def"
+		  >MkT</a
+		  > :: <span class="keyword"
+		  >forall</span
+		  > (f :: <span class="keyword"
+		  >forall</span
+		  > k. k -&gt; <a href="#" title="Data.Kind"
+		  >Type</a
+		  >) k (a :: k). f a -&gt; <a href="#" title="Bug1050"
+		  >T</a
+		  > f a</td
+		><td class="doc empty"
+		>&nbsp;</td
+		></tr
+	      ></table
+	    ></div
+	  ></div
+	><div class="top"
+	><p class="src"
+	  ><a id="v:mkT" class="def"
+	    >mkT</a
+	    > :: <span class="keyword"
+	    >forall</span
+	    > k (f :: <span class="keyword"
+	    >forall</span
+	    > k1. k1 -&gt; <a href="#" title="Data.Kind"
+	    >Type</a
+	    >) (a :: k). f a -&gt; <a href="#" title="Bug1050"
+	    >T</a
+	    > f a <a href="#" class="selflink"
+	    >#</a
+	    ></p
+	  ></div
+	></div
+      ></div
+    ></body
+  ></html
+>

--- a/html-test/src/Bug1050.hs
+++ b/html-test/src/Bug1050.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+module Bug1050 where
+
+import Data.Kind
+
+newtype T :: (forall k. k -> Type) -> (forall k. k -> Type) where
+  MkT :: forall (f :: forall k. k -> Type) k (a :: k). f a -> T f a
+
+mkT = MkT


### PR DESCRIPTION
_This is a second attempt at fixing #1050, following #1051._ 

This makes the `synifyType` case for `AppTy` more intelligent by taking into consideration the visibilities of each `AppTy` argument and filtering out any invisible arguments, as they aren't intended to be displayed in the source code. (See #1050 for an example of what can happen if you fail to filter these out.)

Along the way, I noticed that a special `synifyType` case for `AppTy t1 (CoercionTy {})` could be consolidated with the case below it, so I took the opportunity to tidy this up.