### PR TITLE
Select Cabal 3.4.0.0 instead of 3.4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.4"]
+        cabal: ["3.4.0.0"]
         ghc:
           - "9.0.1"
 


### PR DESCRIPTION
This is a fix for the following CI failure:

```
  /opt/hostedtoolcache/ghcup/0.1.12/x64/ghcup install cabal 3.4
  [ Warn  ] New Cabal version available: 3.4.0.0. To upgrade, run 'ghcup install cabal 3.4.0.0'
  [ Error ] No available Cabal version for 3.4
Error: All install methods for cabal 3.4 failed
```