### PR TITLE
Allow optparse-applicative 0.16 and tree-diff 0.2

### DIFF
--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -117,8 +117,8 @@ test-suite fixtures
     , base-compat           ^>= 0.9.3 || ^>= 0.11.0
     , directory             ^>= 1.3.0.2
     , filepath              ^>= 1.4.1.2
-    , optparse-applicative  ^>= 0.15
-    , tree-diff             ^>= 0.1
+    , optparse-applicative  ^>= 0.15 || ^>= 0.16
+    , tree-diff             ^>= 0.1 || ^>= 0.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
Builds fine and all tests pass here.