### PR TITLE
Update CONTRIBUTING.md (ghc-9.2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,20 +44,20 @@ so that documentation built within GHC can benefit from it.
 
 #### Using `cabal`
 
-Requires cabal `>= 3.4` and GHC `== 9.0`:
+Requires cabal `>= 3.4` and GHC `== 9.2`:
+
+First update the package list:
+
+```bash
+cabal v2-update
+```
+
+This is needed as haddock@ghc-9.2 uses the
+[ghc.head](https://ghc.gitlab.haskell.org/head.hackage/) package repository.
 
 ```bash
 cabal v2-build all --enable-tests
 cabal v2-test all
-```
-
-#### Using `stack`
-
-```bash
-stack init
-stack build
-export HADDOCK_PATH="$(stack exec which haddock)"
-stack test
 ```
 
 ### Updating golden testsuite outputs


### PR DESCRIPTION
As pointed out by #1392, the build instructions for the ghc-9.2 branch are incorrect.

This PR updates the instructions for building using Cabal, 
and removes the stack instructions as I can't find a good
way to have stack use the patches found in head.hackage.

---

closes https://github.com/haskell/haddock/issues/1392