### PR TITLE
Clarify build instructions are for ghc-9.0 branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ so that documentation built within GHC can benefit from it.
 
 #### Using `cabal`
 
-Requires cabal `>= 3.4` and GHC `== 9.0`:
+Building the `ghc-9.0` branch requires cabal `>= 3.4` and GHC `== 9.0`:
 
 ```bash
 cabal v2-build all --enable-tests


### PR DESCRIPTION
Tried to build `ghc-head` using these instructions before realizing that the "GHC `== 9.0`" requirement applies specifically to the `ghc-9.0` branch. (I presume that building `ghc-head` actually requires a GHC that one has built from the latest GitLab source.)

I think this augmentation of the instructions would help clarify the situation for newcomers.
