### PR TITLE
loosen hspec and QuickCheck constraints to fit stack lts-14.27

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -173,8 +173,8 @@ test-suite spec
                , ghc-paths       ^>= 0.1.0.9
                , haddock-library ^>= 1.7.0
                , xhtml           ^>= 3000.2.2
-               , hspec           >= 2.4.4 && < 2.7
-               , QuickCheck      >= 2.11  && < 2.13
+               , hspec           >= 2.4.4 && < 2.8
+               , QuickCheck      >= 2.11  && < 2.14
 
   -- Versions for the dependencies below are transitively pinned by
   -- the non-reinstallable `ghc` package and hence need no version

--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -76,8 +76,8 @@ test-suite spec
     , bytestring   >= 0.9.2.1 && < 0.11
     , containers   >= 0.4.2.1 && < 0.7
     , transformers   >= 0.3.0   && < 0.6
-    , hspec        >= 2.4.4    && < 2.7
-    , QuickCheck   >= 2.11     && < 2.13
+    , hspec        >= 2.4.4    && < 2.8
+    , QuickCheck   >= 2.11     && < 2.14
     , text         >= 1.2.3.0  && < 1.3
     , parsec       >= 3.1.13.0 && < 3.2
     , deepseq      >= 1.3     && < 1.5
@@ -97,7 +97,7 @@ test-suite fixtures
     , directory             ^>= 1.3.0.2
     , filepath              ^>= 1.4.1.2
     , optparse-applicative  ^>= 0.14.0.0
-    , tree-diff             ^>= 0.0.0.1
+    , tree-diff             ^>= 0.1
 
   -- Depend on the library.
   build-depends:


### PR DESCRIPTION
before : `stack init` selects lts-13.11 (GHC 8.6.3), 
after: `stack init` selects lts-14.27 (latest for GHC 8.6.5) 