### PR TITLE
Prepare haddock code for new Language

### DIFF
--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -222,10 +222,7 @@ moduleInfo iface =
           ("Language", lg)
           ] ++ extsForm
         where
-          lg inf = case hmi_language inf of
-            Nothing -> Nothing
-            Just Haskell98 -> Just "Haskell98"
-            Just Haskell2010 -> Just "Haskell2010"
+          lg inf = fmap show (hmi_language inf)
 
           multilineRow :: String -> [String] -> HtmlTable
           multilineRow title xs = (th ! [valign "top"]) << title <-> td << (toLines xs)


### PR DESCRIPTION
With the introduction of GHC2021, the `Languages` data type in GHC will grow. In preparation of that (and to avoid changing haddock with each new language), this change makes the code handle extensions to that data type gracefully.