### PR TITLE
Fix 1261: replace dead links in docs

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -25,7 +25,7 @@ in mind:
    The easier it is to write documentation, the more likely the
    programmer is to do it. Haddock therefore uses lightweight markup in
    its annotations, taking several ideas from
-   `IDoc <http://www.cse.unsw.edu.au/~chak/haskell/idoc/>`__. In fact,
+   `IDoc <http://freshmeat.sourceforge.net/projects/idoc/>`__. In fact,
    Haddock can understand IDoc-annotated source code.
 
 -  The documentation should not expose any of the structure of the
@@ -149,11 +149,11 @@ Acknowledgements
 Several documentation systems provided the inspiration for Haddock, most
 notably:
 
--  `IDoc <http://www.cse.unsw.edu.au/~chak/haskell/idoc/>`__
+-  `IDoc <http://freshmeat.sourceforge.net/projects/idoc/>`__
 
--  `HDoc <http://www.fmi.uni-passau.de/~groessli/hdoc/>`__
+-  `HDoc <https://web.archive.org/web/20010603070527/http://www.fmi.uni-passau.de/~groessli/hdoc/>`__
 
--  `Doxygen <http://www.stack.nl/~dimitri/doxygen/>`__
+-  `Doxygen <https://www.doxygen.nl/index.html>`__
 
 and probably several others I've forgotten.
 


### PR DESCRIPTION
Fixes #1261. I used archive.org for one of the links, because the original page isn't available anywhere else anymore.