### PR TITLE
Update haddockHypsrcTest for GHC MR !6705

### DIFF
--- a/hypsrc-test/ref/src/Classes.html
+++ b/hypsrc-test/ref/src/Classes.html
@@ -342,6 +342,7 @@ forall a. a -&gt; a
       ><span class="annot"
       ><span class="annottext"
 	>[a] -&gt; Int
+forall a. [a] -&gt; Int
 forall (t :: * -&gt; *) a. Foldable t =&gt; t a -&gt; Int
 </span
 	><span class="hs-identifier hs-var"
@@ -716,6 +717,7 @@ forall b c a. (b -&gt; c) -&gt; (a -&gt; b) -&gt; a -&gt; c
 	><span class="annot"
 	><span class="annottext"
 	  >[Int] -&gt; Int
+forall a. Num a =&gt; [a] -&gt; a
 forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
 </span
 	  ><span class="hs-identifier hs-var"
@@ -813,6 +815,7 @@ forall a. Foo a =&gt; a -&gt; Int
       ><span class="annot"
       ><span class="annottext"
 	>[Int] -&gt; Int
+forall a. Num a =&gt; [a] -&gt; a
 forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
 </span
 	><span class="hs-identifier hs-var"

--- a/hypsrc-test/ref/src/Constructors.html
+++ b/hypsrc-test/ref/src/Constructors.html
@@ -1309,6 +1309,7 @@ forall a. Num a =&gt; a -&gt; a -&gt; a
       ><span class="annot"
       ><span class="annottext"
 	>[Int] -&gt; Int
+forall a. Num a =&gt; [a] -&gt; a
 forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
 </span
 	><span class="hs-identifier hs-var"

--- a/hypsrc-test/ref/src/Quasiquoter.html
+++ b/hypsrc-test/ref/src/Quasiquoter.html
@@ -156,6 +156,7 @@
       ><span class="annot"
       ><span class="annottext"
 	>Exp -&gt; Q Exp
+forall a. a -&gt; Q a
 forall (f :: * -&gt; *) a. Applicative f =&gt; a -&gt; f a
 </span
 	><span class="hs-identifier hs-var"
@@ -398,6 +399,7 @@ forall a. String -&gt; Q a
       ><span class="annot"
       ><span class="annottext"
 	>String -&gt; Q a
+forall a. String -&gt; Q a
 forall (m :: * -&gt; *) a. MonadFail m =&gt; String -&gt; m a
 </span
 	><span class="hs-identifier hs-var"


### PR DESCRIPTION
GHC MR [!6705](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6705) makes a small change to `HsWrapper`s which causes some changes in the output of the Haddock `hypsrc` test. The GHC MR is ready to land, so this is good to merge now. Thanks.