### PR TITLE
Haddock as a Plugin

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -61,6 +61,7 @@ library
                , exceptions
                , filepath
                , ghc-boot
+               , mtl
                , transformers
 
   hs-source-dirs: src

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -151,11 +151,16 @@ haddockWithGhc ghc args = handleTopExceptions $ do
   sinceQual <- rightOrThrowE (sinceQualification flags)
 
   -- inject dynamic-too into flags before we proceed
-  flags' <- ghc flags $ do
+  flags'' <- ghc flags $ do
         df <- getDynFlags
         case lookup "GHC Dynamic" (compilerInfo df) of
           Just "YES" -> return $ Flag_OptGhc "-dynamic-too" : flags
           _ -> return flags
+
+  flags' <- pure $ case optParCount flags'' of
+    Nothing       -> flags''
+    Just Nothing  -> Flag_OptGhc "-j" : flags''
+    Just (Just n) -> Flag_OptGhc ("-j" ++ show n) : flags''
 
   -- bypass the interface version check
   let noChecks = Flag_BypassInterfaceVersonCheck `elem` flags

--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -39,7 +39,7 @@ import System.FilePath
 import Data.Char
 import Control.Monad
 import Data.Maybe
-import Data.List
+import Data.List (sort)
 import Prelude hiding ((<>))
 
 import Haddock.Doc (combineDocumentation)

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -34,7 +34,6 @@ import GHC.Driver.Ppr (showPpr )
 import GHC.Types.Name
 import GHC.Unit.Module
 import GHC
