### PR TITLE
Version bump 2.26.1

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:        2.0
 name:                 haddock-api
-version:              2.26.0
+version:              2.26.1
 synopsis:             A documentation-generation tool for Haskell libraries
 description:          Haddock is a documentation-generation tool for Haskell
                       libraries

--- a/haddock.cabal
+++ b/haddock.cabal
@@ -150,7 +150,7 @@ executable haddock
   else
     -- in order for haddock's advertised version number to have proper meaning,
     -- we pin down to a single haddock-api version.
-    build-depends:  haddock-api == 2.26.0
+    build-depends:  haddock-api == 2.26.1
 
 test-suite html-test
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
We extended format accepted by `--read-interface` option, which requires
updating the minor version.
