### PR TITLE
Remove dubious parseModLink

### DIFF
--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -46,9 +46,6 @@ import GHC.Types.Unique.FM
 import GHC.Types.Unique.Supply
 import GHC.Types.Unique
 
-import Documentation.Haddock.Parser (parseModLink)
-
-
 data InterfaceFile = InterfaceFile {
   ifLinkEnv         :: LinkEnv,
   ifInstalledIfaces :: [InstalledInterface]
@@ -625,7 +622,10 @@ instance (Binary mod, Binary id) => Binary (DocH mod id) where
               -- See note [The DocModule story]
               5 -> do
                     af <- get bh
-                    return (parseModLink af)
+                    return $ DocModule ModLink
+                      { modLinkName  = af
+                      , modLinkLabel = Nothing
+                      }
               6 -> do
                     ag <- get bh
                     return (DocEmphasis ag)

--- a/haddock-library/src/Documentation/Haddock/Parser.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser.hs
@@ -18,7 +18,6 @@
 module Documentation.Haddock.Parser (
   parseString,
   parseParas,
-  parseModLink,
   overIdentifier,
   toRegular,
   Identifier
@@ -136,9 +135,6 @@ parseString = parseText . T.pack
 -- drops leading whitespace.
 parseText :: Text -> DocH mod Identifier
 parseText = parseParagraph . T.dropWhile isSpace . T.filter (/= '\r')
-
-parseModLink :: String -> DocH mod id
-parseModLink s = snd $ parse moduleName (T.pack s)
 
 parseParagraph :: Text -> DocH mod Identifier
 parseParagraph = snd . parse p


### PR DESCRIPTION
Instead construct the ModLink value directly when parsing.