### PR TITLE
Fix search div not scrolling

### DIFF
--- a/haddock-api/resources/html/quick-jump.css
+++ b/haddock-api/resources/html/quick-jump.css
@@ -15,7 +15,6 @@
   left: calc(50% - 22em);
   width: 44em;
   z-index: 1000;
-  pointer-events: none;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Issue: When using the search feature on a haddock page, if the search results overflow the search div scrolling will scroll the page rather than the search div.

Expected behavior: Scrolling inside the scroll div will cause it to scroll
Actual behavior: Scrolling inside the scroll div causes the page to scroll

Tested on Google Chrome, Firefox and Chromium Edge.