### PR TITLE
Update CONTRIBUTING.md (ghc-head)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,20 +44,17 @@ so that documentation built within GHC can benefit from it.
 
 #### Using `cabal`
 
-Requires cabal `>= 3.4` and GHC `== 9.0`:
+Requires cabal `>= 3.4` and the latest build of GHC:
+
+You can install the latest build of GHC via ghcup using this command:
+
+```bash
+ghcup install ghc -u "https://gitlab.haskell.org/ghc/ghc/-/jobs/artifacts/master/raw/ghc-x86_64-deb9-linux-integer-simple.tar.xz?job=validate-x86_64-linux-deb9-integer-simple" head
+```
 
 ```bash
 cabal v2-build all --enable-tests
 cabal v2-test all
-```
-
-#### Using `stack`
-
-```bash
-stack init
-stack build
-export HADDOCK_PATH="$(stack exec which haddock)"
-stack test
 ```
 
 ### Updating golden testsuite outputs


### PR DESCRIPTION
As pointed out by #1392, the build instructions for the ghc-head branch are incorrect.

This PR updates the instructions for building using Cabal, 
adds instructions for installing the latest build of ghc,
and removes the stack instructions as I can't find a good
way to have stack use the patches found in head.hackage.