### PR TITLE
fix parsing trailing quotes in backticked identifiers (#1408)

### DIFF
--- a/haddock-library/src/Documentation/Haddock/Parser/Identifier.hs
+++ b/haddock-library/src/Documentation/Haddock/Parser/Identifier.hs
@@ -149,9 +149,9 @@ takeIdentifier input = listToMaybe $ do
       | otherwise = Nothing
 
     -- | Parse all but the last quote off the front of the input
-    -- PRECONDITION: T.head t == '\''
+    -- PRECONDITION: T.head t `elem` ['\'', '`']
     quotes :: Text -> (Int, Text)
-    quotes t = let !n = T.length (T.takeWhile (== '\'') t) - 1
+    quotes t = let !n = T.length (T.takeWhile (`elem` ['\'', '`']) t) - 1
                in (n, T.drop n t)
 
     -- | Parse an operator off the front of the input

--- a/haddock-library/test/Documentation/Haddock/ParserSpec.hs
+++ b/haddock-library/test/Documentation/Haddock/ParserSpec.hs
@@ -121,6 +121,9 @@ spec = do
       it "can parse identifiers ending with a single quote" $ do
         "'foo''" `shouldParseTo` DocIdentifier "foo'"
 
+      it "can parse identifiers in backticks ending with a single quote" $ do
+        "`foo'`" `shouldParseTo` DocIdentifier "foo'"
+
       it "can parse an identifier containing a digit" $ do
         "'f0'" `shouldParseTo` DocIdentifier "f0"
 


### PR DESCRIPTION
I assume this needs a test… It works on the example in #1408 provided by @Kleidukos 

```haskell
module Module where

-- | This is the `foo'` function.
foo' :: ()
foo' = ()
```