### PR TITLE
Add support for labeled module references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         os: [ubuntu-latest]
         cabal: ["3.2"]
         ghc:
-          - "8.10.1"
-          - "8.10.2"
+          - "8.10.3"
+          - "8.10.4"
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Changes in 2.24.1
+
+ * Add support for labeled module references (#1360)
+
 ## Changes in 2.24.0
 
  * Reify oversaturated data family instances correctly (#1103)

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -174,7 +174,7 @@ test-suite spec
 
   build-depends: ghc             ^>= 8.10
                , ghc-paths       ^>= 0.1.0.12
-               , haddock-library ^>= 1.9.0
+               , haddock-library ^>= 1.10.0
                , xhtml           ^>= 3000.2.2
                , hspec           >= 2.4.4 && < 2.8
                , QuickCheck      >= 2.11  && ^>= 2.14

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:        2.0
 name:                 haddock-api
-version:              2.24.0
+version:              2.24.1
 synopsis:             A documentation-generation tool for Haskell libraries
 description:          Haddock is a documentation-generation tool for Haskell
                       libraries
@@ -46,7 +46,7 @@ library
   build-depends: base            ^>= 4.14.0
                , ghc             ^>= 8.10
                , ghc-paths       ^>= 0.1.0.9
-               , haddock-library ^>= 1.9.0
+               , haddock-library ^>= 1.10.0
                , xhtml           ^>= 3000.2.2
 
   -- Versions for the dependencies below are transitively pinned by

--- a/haddock-api/src/Haddock/InterfaceFile.hs
+++ b/haddock-api/src/Haddock/InterfaceFile.hs
@@ -45,9 +45,6 @@ import UniqFM
 import UniqSupply
 import Unique
 
-import Documentation.Haddock.Parser (parseModLink)
-
-
 data InterfaceFile = InterfaceFile {
   ifLinkEnv         :: LinkEnv,
   ifInstalledIfaces :: [InstalledInterface]
@@ -624,7 +621,10 @@ instance (Binary mod, Binary id) => Binary (DocH mod id) where
               -- See note [The DocModule story]
               5 -> do
                     af <- get bh
-                    return (parseModLink af)
+                    return $ DocModule ModLink
+                      { modLinkName  = af
+                      , modLinkLabel = Nothing
+                      }
               6 -> do
                     ag <- get bh
                     return (DocEmphasis ag)

--- a/haddock-library/CHANGES.md
+++ b/haddock-library/CHANGES.md
@@ -1,3 +1,7 @@
+## Changes in version 1.10.0
+
+ * Add support for labeled module references (#1360)
+
 ## Changes in version 1.9.0
 
  * Fix build-time regression for `base < 4.7` (#1119)

--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -1,6 +1,6 @@
 cabal-version:        2.2
 name:                 haddock-library
-version:              1.9.0
+version:              1.10.0
 synopsis:             Library exposing some functionality of Haddock.
 
 description:          Haddock is a documentation-generation tool for Haskell

--- a/haddock-library/src/Documentation/Haddock/Parser.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser.hs
@@ -18,7 +18,6 @@
 module Documentation.Haddock.Parser (
   parseString,
   parseParas,
-  parseModLink,
   overIdentifier,
   toRegular,
   Identifier
@@ -136,9 +135,6 @@ parseString = parseText . T.pack
 -- drops leading whitespace.
 parseText :: Text -> DocH mod Identifier
 parseText = parseParagraph . T.dropWhile isSpace . T.filter (/= '\r')
-
-parseModLink :: String -> DocH mod id
-parseModLink s = snd $ parse moduleName (T.pack s)
 
 parseParagraph :: Text -> DocH mod Identifier
 parseParagraph = snd . parse p

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -1,6 +1,6 @@
 cabal-version:        2.4
 name:                 haddock
-version:              2.24.0
+version:              2.24.1
 synopsis:             A documentation-generation tool for Haskell libraries
 description:
   This is Haddock, a tool for automatically generating documentation

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -146,7 +146,7 @@ executable haddock
   else
     -- in order for haddock's advertised version number to have proper meaning,
     -- we pin down to a single haddock-api version.
-    build-depends:  haddock-api == 2.24.0
+    build-depends:  haddock-api == 2.24.1
 
 test-suite html-test
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
Support a markdown-style way of annotating module references. For instance

```
-- | [label]("Module.Name#anchor")
```

will create a link that points to the same place as the module
reference "Module.Name#anchor" but the text displayed on the link will
be "label".