### PR TITLE
Enable two warnings

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -65,7 +65,8 @@ library
 
   hs-source-dirs: src
 
-  ghc-options: -funbox-strict-fields -Wall -fwarn-tabs -O2
+  ghc-options: -funbox-strict-fields -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wincomplete-record-updates -O2
+
   ghc-options: -Wall
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances

--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Haddock.Backends.Hoogle

--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Haddock.Backends.Hyperlinker.Parser (parse) where
 
 import Control.Applicative ( Alternative(..) )

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 {-# OPTIONS_HADDOCK hide #-}
 -----------------------------------------------------------------------------
 -- |

--- a/haddock-api/src/Haddock/Interface/AttachInstances.hs
+++ b/haddock-api/src/Haddock/Interface/AttachInstances.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE MagicHash, BangPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Haddock.Interface.AttachInstances

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 ----------------------------------------------------------------------------
 -- |
 -- Module      :  Haddock.Interface.Rename

--- a/haddock-api/src/Haddock/Interface/Specialize.hs
+++ b/haddock-api/src/Haddock/Interface/Specialize.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GADTs #-}
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 
 module Haddock.Interface.Specialize
     ( specializeInstHead

--- a/haddock-api/src/Haddock/Utils.hs
+++ b/haddock-api/src/Haddock/Utils.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
+
+{-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Haddock.Utils

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -60,7 +60,7 @@ executable haddock
   default-language:     Haskell2010
   main-is:              Main.hs
   hs-source-dirs:       driver
-  ghc-options:          -funbox-strict-fields -Wall -fwarn-tabs -O2 -threaded
+  ghc-options:          -funbox-strict-fields -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wincomplete-record-updates -O2 -threaded
 
   -- haddock typically only supports a single GHC major version
   build-depends:


### PR DESCRIPTION
because they will be soon be added to -Wall.

See https://gitlab.haskell.org/ghc/ghc/-/issues/15656

Last time I attempted to get this into ghc-head I didn't follow the usual procedure and it caused problems. This time, by way of extra caution, I explain how I am explicitly following @bgamari's [instructions](https://github.com/haskell/haddock/pull/1268#issuecomment-745614890):

1. push your branch to a wip/ branch on https://gitlab.haskell.org/ghc/haddock (and your GitHub fork, if you want)

    ✔ It is at https://gitlab.haskell.org/ghc/haddock/-/tree/wip/tomjaguarpaw1-haddock-warnings

2. open a GHC merge request bumping the haddock submodule.

    ✔ It is at https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4614

3. wait for the merge request to pass CI and get approval

    ✔ It has passed CI and @goldfirere has approved
    
4. push your haddock changes to GitHub (if you haven't already) and request that they be merged to the ghc-head branch

    ✔ This is that request

5. wait for the GitHub MR to be merged; after it's merged queue up the GHC MR for merge

    ⌛ Waiting for merge of this PR


