### PR TITLE
Support mtl-2.3

### DIFF
--- a/haddock-api/src/Haddock/Interface/Create.hs
+++ b/haddock-api/src/Haddock/Interface/Create.hs
@@ -442,7 +442,7 @@ mkDocOpts mbOpts flags mdl = do
   opts <- case mbOpts of
     Just opts -> case words $ replace ',' ' ' opts of
       [] -> tell ["No option supplied to DOC_OPTION/doc_option"] >> return []
-      xs -> liftM catMaybes (mapM parseOption xs)
+      xs -> fmap catMaybes (mapM parseOption xs)
     Nothing -> return []
   pure (foldl go opts flags)
   where
@@ -651,7 +651,7 @@ mkExportItems
       fullModuleContents is_sig modMap pkgName thisMod semMod warnings gre
         exportedNames decls maps fixMap splices instIfaceMap dflags
         allExports
-    Just exports -> liftM concat $ mapM lookupExport exports
+    Just exports -> fmap concat $ mapM lookupExport exports
   where
     lookupExport (IEGroup _ lev docStr, _)  = liftErrMsg $ do
       doc <- processDocString dflags gre (hsDocString . unLoc $ docStr)


### PR DESCRIPTION
Starting from `mtl-2.3` `liftM` is no longer re-exported from `Control.Monad` by `Control.Monad.Writer.Strict`. A simple backward-compatible fix is to replace `liftM` with `fmap`. 