### PR TITLE
Add import list to Data.List in Haddock.Interface.Create

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -68,6 +68,7 @@ library
   ghc-options: -funbox-strict-fields -O2
                -Wall
                -Wcompat
+               -Wcompat-unqualified-imports
                -Widentities
                -Wredundant-constraints
                -Wnoncanonical-monad-instances

--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -35,7 +35,7 @@ import Control.Monad.Writer.Strict hiding (tell)
 import Data.Bitraversable
 import qualified Data.Map as M
 import Data.Map (Map)
-import Data.List
+import Data.List (foldl', find)
 import Data.Maybe
 import Data.Traversable
 import GHC.Stack


### PR DESCRIPTION
This change is in `ghc-9.0` branch, but isn't in `ghc-head`.

To help it not appear again I added a compat warning.