### PR TITLE
fix grammar in docs: "can the" → "can be"

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -178,7 +178,7 @@ Deriving clauses
 Most instances are top-level, so can be documented as in
 :ref:`top-level-declaration`. The exception to this is instance that are
 come from a ``deriving`` clause on a datatype declaration. These can
-the documented like this: ::
+be documented like this: ::
 
     data D a = L a | M
       deriving ( Eq   -- ^ @since 4.5


### PR DESCRIPTION
(refiling #1476 against `ghc-9.2` as [requested](https://github.com/haskell/haddock/pull/1476#issuecomment-1114578344))