### PR TITLE
Rename "levity" to "representation" in Bug873 reference output

### DIFF
--- a/hoogle-test/ref/Bug873/test.txt
+++ b/hoogle-test/ref/Bug873/test.txt
@@ -18,9 +18,9 @@ module Bug873
 --   It is also useful in higher-order situations, such as <tt><a>map</a>
 --   (<a>$</a> 0) xs</tt>, or <tt><a>zipWith</a> (<a>$</a>) fs xs</tt>.
 --   
---   Note that <tt>(<a>$</a>)</tt> is levity-polymorphic in its result
---   type, so that <tt>foo <a>$</a> True</tt> where <tt>foo :: Bool -&gt;
---   Int#</tt> is well-typed.
+--   Note that <tt>(<a>$</a>)</tt> is representation-polymorphic in its
+--   result type, so that <tt>foo <a>$</a> True</tt> where <tt>foo :: Bool
+--   -&gt; Int#</tt> is well-typed.
 ($) :: forall (r :: RuntimeRep) a (b :: TYPE r). (a -> b) -> a -> b
 infixr 0 $
 ($$) :: (a -> b) -> a -> b


### PR DESCRIPTION
I'm adjusting documentation and error messages throughout GHC to mention representation polymorphism instead of levity polymorphism where appropriate, see [GHC merge request 5860](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/5860).    
This is the only change needed to the haddock submodule to account for that.