### PR TITLE
Add dependency on exceptions because GHC.Exception was boiled down (ghc #18075)

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -58,6 +58,7 @@ library
                , containers
                , deepseq
                , directory
+               , exceptions
                , filepath
                , ghc-boot
                , transformers

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -446,11 +446,6 @@ modifySessionDynFlags f = do
   return ()
 
 
--- | A variant of 'gbracket' where the return value from the first computation
--- is not required.
-gbracket_ :: ExceptionMonad m => m a -> m b -> m c -> m c
-gbracket_ before_ after thing = gbracket before_ (const after) (const thing)
-
 -- Extract the minimal complete definition of a Name, if one exists
 minimalDef :: GhcMonad m => Name -> m (Maybe ClassMinimalDef)
 minimalDef n = do

--- a/haddock-api/src/Haddock/Utils.hs
+++ b/haddock-api/src/Haddock/Utils.hs
@@ -67,6 +67,7 @@ import GHC
 import GHC.Types.Name
 
 import Control.Monad ( liftM )
+import Control.Monad.Catch ( bracket_ )
 import Data.Char ( isAlpha, isAlphaNum, isAscii, ord, chr )
 import Numeric ( showIntAtBase )
 import Data.Map ( Map )
@@ -404,7 +405,7 @@ writeUtf8File filepath contents = withFile filepath WriteMode $ \h -> do
     hPutStr h contents
 
 withTempDir :: (ExceptionMonad m) => FilePath -> m a -> m a
-withTempDir dir = gbracket_ (liftIO $ createDirectory dir)
+withTempDir dir = bracket_ (liftIO $ createDirectory dir)
                             (liftIO $ removeDirectoryRecursive dir)
 
 -----------------------------------------------------------------------------

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -74,6 +74,7 @@ executable haddock
       directory,
       containers,
       deepseq,
+      exceptions,
       array,
       xhtml >= 3000.2 && < 3000.3,
       Cabal >= 1.10,


### PR DESCRIPTION
As per [GHC ticket #18075](https://gitlab.haskell.org/ghc/ghc/issues/18075) (corresponding [MR: 3155](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3155/)), the `Exception` module in GHC was boiled down, and functions like `Exception.gcatch` should be replaced with their `Control.Monad.Catch` equivalents from the `exceptions` package. This PR implements this replacement for Haddock as well as adding the `exceptions` dependency.