### PR TITLE
CI configuration for ghc-head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: ["ghc-9.0"]
+    branches: ["ghc-head"]
 
 jobs:
   cabal:
@@ -13,15 +13,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.4"]
+        cabal: ["3.4.0.0"]
         ghc:
-          - "9.0.1"
+          - "head"
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/ghc-9.0'
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/ghc-head'
 
-    - uses: haskell/actions/setup@v1
+    - name: Install gmp and tinfo
+      run: |
+        sudo -- sh -c "apt-get update"
+        sudo -- sh -c "apt-get -y install libgmp-dev libtinfo-dev"
+
+    - uses: haskell/actions/setup@main
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -30,7 +35,6 @@ jobs:
 
     - name: Prepare environment
       run: echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
-
 
     - name: Freeze
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -3,12 +3,19 @@ packages: ./
           ./haddock-library
           ./haddock-test
 
-with-compiler: ghc-9.0
+with-compiler: ghc-head
 
 allow-newer:
   ghc-paths:Cabal,
   *:base,
-  *:ghc-prim
+  *:ghc-prim,
+  tree-diff:time
+
+package haddock-library
+ tests: False
+
+package haddock-api
+  tests: False
 
 -- Pinning the index-state helps to make reasonably CI deterministic
 index-state: 2021-01-24T12:09:34Z

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -44,7 +44,7 @@ library
 
   -- this package typically supports only single major versions
   build-depends: base            ^>= 4.16.0
-               , ghc             ^>= 9.1
+               , ghc             ^>= 9.3
                , ghc-paths       ^>= 0.1.0.9
                , haddock-library ^>= 1.9.0
                , xhtml           ^>= 3000.2.2

--- a/haddock-library/fixtures/Fixtures.hs
+++ b/haddock-library/fixtures/Fixtures.hs
@@ -9,8 +9,7 @@ import Data.Foldable (traverse_)
 import Data.List (foldl')
 import Data.Traversable (for)
 import GHC.Generics (Generic)
-import Prelude ()
-import Prelude.Compat
+import Prelude
 import System.Directory (getDirectoryContents)
 import System.Exit (exitFailure)
 import System.FilePath

--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -39,7 +39,7 @@ common lib-defaults
 
   build-depends:
     , base         >= 4.5     && < 4.17
-    , bytestring   ^>= 0.9.2.1 || ^>= 0.10.0.0
+    , bytestring   ^>= 0.9.2.1 || ^>= 0.10.0.0 || ^>= 0.11.0.0
     , containers   ^>= 0.4.2.1 || ^>= 0.5.0.0 || ^>= 0.6.0.1
     , transformers ^>= 0.3.0.0 || ^>= 0.4.1.0 || ^>= 0.5.0.0
     , text         ^>= 1.2.3.0
@@ -87,8 +87,7 @@ test-suite spec
     Documentation.Haddock.Parser.Identifier
 
   build-depends:
-    , base-compat  ^>= 0.9.3 || ^>= 0.11.0
-    , QuickCheck   ^>= 2.11  || ^>= 2.13.2 || ^>= 2.14 
+    , QuickCheck   ^>= 2.11  || ^>= 2.13.2 || ^>= 2.14
     , deepseq      ^>= 1.3.0.0 || ^>= 1.4.0.0
 
   -- NB: build-depends & build-tool-depends have independent
@@ -114,7 +113,6 @@ test-suite fixtures
     , base
 
       -- extra dependencies
-    , base-compat           ^>= 0.9.3 || ^>= 0.11.0
     , directory             ^>= 1.3.0.2
     , filepath              ^>= 1.4.1.2
     , optparse-applicative  ^>= 0.15

--- a/haddock-library/test/Documentation/Haddock/Parser/UtilSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/Parser/UtilSpec.hs
@@ -3,7 +3,7 @@ module Documentation.Haddock.Parser.UtilSpec (main, spec) where
 
 import Documentation.Haddock.Parser.Monad
 import Documentation.Haddock.Parser.Util
-import Data.Either.Compat (isLeft)
+import Data.Either (isLeft)
 import Test.Hspec
 import Control.Applicative
 


### PR DESCRIPTION
Hi, this PR configures the CI workflow to work on the ghc-head branch.

I'm opening this PR now as the workflow succeeds for the current ghc-head (https://github.com/simmsb/haddock/actions/runs/882402835).

Currently tests for haddock-library and haddock-api are disabled.