### PR TITLE
use floor over round to calculate the percentage

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -182,7 +182,7 @@ processModule verbosity modsum flags modMap instIfaceMap = do
     liftIO $ mapM_ putStrLn (nub msgs)
     dflags <- getDynFlags
     let (haddockable, haddocked) = ifaceHaddockCoverage interface
-        percentage = round (fromIntegral haddocked * 100 / fromIntegral haddockable :: Double) :: Int
+        percentage = floor (fromIntegral haddocked * 100 / fromIntegral haddockable :: Double) :: Int
         modString = moduleString (ifaceMod interface)
         coverageMsg = printf " %3d%% (%3d /%3d) in '%s'" percentage haddocked haddockable modString
         header = case ifaceDoc interface of


### PR DESCRIPTION
Based on issue #1194 a change to `floor` the percentage over `round`ing.