### PR TITLE
Add import list to Data.List

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hoogle.hs
+++ b/haddock-api/src/Haddock/Backends/Hoogle.hs
@@ -31,7 +31,7 @@ import GHC.Utils.Outputable as Outputable
 import GHC.Parser.Annotation (IsUnicodeSyntax(..))
 
 import Data.Char
-import Data.List
+import Data.List (intercalate, isPrefixOf)
 import Data.Maybe
 import Data.Version
 


### PR DESCRIPTION
```
src/Haddock/Backends/Hoogle.hs:34:8: warning: [-Wcompat-unqualified-imports]
    To ensure compatibility with future core libraries changes
    imports to Data.List should be
    either qualified or have an explicit import list.
   |
34 | import Data.List
   |        ^^^^^^^^^
```