### PR TITLE
Allow more characters in anchor following module reference

### DIFF
--- a/haddock-library/test/Documentation/Haddock/ParserSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/ParserSpec.hs
@@ -431,6 +431,9 @@ spec = do
       it "accepts anchor reference syntax as DocModule" $ do
         "\"Foo#bar\"" `shouldParseTo` DocModule "Foo#bar"
 
+      it "accepts anchor with hyphen as DocModule" $ do
+        "\"Foo#bar-baz\"" `shouldParseTo` DocModule "Foo\\#bar-baz"
+
       it "accepts old anchor reference syntax as DocModule" $ do
         "\"Foo\\#bar\"" `shouldParseTo` DocModule "Foo\\#bar"
 


### PR DESCRIPTION
Currently the only allowed characters in a `"module#anchor`" anchor are alphanums plus `[.#\\]`. In particular it rejects hyphens `-`, which are pretty common in anchors.

This PR refines the parsing of anchors in modules to allow more characters, and also reject spaces (because they're technically [not allowed by HTML](https://www.w3.org/TR/html51/dom.html#the-id-attribute)).