-import GHC.Core.Class
 import GHC.Driver.Session
 import GHC.Types.SrcLoc  ( advanceSrcLoc )
 import GHC.Types.Var     ( Specificity, VarBndr(..), TyVarBinder
@@ -402,14 +401,6 @@ modifySessionDynFlags f = do
   _ <- setSessionDynFlags (f dflags)
   return ()
 
-
--- Extract the minimal complete definition of a Name, if one exists
-minimalDef :: GhcMonad m => Name -> m (Maybe ClassMinimalDef)
-minimalDef n = do
-  mty <- lookupGlobalName n
-  case mty of
-    Just (ATyCon (tyConClass_maybe -> Just c)) -> return . Just $ classMinimalDef c
-    _ -> return Nothing
 
 -------------------------------------------------------------------------------
 -- * DynFlags

--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -163,9 +163,15 @@ processModule verbosity modsum flags modMap instIfaceMap = do
     NotBoot -> do
       unit_state <- hsc_units <$> getSession
       out verbosity verbose "Creating interface..."
+
+      let
+        mod_summary = pm_mod_summary (tm_parsed_module tm)
+        tcg_gbl_env = fst (tm_internals_ tm)
+
       (interface, msgs) <- {-# SCC createIterface #-}
                           withTimingD "createInterface" (const ()) $ do
-                            runWriterGhc $ createInterface tm unit_state flags modMap instIfaceMap
+                            runWriterGhc $ createInterface1 flags unit_state
+                              mod_summary tcg_gbl_env modMap instIfaceMap
 
       -- We need to keep track of which modules were somehow in scope so that when
       -- Haddock later looks for instances, it also looks in these modules too.

--- a/haddock-api/src/Haddock/Interface/LexParseRn.hs
+++ b/haddock-api/src/Haddock/Interface/LexParseRn.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -Wwarn #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns #-}
   -----------------------------------------------------------------------------
 -- |
@@ -22,7 +23,7 @@ module Haddock.Interface.LexParseRn
 import GHC.Types.Avail
 import Control.Arrow
 import Control.Monad
-import Data.List
+import Data.List ((\\), maximumBy)
 import Data.Ord
 import Documentation.Haddock.Doc (metaDocConcat)
 import GHC.Driver.Session (languageExtensions)

--- a/haddock-api/src/Haddock/Interface/Rename.hs
+++ b/haddock-api/src/Haddock/Interface/Rename.hs
@@ -29,7 +29,6 @@ import GHC.Builtin.Types (eqTyCon_RDR)
 import Control.Applicative
 import Control.Arrow ( first )
 import Control.Monad hiding (mapM)
-import Data.List
 import qualified Data.Map as Map hiding ( Map )
 import Prelude hiding (mapM)
 import GHC.HsToCore.Docs

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -27,7 +27,7 @@ import Haddock.Utils hiding (out)
 import Control.Monad
 import Data.Array
 import Data.IORef
-import Data.List
+import Data.List (mapAccumR)
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Word

--- a/haddock-api/src/Haddock/Options.hs
+++ b/haddock-api/src/Haddock/Options.hs
@@ -46,11 +46,10 @@ import           Data.Version
 import           Control.Applicative
 import           Distribution.Verbosity
 import           GHC.Data.FastString
-import           GHC ( DynFlags, Module, moduleUnit )
+import           GHC ( Module, moduleUnit )
 import           GHC.Unit.State
 import           Haddock.Types
 import           Haddock.Utils
-import           GHC.Unit.State
 import           System.Console.GetOpt
 import qualified Text.ParserCombinators.ReadP as RP
 

--- a/haddock-api/src/Haddock/Options.hs
+++ b/haddock-api/src/Haddock/Options.hs
@@ -24,6 +24,7 @@ module Haddock.Options (
   optSourceCssFile,
   sourceUrls,
   wikiUrls,
+  optParCount,
   optDumpInterfaceFile,
   optShowInterfaceFile,
   optLaTeXStyle,
@@ -110,6 +111,7 @@ data Flag
   | Flag_PackageVersion String
   | Flag_Reexport String
   | Flag_SinceQualification String
+  | Flag_ParCount (Maybe Int)
   deriving (Eq, Show)
 
 
@@ -221,7 +223,9 @@ options backwardsCompat =
     Option [] ["package-version"] (ReqArg Flag_PackageVersion "VERSION")
       "version of the package being documented in usual x.y.z.w format",
     Option []  ["since-qual"] (ReqArg Flag_SinceQualification "QUAL")
-      "package qualification of @since, one of\n'always' (default) or 'only-external'"
+      "package qualification of @since, one of\n'always' (default) or 'only-external'",
+    Option ['j'] [] (OptArg (\count -> Flag_ParCount (fmap read count)) "n")
+      "load modules in parallel"
   ]
 
 
@@ -304,10 +308,11 @@ optShowInterfaceFile flags = optLast [ str | Flag_ShowInterface str <- flags ]
 optLaTeXStyle :: [Flag] -> Maybe String
 optLaTeXStyle flags = optLast [ str | Flag_LaTeXStyle str <- flags ]
 
-
 optMathjax :: [Flag] -> Maybe String
 optMathjax flags = optLast [ str | Flag_Mathjax str <- flags ]
 
+optParCount :: [Flag] -> Maybe (Maybe Int)
+optParCount flags = optLast [ n | Flag_ParCount n <- flags ]
 
 qualification :: [Flag] -> Either String QualOption
 qualification flags =

--- a/html-test/ref/Bug574.html
+++ b/html-test/ref/Bug574.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug679.html
+++ b/html-test/ref/Bug679.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Bug8.html
+++ b/html-test/ref/Bug8.html
@@ -89,7 +89,7 @@
 	><p class="src"
 	  ><a id="v:-45--45--62-" class="def"
 	    >(--&gt;)</a
-	    > :: p1 -&gt; p2 -&gt; <a href="#" title="Bug8"
+	    > :: p -&gt; p -&gt; <a href="#" title="Bug8"
 	    >Typ</a
 	    > <span class="fixity"
 	    >infix 9</span

--- a/html-test/ref/BundledPatterns.html
+++ b/html-test/ref/BundledPatterns.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"
@@ -52,7 +52,7 @@
 	      >data</span
 	      > <a href="#"
 	      >Vec</a
-	      > :: <a href="#" title="GHC.TypeNats"
+	      > :: <a href="#" title="GHC.TypeLits"
 	      >Nat</a
 	      > -&gt; * -&gt; * <span class="keyword"
 	      >where</span
@@ -82,7 +82,7 @@
 	      >data</span
 	      > <a href="#"
 	      >RTree</a
-	      > :: <a href="#" title="GHC.TypeNats"
+	      > :: <a href="#" title="GHC.TypeLits"
 	      >Nat</a
 	      > -&gt; * -&gt; * <span class="keyword"
 	      >where</span
@@ -123,7 +123,7 @@
 	    >data</span
 	    > <a id="t:Vec" class="def"
 	    >Vec</a
-	    > :: <a href="#" title="GHC.TypeNats"
+	    > :: <a href="#" title="GHC.TypeLits"
 	    >Nat</a
 	    > -&gt; * -&gt; * <span class="keyword"
 	    >where</span
@@ -146,7 +146,7 @@
 		> subscript starting from 0 and
    ending at <code
 		><code
-		  ><a href="#" title="Data.Foldable"
+		  ><a href="#" title="Data.List"
 		    >length</a
 		    ></code
 		  > - 1</code
@@ -285,7 +285,7 @@
 	    >data</span
 	    > <a id="t:RTree" class="def"
 	    >RTree</a
-	    > :: <a href="#" title="GHC.TypeNats"
+	    > :: <a href="#" title="GHC.TypeLits"
 	    >Nat</a
 	    > -&gt; * -&gt; * <span class="keyword"
 	    >where</span

--- a/html-test/ref/BundledPatterns2.html
+++ b/html-test/ref/BundledPatterns2.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"
@@ -52,7 +52,7 @@
 	      >data</span
 	      > <a href="#"
 	      >Vec</a
-	      > :: <a href="#" title="GHC.TypeNats"
+	      > :: <a href="#" title="GHC.TypeLits"
 	      >Nat</a
 	      > -&gt; * -&gt; * <span class="keyword"
 	      >where</span
@@ -84,7 +84,7 @@
 	      >data</span
 	      > <a href="#"
 	      >RTree</a
-	      > :: <a href="#" title="GHC.TypeNats"
+	      > :: <a href="#" title="GHC.TypeLits"
 	      >Nat</a
 	      > -&gt; * -&gt; * <span class="keyword"
 	      >where</span
@@ -125,7 +125,7 @@
 	    >data</span
 	    > <a id="t:Vec" class="def"
 	    >Vec</a
-	    > :: <a href="#" title="GHC.TypeNats"
+	    > :: <a href="#" title="GHC.TypeLits"
 	    >Nat</a
 	    > -&gt; * -&gt; * <span class="keyword"
 	    >where</span
@@ -148,7 +148,7 @@
 		> subscript starting from 0 and
    ending at <code
 		><code
-		  ><a href="#" title="Data.Foldable"
+		  ><a href="#" title="Data.List"
 		    >length</a
 		    ></code
 		  > - 1</code
@@ -283,7 +283,7 @@
 	    >data</span
 	    > <a id="t:RTree" class="def"
 	    >RTree</a
-	    > :: <a href="#" title="GHC.TypeNats"
+	    > :: <a href="#" title="GHC.TypeLits"
 	    >Nat</a
 	    > -&gt; * -&gt; * <span class="keyword"
 	    >where</span

--- a/html-test/ref/QuasiExpr.html
+++ b/html-test/ref/QuasiExpr.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/QuasiQuote.html
+++ b/html-test/ref/QuasiQuote.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/TH.html
+++ b/html-test/ref/TH.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/TH2.html
+++ b/html-test/ref/TH2.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Threaded.html
+++ b/html-test/ref/Threaded.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"

--- a/html-test/ref/Ticket112.html
+++ b/html-test/ref/Ticket112.html
@@ -36,7 +36,7 @@
 	  ><th
 	    >Safe Haskell</th
 	    ><td
-	    >None</td
+	    >Safe-Inferred</td
 	    ></tr
 	  ></table
 	><p class="caption"


### PR DESCRIPTION
This PR implements the interface creation part of Haddock as Typechecker plugin. Being a plugin for the compilation pipeline allows Haddock to exploit GHC parallel type checking which hopefully speeds up running Haddock on large projects.