### PR TITLE
Add support for QualifiedDo in Haddock

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
@@ -175,7 +175,7 @@ classify tok =
     ITdata                 -> TkKeyword
     ITdefault              -> TkKeyword
     ITderiving             -> TkKeyword
-    ITdo                   -> TkKeyword
+    ITdo                {} -> TkKeyword
     ITelse                 -> TkKeyword
     IThiding               -> TkKeyword
     ITforeign              -> TkKeyword
@@ -208,7 +208,7 @@ classify tok =
     ITcapiconv             -> TkKeyword
     ITprimcallconv         -> TkKeyword
     ITjavascriptcallconv   -> TkKeyword
-    ITmdo                  -> TkKeyword
+    ITmdo               {} -> TkKeyword
     ITfamily               -> TkKeyword
     ITrole                 -> TkKeyword
     ITgroup                -> TkKeyword


### PR DESCRIPTION
This changes the matches for `ITdo` and `ITmdo` so that they match the new `ITdo Expr` in the `-XQualifiedDo` extension, but in a backwards compatible manner.