### PR TITLE
Fix line wrapping in instances list

### DIFF
--- a/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
+++ b/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
@@ -568,7 +568,7 @@ table.info {
 }
 
 #interface td.src {
-  white-space: nowrap;
+  white-space: pre-wrap;
 }
 
 /* @end */


### PR DESCRIPTION
Previously, we set the white-space to nowrap on the instances
section. This is incorrect, because it means that on particularly long
instances, the text will overflow the page and cause horizontal
scrolling.

I chose pre-wrap here because this is code. This setting will, per MDN,
ensure that:

    Sequences of white space are preserved. Lines are broken at newline
    characters, at <br>, and as necessary to fill line boxes.

before:
![image](https://user-images.githubusercontent.com/6652840/187538690-4c120001-6ed3-4a11-b79f-a68fc380a720.png)


after:
![image](https://user-images.githubusercontent.com/6652840/187538657-b40d3989-61c7-434a-b956-ec701933f893.png)
