### PR TITLE
Rename pprError to mkParserErr

### DIFF
--- a/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker/Parser.hs
@@ -14,7 +14,7 @@ import GHC.Types.SourceText
 import GHC.Driver.Session
 import GHC.Utils.Error     ( pprLocMsgEnvelope )
 import GHC.Data.FastString ( mkFastString )
-import GHC.Parser.Errors.Ppr ( pprError )
+import GHC.Parser.Errors.Ppr ( mkParserErr )
 import GHC.Parser.Lexer    as Lexer
                            ( P(..), ParseResult(..), PState(..), Token(..)
                            , initParserState, lexer, mkParserOpts, getErrorMessages)
@@ -40,7 +40,7 @@ parse
 parse dflags fpath bs = case unP (go False []) initState of
     POk _ toks -> reverse toks
     PFailed pst ->
-      let err:_ = bagToList (fmap pprError (getErrorMessages pst)) in
+      let err:_ = bagToList (fmap mkParserErr (getErrorMessages pst)) in
       panic $ showSDoc dflags $
         text "Hyperlinker parse error:" $$ pprLocMsgEnvelope err
   where


### PR DESCRIPTION
See this GHC MR: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/5172

In particular, in the context of GHC's [18516](https://gitlab.haskell.org/ghc/ghc/-/issues/18516) we are refactoring the error & warning structure, and this is just a small stepping stone.

This is also the first time I am executing the "plan" @hsyl20 gave me as part of this [other PR](https://github.com/haskell/haddock/pull/1310#issuecomment-773898454) so I beg your pardon if I am doing it wrong 😉 

In particular, let me recap what I have done: I have pushed into a `wip/xxx` branch directly into **ghc's haddock fork** (and my local Github's fork of Haddock), and now I am opening this PR here. My understanding is that now we merge this, the ghc's fork will _mirror_ the merge commit and then I can proceed to rebase my GHC MR so that it doesn't point anymore to an Haddock's `wip/` branch (but rather the right commit in `ghc-head`), so Marge won't complain when trying to merge my work. 

Am I on the right track?
