### PR TITLE
Update for adding typeclass info to `.hie` files

### DIFF
--- a/hypsrc-test/ref/src/Types.html
+++ b/hypsrc-test/ref/src/Types.html
@@ -699,8 +699,11 @@
       ><span
       > </span
       ><span class="annot"
-      ><a href="Types.html#Bar"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Bar"
+	><span class="hs-identifier hs-var"
 	  >Bar</span
 	  ></a
 	></span
@@ -761,8 +764,11 @@
       ><span
       > </span
       ><span class="annot"
-      ><a href="Types.html#Baz"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Baz"
+	><span class="hs-identifier hs-var"
 	  >Baz</span
 	  ></a
 	></span
@@ -864,8 +870,11 @@
       ><span
       > </span
       ><span class="annot"
-      ><a href="Types.html#Bar"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Bar"
+	><span class="hs-identifier hs-var"
 	  >Bar</span
 	  ></a
 	></span
@@ -926,8 +935,11 @@
       ><span
       > </span
       ><span class="annot"
-      ><a href="Types.html#Baz"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Baz"
+	><span class="hs-identifier hs-var"
 	  >Baz</span
 	  ></a
 	></span
@@ -1060,8 +1072,11 @@
       ><span
       > </span
       ><span class="annot"
-      ><a href="Types.html#Bar"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Bar"
+	><span class="hs-identifier hs-var"
 	  >Bar</span
 	  ></a
 	></span
@@ -1112,8 +1127,11 @@
       ><span
       > </span
       ><span class="annot"
-      ><a href="Types.html#Baz"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Baz"
+	><span class="hs-identifier hs-var"
 	  >Baz</span
 	  ></a
 	></span
@@ -1207,8 +1225,11 @@
       ><span class="hs-special"
       >(</span
       ><span class="annot"
-      ><a href="Types.html#Bar"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Bar"
+	><span class="hs-identifier hs-var"
 	  >Bar</span
 	  ></a
 	></span
@@ -1259,8 +1280,11 @@
       ><span class="hs-special"
       >(</span
       ><span class="annot"
-      ><a href="Types.html#Baz"
-	><span class="hs-identifier hs-type"
+      ><span class="annottext"
+	>Quux
+</span
+	><a href="Types.html#Baz"
+	><span class="hs-identifier hs-var"
 	  >Baz</span
 	  ></a
 	></span


### PR DESCRIPTION
Also happens to improve hyperlinker output a bit.

Companion to https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1286