### PR TITLE
Add UnitId to Target record

### DIFF
--- a/haddock-api/src/Haddock/Interface.hs
+++ b/haddock-api/src/Haddock/Interface.hs
@@ -158,7 +158,7 @@ createIfaces verbosity modules flags instIfaceMap = do
   -- alive to be able to find all the instances.
   modifySession installHaddockPlugin
 
-  targets <- mapM (\filePath -> guessTarget filePath Nothing) modules
+  targets <- mapM (\filePath -> guessTarget filePath Nothing Nothing) modules
   setTargets targets
 
   loadOk <- withTimingM "load" (const ()) $


### PR DESCRIPTION
This way we always know to which home-unit a given target belongs to.
So far, there only exists a single home-unit at a time, but it
enables having multiple home-units at the same time.

Add the changes back from https://github.com/haskell/haddock/pull/1311 to merge https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4937 again.

CI is not green yet, afaict, I will ping when it is.

cc @Ericson2314, @Kleidukos, @hsyl20 