### PR TITLE
Update html-test ref, the variables got renamed.

### DIFF
--- a/html-test/ref/Instances.html
+++ b/html-test/ref/Instances.html
@@ -1300,9 +1300,9 @@
 			  >baz</a
 			  > :: [c] -&gt; (<span class="keyword"
 			  >forall</span
-			  > a. a -&gt; a) -&gt; (b, <span class="keyword"
+			  > a1. a1 -&gt; a1) -&gt; (b, <span class="keyword"
 			  >forall</span
-			  > c0. c0 -&gt; [c]) -&gt; (b, c1) <a href="#" class="selflink"
+			  > c1. c1 -&gt; [c]) -&gt; (b, c0) <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1310,9 +1310,9 @@
 			  >baz'</a
 			  > :: b -&gt; (<span class="keyword"
 			  >forall</span
-			  > b. b -&gt; [c]) -&gt; (<span class="keyword"
+			  > b1. b1 -&gt; [c]) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b. b -&gt; [c]) -&gt; [(b, [c])] <a href="#" class="selflink"
+			  > b1. b1 -&gt; [c]) -&gt; [(b, [c])] <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1320,9 +1320,9 @@
 			  >baz''</a
 			  > :: b -&gt; (<span class="keyword"
 			  >forall</span
-			  > b. (<span class="keyword"
+			  > b1. (<span class="keyword"
 			  >forall</span
-			  > b. b -&gt; [c]) -&gt; c0) -&gt; <span class="keyword"
+			  > b2. b2 -&gt; [c]) -&gt; c0) -&gt; <span class="keyword"
 			  >forall</span
 			  > c1. c1 -&gt; b <a href="#" class="selflink"
 			  >#</a
@@ -1362,9 +1362,9 @@
 			  >baz</a
 			  > :: (a -&gt; b) -&gt; (<span class="keyword"
 			  >forall</span
-			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
+			  > a1. a1 -&gt; a1) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c. c -&gt; a -&gt; b) -&gt; (b0, c) <a href="#" class="selflink"
+			  > c1. c1 -&gt; a -&gt; b) -&gt; (b0, c) <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1374,7 +1374,7 @@
 			  >forall</span
 			  > b1. b1 -&gt; a -&gt; b) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; a -&gt; b) -&gt; [(b0, a -&gt; b)] <a href="#" class="selflink"
+			  > b1. b1 -&gt; a -&gt; b) -&gt; [(b0, a -&gt; b)] <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1386,7 +1386,7 @@
 			  >forall</span
 			  > b2. b2 -&gt; a -&gt; b) -&gt; c) -&gt; <span class="keyword"
 			  >forall</span
-			  > c. c -&gt; b0 <a href="#" class="selflink"
+			  > c1. c1 -&gt; b0 <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			></div
@@ -1428,11 +1428,11 @@
 			  >Quux</a
 			  > a b c -&gt; (<span class="keyword"
 			  >forall</span
-			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
+			  > a1. a1 -&gt; a1) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c0. c0 -&gt; <a href="#" title="Instances"
+			  > c1. c1 -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a b c) -&gt; (b0, c1) <a href="#" class="selflink"
+			  > a b c) -&gt; (b0, c0) <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1444,7 +1444,7 @@
 			  >Quux</a
 			  > a b c) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; <a href="#" title="Instances"
+			  > b1. b1 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; [(b0, <a href="#" title="Instances"
 			  >Quux</a
@@ -1500,9 +1500,9 @@
 			  >baz</a
 			  > :: (a, b, c) -&gt; (<span class="keyword"
 			  >forall</span
-			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
+			  > a1. a1 -&gt; a1) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c0. c0 -&gt; (a, b, c)) -&gt; (b0, c1) <a href="#" class="selflink"
+			  > c1. c1 -&gt; (a, b, c)) -&gt; (b0, c0) <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1512,7 +1512,7 @@
 			  >forall</span
 			  > b1. b1 -&gt; (a, b, c)) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; (a, b, c)) -&gt; [(b0, (a, b, c))] <a href="#" class="selflink"
+			  > b1. b1 -&gt; (a, b, c)) -&gt; [(b0, (a, b, c))] <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1562,9 +1562,9 @@
 			  >baz</a
 			  > :: (a, [b], b, a) -&gt; (<span class="keyword"
 			  >forall</span
-			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
+			  > a1. a1 -&gt; a1) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c. c -&gt; (a, [b], b, a)) -&gt; (b0, c) <a href="#" class="selflink"
+			  > c1. c1 -&gt; (a, [b], b, a)) -&gt; (b0, c) <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1574,7 +1574,7 @@
 			  >forall</span
 			  > b1. b1 -&gt; (a, [b], b, a)) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; (a, [b], b, a)) -&gt; [(b0, (a, [b], b, a))] <a href="#" class="selflink"
+			  > b1. b1 -&gt; (a, [b], b, a)) -&gt; [(b0, (a, [b], b, a))] <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1586,7 +1586,7 @@
 			  >forall</span
 			  > b2. b2 -&gt; (a, [b], b, a)) -&gt; c) -&gt; <span class="keyword"
 			  >forall</span
-			  > c. c -&gt; b0 <a href="#" class="selflink"
+			  > c1. c1 -&gt; b0 <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			></div
@@ -1844,11 +1844,11 @@
 			  >Quux</a
 			  > a b c -&gt; (<span class="keyword"
 			  >forall</span
-			  > a0. a0 -&gt; a0) -&gt; (b0, <span class="keyword"
+			  > a1. a1 -&gt; a1) -&gt; (b0, <span class="keyword"
 			  >forall</span
-			  > c0. c0 -&gt; <a href="#" title="Instances"
+			  > c1. c1 -&gt; <a href="#" title="Instances"
 			  >Quux</a
-			  > a b c) -&gt; (b0, c1) <a href="#" class="selflink"
+			  > a b c) -&gt; (b0, c0) <a href="#" class="selflink"
 			  >#</a
 			  ></p
 			><p class="src"
@@ -1860,7 +1860,7 @@
 			  >Quux</a
 			  > a b c) -&gt; (<span class="keyword"
 			  >forall</span
-			  > b2. b2 -&gt; <a href="#" title="Instances"
+			  > b1. b1 -&gt; <a href="#" title="Instances"
 			  >Quux</a
 			  > a b c) -&gt; [(b0, <a href="#" title="Instances"
 			  >Quux</a


### PR DESCRIPTION
PR corresponding to ghc/!5555 which caused a change in ModDetails in case of NoBackend. Now the initModDetails is used to recreate the ModDetails from interface and in-memory ModDetails is not used.

Ref: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/5555