### PR TITLE
Fix #1201: Add link to the readthedocs in cabal description to show on hackage.

### DIFF
--- a/haddock.cabal
+++ b/haddock.cabal
@@ -23,6 +23,8 @@ description:
   without any documentation annotations, Haddock can generate useful documentation
   from your source code.
   .
+  Documentation for the haddock binary is available at [readthedocs](https://haskell-haddock.readthedocs.io/en/latest/).
+  .
   <<https://cdn.rawgit.com/haskell/haddock/ghc-8.10/doc/cheatsheet/haddocks.svg>>
 license:              BSD-3-Clause
 license-file:         LICENSE


### PR DESCRIPTION
This PR adds a link to the haddock binary readthedocs in the package description, which shows up on hackage.

I agree with #1201 that it's a good idea to add a link to the readthedocs, I hadn't encountered it until I saw this issue. Even though the docs are quite outdated, the base usage has stayed pretty much the same, so I think it's still fruitful to know about them.

Perhaps it could be useful to also include this link in the README. (Or only in the README, as it would be visible in both of the places.)