### PR TITLE
Add links to instance definition in hyperlinker tooltips

### DIFF
--- a/haddock-api/resources/html/solarized.css
+++ b/haddock-api/resources/html/solarized.css
@@ -90,8 +90,13 @@ span.annot:hover span.annottext{
 span.annot span.annottext:before{
   content: "";
   position: absolute;
-  left: -1em; top: -1em;
+  left: -1.5em; top: -1.1em;
   background: #FFFFFF00;
   z-index:-1;
-  padding: 2em 2em;
+  padding: 2em 3em;
+}
+
+:target {
+  border: 2px solid #D4D4D4;
+  background-color: #e5eecc;
 }

--- a/haddock-api/src/Haddock/Backends/Hyperlinker.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker.hs
@@ -19,6 +19,7 @@ import System.Directory
 import System.FilePath
 
 import GHC.Iface.Ext.Types  ( HieFile(..), HieASTs(..) )
+import GHC.Iface.Ext.Utils  ( generateReferencesMap    )
 import GHC.Iface.Ext.Binary ( readHieFile, hie_file_result, NameCacheUpdater(..))
 import Data.Map as M
 import GHC.Data.FastString     ( mkFastString )
@@ -74,7 +75,8 @@ ppHyperlinkedModuleSource srcdir pretty srcs iface = case ifaceHieFile iface of
         case mast of
           Just ast ->
               let fullAst = recoverFullIfaceTypes df types ast
-              in writeUtf8File path . renderToString pretty . render' fullAst $ tokens
+                  refmap = generateReferencesMap (Just fullAst)
+              in writeUtf8File path . renderToString pretty . render' fullAst refmap $ tokens
           Nothing
             | M.size asts == 0 -> return ()
             | otherwise -> error $ unwords [ "couldn't find ast for"

--- a/hypsrc-test/ref/src/Classes.html
+++ b/hypsrc-test/ref/src/Classes.html
@@ -159,17 +159,19 @@
       >instance</span
       ><span
       > </span
+      ><span id="%24fFooInt"
       ><span class="annot"
-      ><a href="Classes.html#Foo"
+	><a href="Classes.html#Foo"
+	  ><span class="hs-identifier hs-type"
+	    >Foo</span
+	    ></a
+	  ></span
+	><span
+	> </span
+	><span class="annot"
 	><span class="hs-identifier hs-type"
-	  >Foo</span
-	  ></a
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="hs-identifier hs-type"
-	>Int</span
+	  >Int</span
+	  ></span
 	></span
       ><span
       > </span
@@ -285,24 +287,26 @@ forall a. a -&gt; a
 	>instance</span
 	><span
 	> </span
+	><span id="%24fFoo%5B%5D"
 	><span class="annot"
-	><a href="Classes.html#Foo"
-	  ><span class="hs-identifier hs-type"
-	    >Foo</span
-	    ></a
+	  ><a href="Classes.html#Foo"
+	    ><span class="hs-identifier hs-type"
+	      >Foo</span
+	      ></a
+	    ></span
+	  ><span
+	  > </span
+	  ><span class="hs-special"
+	  >[</span
+	  ><span class="annot"
+	  ><a href="#"
+	    ><span class="hs-identifier hs-type"
+	      >a</span
+	      ></a
+	    ></span
+	  ><span class="hs-special"
+	  >]</span
 	  ></span
-	><span
-	> </span
-	><span class="hs-special"
-	>[</span
-	><span class="annot"
-	><a href="#"
-	  ><span class="hs-identifier hs-type"
-	    >a</span
-	    ></a
-	  ></span
-	><span class="hs-special"
-	>]</span
 	><span
 	> </span
 	><span class="hs-keyword"
@@ -335,6 +339,7 @@ forall a. a -&gt; a
 	><span class="annottext"
 	  >[a] -&gt; Int
 forall (t :: * -&gt; *) a. Foldable t =&gt; t a -&gt; Int
+External instance of the constraint type Foldable []
 </span
 	  ><span class="hs-identifier hs-var"
 	  >length</span
@@ -404,347 +409,373 @@ forall (t :: * -&gt; *) a. Foldable t =&gt; t a -&gt; Int
 </span
       ><span id="line-17"
       ></span
+      ><span id="%24p1Foo%27"
       ><span class="hs-keyword"
-      >class</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><a href="Classes.html#Foo"
-	><span class="hs-identifier hs-type"
-	  >Foo</span
-	  ></a
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><a href="#"
-	><span class="hs-identifier hs-type"
-	  >a</span
-	  ></a
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=&gt;</span
-      ><span
-      > </span
-      ><span id="Foo%27"
-      ><span class="annot"
-	><a href="Classes.html#Foo%27"
-	  ><span class="hs-identifier hs-var"
-	    >Foo'</span
+	>class</span
+	><span
+	> </span
+	><span class="annot"
+	><a href="Classes.html#Foo"
+	  ><span class="hs-identifier hs-type"
+	    >Foo</span
 	    ></a
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span id=""
-      ><span class="annot"
+	><span
+	> </span
+	><span class="annot"
 	><a href="#"
 	  ><span class="hs-identifier hs-type"
 	    >a</span
 	    ></a
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-keyword"
-      >where</span
-      ><span
-      >
-</span
-      ><span id="line-18"
-      ></span
-      ><span
-      >    </span
-      ><span id="quux"
-      ><span class="annot"
-	><a href="Classes.html#quux"
-	  ><span class="hs-identifier hs-type"
-	    >quux</span
-	    ></a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=&gt;</span
+	><span
+	> </span
+	><span id="Foo%27"
+	><span class="annot"
+	  ><a href="Classes.html#Foo%27"
+	    ><span class="hs-identifier hs-var"
+	      >Foo'</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >::</span
-      ><span
-      > </span
-      ><span class="hs-special"
-      >(</span
-      ><span class="annot"
-      ><a href="#"
-	><span class="hs-identifier hs-type"
-	  >a</span
-	  ></a
-	></span
-      ><span class="hs-special"
-      >,</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><a href="#"
-	><span class="hs-identifier hs-type"
-	  >a</span
-	  ></a
-	></span
-      ><span class="hs-special"
-      >)</span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >-&gt;</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><a href="#"
-	><span class="hs-identifier hs-type"
-	  >a</span
-	  ></a
-	></span
-      ><span
-      >
-</span
-      ><span id="line-19"
-      ></span
-      ><span
-      >    </span
-      ><span id=""
-      ><span class="annot"
-	><a href="Classes.html#quux"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >quux</span
-	    ></a
+	><span
+	> </span
+	><span id=""
+	><span class="annot"
+	  ><a href="#"
+	    ><span class="hs-identifier hs-type"
+	      >a</span
+	      ></a
+	    ></span
 	  ></span
+	><span
+	> </span
+	><span class="hs-keyword"
+	>where</span
+	><span
+	>
+</span
+	><span id="line-18"
+	></span
+	><span
+	>    </span
+	><span id="quux"
+	><span class="annot"
+	  ><a href="Classes.html#quux"
+	    ><span class="hs-identifier hs-type"
+	      >quux</span
+	      ></a
+	    ></span
+	  ></span
+	><span
+	> </span
+	><span class="hs-glyph"
+	>::</span
 	><span
 	> </span
 	><span class="hs-special"
 	>(</span
-	><span id=""
 	><span class="annot"
-	  ><span class="annottext"
-	    >a
-</span
-	    ><a href="#"
-	    ><span class="hs-identifier hs-var"
-	      >x</span
-	      ></a
-	    ></span
+	><a href="#"
+	  ><span class="hs-identifier hs-type"
+	    >a</span
+	    ></a
 	  ></span
 	><span class="hs-special"
 	>,</span
 	><span
 	> </span
-	><span id=""
 	><span class="annot"
-	  ><span class="annottext"
-	    >a
-</span
-	    ><a href="#"
-	    ><span class="hs-identifier hs-var"
-	      >y</span
-	      ></a
-	    ></span
+	><a href="#"
+	  ><span class="hs-identifier hs-type"
+	    >a</span
+	    ></a
 	  ></span
 	><span class="hs-special"
 	>)</span
 	><span
 	> </span
 	><span class="hs-glyph"
-	>=</span
+	>-&gt;</span
 	><span
 	> </span
 	><span class="annot"
-	><span class="annottext"
-	  >[a] -&gt; a
-forall a. Foo' a =&gt; [a] -&gt; a
-</span
-	  ><a href="Classes.html#norf"
-	  ><span class="hs-identifier hs-var"
-	    >norf</span
+	><a href="#"
+	  ><span class="hs-identifier hs-type"
+	    >a</span
 	    ></a
 	  ></span
+	><span
+	>
+</span
+	><span id="line-19"
+	></span
+	><span
+	>    </span
+	><span id=""
+	><span id=""
+	  ><span class="annot"
+	    ><a href="Classes.html#quux"
+	      ><span class="hs-identifier hs-var hs-var"
+		>quux</span
+		></a
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="hs-special"
+	    >(</span
+	    ><span id=""
+	    ><span class="annot"
+	      ><span class="annottext"
+		>a
+</span
+		><a href="#"
+		><span class="hs-identifier hs-var"
+		  >x</span
+		  ></a
+		></span
+	      ></span
+	    ><span class="hs-special"
+	    >,</span
+	    ><span
+	    > </span
+	    ><span id=""
+	    ><span class="annot"
+	      ><span class="annottext"
+		>a
+</span
+		><a href="#"
+		><span class="hs-identifier hs-var"
+		  >y</span
+		  ></a
+		></span
+	      ></span
+	    ><span class="hs-special"
+	    >)</span
+	    ><span
+	    > </span
+	    ><span class="hs-glyph"
+	    >=</span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >[a] -&gt; a
+forall a. Foo' a =&gt; [a] -&gt; a
+<a href="#line-19"
+		>Evidence bound by a type signature</a
+		> of the constraint type Foo' a
+</span
+	      ><a href="Classes.html#norf"
+	      ><span class="hs-identifier hs-var"
+		>norf</span
+		></a
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="hs-special"
+	    >[</span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >a
+</span
+	      ><a href="#"
+	      ><span class="hs-identifier hs-var"
+		>x</span
+		></a
+	      ></span
+	    ><span class="hs-special"
+	    >,</span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >a
+</span
+	      ><a href="#"
+	      ><span class="hs-identifier hs-var"
+		>y</span
+		></a
+	      ></span
+	    ><span class="hs-special"
+	    >]</span
+	    ></span
+	  ></span
+	><span
+	>
+</span
+	><span id="line-20"
+	></span
+	><span
+	>
+</span
+	><span id="line-21"
+	></span
+	><span
+	>    </span
+	><span id="norf"
+	><span class="annot"
+	  ><a href="Classes.html#norf"
+	    ><span class="hs-identifier hs-type"
+	      >norf</span
+	      ></a
+	    ></span
+	  ></span
+	><span
+	> </span
+	><span class="hs-glyph"
+	>::</span
 	><span
 	> </span
 	><span class="hs-special"
 	>[</span
 	><span class="annot"
-	><span class="annottext"
-	  >a
-</span
-	  ><a href="#"
-	  ><span class="hs-identifier hs-var"
-	    >x</span
-	    ></a
-	  ></span
-	><span class="hs-special"
-	>,</span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >a
-</span
-	  ><a href="#"
-	  ><span class="hs-identifier hs-var"
-	    >y</span
+	><a href="#"
+	  ><span class="hs-identifier hs-type"
+	    >a</span
 	    ></a
 	  ></span
 	><span class="hs-special"
 	>]</span
-	></span
-      ><span
-      >
-</span
-      ><span id="line-20"
-      ></span
-      ><span
-      >
-</span
-      ><span id="line-21"
-      ></span
-      ><span
-      >    </span
-      ><span id="norf"
-      ><span class="annot"
-	><a href="Classes.html#norf"
-	  ><span class="hs-identifier hs-type"
-	    >norf</span
-	    ></a
-	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >::</span
-      ><span
-      > </span
-      ><span class="hs-special"
-      >[</span
-      ><span class="annot"
-      ><a href="#"
-	><span class="hs-identifier hs-type"
-	  >a</span
-	  ></a
-	></span
-      ><span class="hs-special"
-      >]</span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >-&gt;</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><a href="#"
-	><span class="hs-identifier hs-type"
-	  >a</span
-	  ></a
-	></span
-      ><span
-      >
-</span
-      ><span id="line-22"
-      ></span
-      ><span
-      >    </span
-      ><span id=""
-      ><span class="annot"
-	><a href="Classes.html#norf"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >norf</span
-	    ></a
-	  ></span
 	><span
 	> </span
 	><span class="hs-glyph"
-	>=</span
+	>-&gt;</span
 	><span
 	> </span
 	><span class="annot"
-	><span class="annottext"
-	  >(a, a) -&gt; a
+	><a href="#"
+	  ><span class="hs-identifier hs-type"
+	    >a</span
+	    ></a
+	  ></span
+	><span
+	>
+</span
+	><span id="line-22"
+	></span
+	><span
+	>    </span
+	><span id=""
+	><span id=""
+	  ><span class="annot"
+	    ><a href="Classes.html#norf"
+	      ><span class="hs-identifier hs-var hs-var"
+		>norf</span
+		></a
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="hs-glyph"
+	    >=</span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >(a, a) -&gt; a
 forall a. Foo' a =&gt; (a, a) -&gt; a
+<a href="#line-19"
+		>Evidence bound by a type signature</a
+		> of the constraint type Foo' a
 </span
-	  ><a href="Classes.html#quux"
-	  ><span class="hs-identifier hs-var"
-	    >quux</span
-	    ></a
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >((a, a) -&gt; a) -&gt; ([a] -&gt; (a, a)) -&gt; [a] -&gt; a
+	      ><a href="Classes.html#quux"
+	      ><span class="hs-identifier hs-var"
+		>quux</span
+		></a
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >((a, a) -&gt; a) -&gt; ([a] -&gt; (a, a)) -&gt; [a] -&gt; a
 forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
 </span
-	  ><span class="hs-operator hs-var"
-	  >.</span
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >Int -&gt; (a, a)
+	      ><span class="hs-operator hs-var"
+	      >.</span
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >Int -&gt; (a, a)
 forall a. Foo a =&gt; Int -&gt; (a, a)
+<a href="Classes.html#%24p1Foo%27"
+		>Evidence bound by a superclass of: Foo'</a
+		> of the constraint type forall a. Foo' a =&gt; Foo a
+<a href="#line-19"
+		>Evidence bound by a type signature</a
+		> of the constraint type Foo' a
 </span
-	  ><a href="Classes.html#baz"
-	  ><span class="hs-identifier hs-var"
-	    >baz</span
-	    ></a
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >(Int -&gt; (a, a)) -&gt; ([a] -&gt; Int) -&gt; [a] -&gt; (a, a)
+	      ><a href="Classes.html#baz"
+	      ><span class="hs-identifier hs-var"
+		>baz</span
+		></a
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >(Int -&gt; (a, a)) -&gt; ([a] -&gt; Int) -&gt; [a] -&gt; (a, a)
 forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
 </span
-	  ><span class="hs-operator hs-var"
-	  >.</span
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >[Int] -&gt; Int
+	      ><span class="hs-operator hs-var"
+	      >.</span
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >[Int] -&gt; Int
 forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
+External instance of the constraint type Num Int
+External instance of the constraint type Foldable []
 </span
-	  ><span class="hs-identifier hs-var"
-	  >sum</span
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >([Int] -&gt; Int) -&gt; ([a] -&gt; [Int]) -&gt; [a] -&gt; Int
+	      ><span class="hs-identifier hs-var"
+	      >sum</span
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >([Int] -&gt; Int) -&gt; ([a] -&gt; [Int]) -&gt; [a] -&gt; Int
 forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
 </span
-	  ><span class="hs-operator hs-var"
-	  >.</span
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >(a -&gt; Int) -&gt; [a] -&gt; [Int]
+	      ><span class="hs-operator hs-var"
+	      >.</span
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >(a -&gt; Int) -&gt; [a] -&gt; [Int]
 forall a b. (a -&gt; b) -&gt; [a] -&gt; [b]
 </span
-	  ><span class="hs-identifier hs-var"
-	  >map</span
-	  ></span
-	><span
-	> </span
-	><span class="annot"
-	><span class="annottext"
-	  >a -&gt; Int
+	      ><span class="hs-identifier hs-var"
+	      >map</span
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="annot"
+	    ><span class="annottext"
+	      >a -&gt; Int
 forall a. Foo a =&gt; a -&gt; Int
+<a href="Classes.html#%24p1Foo%27"
+		>Evidence bound by a superclass of: Foo'</a
+		> of the constraint type forall a. Foo' a =&gt; Foo a
+<a href="#line-19"
+		>Evidence bound by a type signature</a
+		> of the constraint type Foo' a
 </span
-	  ><a href="Classes.html#bar"
-	  ><span class="hs-identifier hs-var"
-	    >bar</span
-	    ></a
+	      ><a href="Classes.html#bar"
+	      ><span class="hs-identifier hs-var"
+		>bar</span
+		></a
+	      ></span
+	    ></span
 	  ></span
 	></span
       ><span
@@ -762,17 +793,19 @@ forall a. Foo a =&gt; a -&gt; Int
       ><span
       > </span
       ><span id=""
-      ><span class="annot"
-	><a href="Classes.html#Foo%27"
-	  ><span class="hs-identifier hs-type"
-	    >Foo'</span
-	    ></a
-	  ></span
-	><span
-	> </span
+      ><span id="%24fFoo%27Int"
 	><span class="annot"
-	><span class="hs-identifier hs-type"
-	  >Int</span
+	  ><a href="Classes.html#Foo%27"
+	    ><span class="hs-identifier hs-type"
+	      >Foo'</span
+	      ></a
+	    ></span
+	  ><span
+	  > </span
+	  ><span class="annot"
+	  ><span class="hs-identifier hs-type"
+	    >Int</span
+	    ></span
 	  ></span
 	></span
       ><span
@@ -807,6 +840,8 @@ forall a. Foo a =&gt; a -&gt; Int
       ><span class="annottext"
 	>[Int] -&gt; Int
 forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
+External instance of the constraint type Num Int
+External instance of the constraint type Foldable []
 </span
 	><span class="hs-identifier hs-var"
 	>sum</span
@@ -827,24 +862,26 @@ forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
 	><span
 	> </span
 	><span id=""
-	><span class="annot"
-	  ><a href="Classes.html#Foo%27"
-	    ><span class="hs-identifier hs-type"
-	      >Foo'</span
-	      ></a
-	    ></span
-	  ><span
-	  > </span
-	  ><span class="hs-special"
-	  >[</span
+	><span id="%24fFoo%27%5B%5D"
 	  ><span class="annot"
-	  ><a href="#"
-	    ><span class="hs-identifier hs-type"
-	      >a</span
-	      ></a
+	    ><a href="Classes.html#Foo%27"
+	      ><span class="hs-identifier hs-type"
+		>Foo'</span
+		></a
+	      ></span
+	    ><span
+	    > </span
+	    ><span class="hs-special"
+	    >[</span
+	    ><span class="annot"
+	    ><a href="#"
+	      ><span class="hs-identifier hs-type"
+		>a</span
+		></a
+	      ></span
+	    ><span class="hs-special"
+	    >]</span
 	    ></span
-	  ><span class="hs-special"
-	  >]</span
 	  ></span
 	><span
 	> </span
@@ -1083,17 +1120,19 @@ forall a. [a] -&gt; [a] -&gt; [a]
       >instance</span
       ><span
       > </span
+      ><span id="%24fPlughEither"
       ><span class="annot"
-      ><a href="Classes.html#Plugh"
+	><a href="Classes.html#Plugh"
+	  ><span class="hs-identifier hs-type"
+	    >Plugh</span
+	    ></a
+	  ></span
+	><span
+	> </span
+	><span class="annot"
 	><span class="hs-identifier hs-type"
-	  >Plugh</span
-	  ></a
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="hs-identifier hs-type"
-	>Either</span
+	  >Either</span
+	  ></span
 	></span
       ><span
       > </span

--- a/hypsrc-test/ref/src/Constructors.html
+++ b/hypsrc-test/ref/src/Constructors.html
@@ -538,6 +538,7 @@
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -559,6 +560,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -1066,6 +1068,7 @@ forall a. HasCallStack =&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -1087,6 +1090,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -1119,6 +1123,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -1217,6 +1222,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -1249,6 +1255,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -1303,6 +1310,8 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>[Int] -&gt; Int
 forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
+External instance of the constraint type Num Int
+External instance of the constraint type Foldable []
 </span
 	><span class="hs-identifier hs-var"
 	>sum</span

--- a/hypsrc-test/ref/src/Identifiers.html
+++ b/hypsrc-test/ref/src/Identifiers.html
@@ -150,6 +150,7 @@
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -171,6 +172,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -214,6 +216,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -235,6 +238,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -313,6 +317,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -334,6 +339,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-glyph hs-var"
 	>-</span
@@ -377,6 +383,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-glyph hs-var"
 	>-</span
@@ -398,6 +405,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -476,6 +484,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -497,6 +506,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -518,6 +528,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -539,6 +550,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -845,6 +857,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Bool
 forall a. Ord a =&gt; a -&gt; a -&gt; Bool
+External instance of the constraint type Ord Int
 </span
 	><span class="hs-operator hs-var"
 	>&lt;</span
@@ -910,6 +923,7 @@ forall a. Ord a =&gt; a -&gt; a -&gt; Bool
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Bool
 forall a. Ord a =&gt; a -&gt; a -&gt; Bool
+External instance of the constraint type Ord Int
 </span
 	><span class="hs-operator hs-var"
 	>&lt;</span
@@ -975,6 +989,7 @@ forall a. Ord a =&gt; a -&gt; a -&gt; Bool
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Bool
 forall a. Ord a =&gt; a -&gt; a -&gt; Bool
+External instance of the constraint type Ord Int
 </span
 	><span class="hs-operator hs-var"
 	>&lt;</span
@@ -1189,6 +1204,7 @@ forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
       ><span class="annottext"
 	>Int -&gt; String
 forall a. Show a =&gt; a -&gt; String
+External instance of the constraint type Show Int
 </span
 	><span class="hs-identifier hs-var"
 	>show</span
@@ -1266,6 +1282,7 @@ forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
       ><span class="annottext"
 	>Int -&gt; String
 forall a. Show a =&gt; a -&gt; String
+External instance of the constraint type Show Int
 </span
 	><span class="hs-identifier hs-var"
 	>show</span
@@ -1332,6 +1349,7 @@ forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
       ><span class="annottext"
 	>Int -&gt; String
 forall a. Show a =&gt; a -&gt; String
+External instance of the constraint type Show Int
 </span
 	><span class="hs-identifier hs-var"
 	>show</span

--- a/hypsrc-test/ref/src/LinkingIdentifiers.html
+++ b/hypsrc-test/ref/src/LinkingIdentifiers.html
@@ -180,6 +180,7 @@
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -293,6 +294,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -457,6 +459,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -570,6 +573,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span

--- a/hypsrc-test/ref/src/Literals.html
+++ b/hypsrc-test/ref/src/Literals.html
@@ -129,105 +129,119 @@
 </span
       ><span id="line-8"
       ></span
+      ><span id=""
       ><span id="num"
-      ><span class="annot"
-	><span class="annottext"
-	  >num :: a
+	><span class="annot"
+	  ><span class="annottext"
+	    >num :: a
 </span
-	  ><a href="Literals.html#num"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >num</span
-	    ></a
+	    ><a href="Literals.html#num"
+	    ><span class="hs-identifier hs-var hs-var"
+	      >num</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=</span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a
 </span
-	><span class="hs-number"
-	>0</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a -&gt; a -&gt; a
+	  ><span class="hs-number"
+	  >0</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a -&gt; a -&gt; a
 forall a. Num a =&gt; a -&gt; a -&gt; a
+<a href="#line-8"
+	    >Evidence bound by a type signature</a
+	    > of the constraint type Num a
 </span
-	><span class="hs-operator hs-var"
-	>+</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a
+	  ><span class="hs-operator hs-var"
+	  >+</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a
 </span
-	><span class="hs-number"
-	>1</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a -&gt; a -&gt; a
+	  ><span class="hs-number"
+	  >1</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a -&gt; a -&gt; a
 forall a. Num a =&gt; a -&gt; a -&gt; a
+<a href="#line-8"
+	    >Evidence bound by a type signature</a
+	    > of the constraint type Num a
 </span
-	><span class="hs-operator hs-var"
-	>+</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a
+	  ><span class="hs-operator hs-var"
+	  >+</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a
 </span
-	><span class="hs-number"
-	>1010011</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a -&gt; a -&gt; a
+	  ><span class="hs-number"
+	  >1010011</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a -&gt; a -&gt; a
 forall a. Num a =&gt; a -&gt; a -&gt; a
+<a href="#line-8"
+	    >Evidence bound by a type signature</a
+	    > of the constraint type Num a
 </span
-	><span class="hs-operator hs-var"
-	>*</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a
+	  ><span class="hs-operator hs-var"
+	  >*</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a
 </span
-	><span class="hs-number"
-	>41231</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a -&gt; a -&gt; a
+	  ><span class="hs-number"
+	  >41231</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a -&gt; a -&gt; a
 forall a. Num a =&gt; a -&gt; a -&gt; a
+<a href="#line-8"
+	    >Evidence bound by a type signature</a
+	    > of the constraint type Num a
 </span
-	><span class="hs-operator hs-var"
-	>+</span
-	></span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a
+	  ><span class="hs-operator hs-var"
+	  >+</span
+	  ></span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a
 </span
-	><span class="hs-number"
-	>12131</span
+	  ><span class="hs-number"
+	  >12131</span
+	  ></span
 	></span
       ><span
       >
@@ -282,29 +296,31 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
 </span
       ><span id="line-11"
       ></span
+      ><span id=""
       ><span id="frac"
-      ><span class="annot"
-	><span class="annottext"
-	  >frac :: a
+	><span class="annot"
+	  ><span class="annottext"
+	    >frac :: a
 </span
-	  ><a href="Literals.html#frac"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >frac</span
-	    ></a
+	    ><a href="Literals.html#frac"
+	    ><span class="hs-identifier hs-var hs-var"
+	      >frac</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=</span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a
 </span
-	><span class="hs-number"
-	>42.0000001</span
+	  ><span class="hs-number"
+	  >42.0000001</span
+	  ></span
 	></span
       ><span
       >

--- a/hypsrc-test/ref/src/Operators.html
+++ b/hypsrc-test/ref/src/Operators.html
@@ -687,6 +687,7 @@ forall a. [a] -&gt; [a] -&gt; [a]
       ><span class="annottext"
 	>([a] -&gt; [a]) -&gt; [[a]] -&gt; [a]
 forall (t :: * -&gt; *) a b. Foldable t =&gt; (a -&gt; [b]) -&gt; t a -&gt; [b]
+External instance of the constraint type Foldable []
 </span
 	><span class="hs-identifier hs-var"
 	>concatMap</span

--- a/hypsrc-test/ref/src/Polymorphism.html
+++ b/hypsrc-test/ref/src/Polymorphism.html
@@ -1137,30 +1137,32 @@ forall a. a -&gt; a
 </span
       ><span id="line-34"
       ></span
+      ><span id=""
       ><span id="num"
-      ><span class="annot"
-	><span class="annottext"
-	  >num :: a -&gt; a -&gt; a
+	><span class="annot"
+	  ><span class="annottext"
+	    >num :: a -&gt; a -&gt; a
 </span
-	  ><a href="Polymorphism.html#num"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >num</span
-	    ></a
+	    ><a href="Polymorphism.html#num"
+	    ><span class="hs-identifier hs-var hs-var"
+	      >num</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a -&gt; a -&gt; a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=</span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a -&gt; a -&gt; a
 forall a. HasCallStack =&gt; a
 </span
-	><span class="hs-identifier hs-var"
-	>undefined</span
+	  ><span class="hs-identifier hs-var"
+	  >undefined</span
+	  ></span
 	></span
       ><span
       >
@@ -1253,30 +1255,32 @@ forall a. HasCallStack =&gt; a
 </span
       ><span id="line-37"
       ></span
+      ><span id=""
       ><span id="num%27"
-      ><span class="annot"
-	><span class="annottext"
-	  >num' :: a -&gt; a -&gt; a
+	><span class="annot"
+	  ><span class="annottext"
+	    >num' :: a -&gt; a -&gt; a
 </span
-	  ><a href="Polymorphism.html#num%27"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >num'</span
-	    ></a
+	    ><a href="Polymorphism.html#num%27"
+	    ><span class="hs-identifier hs-var hs-var"
+	      >num'</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>a -&gt; a -&gt; a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=</span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >a -&gt; a -&gt; a
 forall a. HasCallStack =&gt; a
 </span
-	><span class="hs-identifier hs-var"
-	>undefined</span
+	  ><span class="hs-identifier hs-var"
+	  >undefined</span
+	  ></span
 	></span
       ><span
       >
@@ -1399,30 +1403,34 @@ forall a. HasCallStack =&gt; a
 </span
       ><span id="line-40"
       ></span
-      ><span id="eq"
-      ><span class="annot"
-	><span class="annottext"
-	  >eq :: [a] -&gt; [b] -&gt; (a, b)
+      ><span id=""
+      ><span id=""
+	><span id="eq"
+	  ><span class="annot"
+	    ><span class="annottext"
+	      >eq :: [a] -&gt; [b] -&gt; (a, b)
 </span
-	  ><a href="Polymorphism.html#eq"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >eq</span
-	    ></a
-	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>[a] -&gt; [b] -&gt; (a, b)
+	      ><a href="Polymorphism.html#eq"
+	      ><span class="hs-identifier hs-var hs-var"
+		>eq</span
+		></a
+	      ></span
+	    ></span
+	  ><span
+	  > </span
+	  ><span class="hs-glyph"
+	  >=</span
+	  ><span
+	  > </span
+	  ><span class="annot"
+	  ><span class="annottext"
+	    >[a] -&gt; [b] -&gt; (a, b)
 forall a. HasCallStack =&gt; a
 </span
-	><span class="hs-identifier hs-var"
-	>undefined</span
+	    ><span class="hs-identifier hs-var"
+	    >undefined</span
+	    ></span
+	  ></span
 	></span
       ><span
       >
@@ -1567,30 +1575,34 @@ forall a. HasCallStack =&gt; a
 </span
       ><span id="line-43"
       ></span
-      ><span id="eq%27"
-      ><span class="annot"
-	><span class="annottext"
-	  >eq' :: [a] -&gt; [b] -&gt; (a, b)
+      ><span id=""
+      ><span id=""
+	><span id="eq%27"
+	  ><span class="annot"
+	    ><span class="annottext"
+	      >eq' :: [a] -&gt; [b] -&gt; (a, b)
 </span
-	  ><a href="Polymorphism.html#eq%27"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >eq'</span
-	    ></a
-	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>[a] -&gt; [b] -&gt; (a, b)
+	      ><a href="Polymorphism.html#eq%27"
+	      ><span class="hs-identifier hs-var hs-var"
+		>eq'</span
+		></a
+	      ></span
+	    ></span
+	  ><span
+	  > </span
+	  ><span class="hs-glyph"
+	  >=</span
+	  ><span
+	  > </span
+	  ><span class="annot"
+	  ><span class="annottext"
+	    >[a] -&gt; [b] -&gt; (a, b)
 forall a. HasCallStack =&gt; a
 </span
-	><span class="hs-identifier hs-var"
-	>undefined</span
+	    ><span class="hs-identifier hs-var"
+	    >undefined</span
+	    ></span
+	  ></span
 	></span
       ><span
       >
@@ -1691,30 +1703,32 @@ forall a. HasCallStack =&gt; a
 </span
       ><span id="line-46"
       ></span
+      ><span id=""
       ><span id="mon"
-      ><span class="annot"
-	><span class="annottext"
-	  >mon :: (a -&gt; m a) -&gt; m a
+	><span class="annot"
+	  ><span class="annottext"
+	    >mon :: (a -&gt; m a) -&gt; m a
 </span
-	  ><a href="Polymorphism.html#mon"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >mon</span
-	    ></a
+	    ><a href="Polymorphism.html#mon"
+	    ><span class="hs-identifier hs-var hs-var"
+	      >mon</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>(a -&gt; m a) -&gt; m a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=</span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >(a -&gt; m a) -&gt; m a
 forall a. HasCallStack =&gt; a
 </span
-	><span class="hs-identifier hs-var"
-	>undefined</span
+	  ><span class="hs-identifier hs-var"
+	  >undefined</span
+	  ></span
 	></span
       ><span
       >
@@ -1837,30 +1851,32 @@ forall a. HasCallStack =&gt; a
 </span
       ><span id="line-49"
       ></span
+      ><span id=""
       ><span id="mon%27"
-      ><span class="annot"
-	><span class="annottext"
-	  >mon' :: (a -&gt; m a) -&gt; m a
+	><span class="annot"
+	  ><span class="annottext"
+	    >mon' :: (a -&gt; m a) -&gt; m a
 </span
-	  ><a href="Polymorphism.html#mon%27"
-	  ><span class="hs-identifier hs-var hs-var"
-	    >mon'</span
-	    ></a
+	    ><a href="Polymorphism.html#mon%27"
+	    ><span class="hs-identifier hs-var hs-var"
+	      >mon'</span
+	      ></a
+	    ></span
 	  ></span
-	></span
-      ><span
-      > </span
-      ><span class="hs-glyph"
-      >=</span
-      ><span
-      > </span
-      ><span class="annot"
-      ><span class="annottext"
-	>(a -&gt; m a) -&gt; m a
+	><span
+	> </span
+	><span class="hs-glyph"
+	>=</span
+	><span
+	> </span
+	><span class="annot"
+	><span class="annottext"
+	  >(a -&gt; m a) -&gt; m a
 forall a. HasCallStack =&gt; a
 </span
-	><span class="hs-identifier hs-var"
-	>undefined</span
+	  ><span class="hs-identifier hs-var"
+	  >undefined</span
+	  ></span
 	></span
       ><span
       >

--- a/hypsrc-test/ref/src/Records.html
+++ b/hypsrc-test/ref/src/Records.html
@@ -488,6 +488,7 @@
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -509,6 +510,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -530,6 +532,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -672,6 +675,7 @@ y :: Point -&gt; Int
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -693,6 +697,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -714,6 +719,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>*</span
@@ -898,6 +904,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -1021,6 +1028,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -1362,6 +1370,7 @@ x :: Point -&gt; Int
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span
@@ -1411,6 +1420,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annottext"
 	>Int -&gt; Int -&gt; Int
 forall a. Num a =&gt; a -&gt; a -&gt; a
+External instance of the constraint type Num Int
 </span
 	><span class="hs-operator hs-var"
 	>+</span


### PR DESCRIPTION
Now that https://gitlab.haskell.org/ghc/ghc/-/merge_requests/1286 has landed, we can take advantage of it in haddock by displaying links to instance definitions on hover.

![demo](https://s6.gifyu.com/images/JumpToInstance.gif)

You can browse through all the docs of ghc+boot libs here: http://78.47.113.11/docs/html/libraries/

/ping @harpocrates since I think this will require more of a review than the usual PR to `ghc-head`