### PR TITLE
atSign has no unicode variant

### DIFF
--- a/haddock-api/src/Haddock/Backends/LaTeX.hs
+++ b/haddock-api/src/Haddock/Backends/LaTeX.hs
@@ -1059,8 +1059,7 @@ ppSigType unicode sig_ty = ppr_sig_ty (reparenSigType sig_ty) unicode
 
 ppLHsTypeArg :: Bool -> LHsTypeArg DocNameI -> LaTeX
 ppLHsTypeArg unicode (HsValArg ty) = ppLParendType unicode ty
-ppLHsTypeArg unicode (HsTypeArg _ ki) = atSign unicode <>
-                                       ppLParendType unicode ki
+ppLHsTypeArg unicode (HsTypeArg _ ki) = atSign <> ppLParendType unicode ki
 ppLHsTypeArg _ (HsArgPar _) = text ""
 
 class RenderableBndrFlag flag where
@@ -1131,7 +1130,7 @@ ppr_mono_ty (HsAppTy _ fun_ty arg_ty) unicode
   = hsep [ppr_mono_lty fun_ty unicode, ppr_mono_lty arg_ty unicode]
 
 ppr_mono_ty (HsAppKindTy _ fun_ty arg_ki) unicode
-  = hsep [ppr_mono_lty fun_ty unicode, atSign unicode <> ppr_mono_lty arg_ki unicode]
+  = hsep [ppr_mono_lty fun_ty unicode, atSign <> ppr_mono_lty arg_ki unicode]
 
 ppr_mono_ty (HsOpTy _ prom ty1 op ty2) unicode
   = ppr_mono_lty ty1 unicode <+> ppr_op_prom <+> ppr_mono_lty ty2 unicode
@@ -1409,21 +1408,22 @@ quote :: LaTeX -> LaTeX
 quote doc = text "\\begin{quote}" $$ doc $$ text "\\end{quote}"
 
 
-dcolon, arrow, lollipop, darrow, forallSymbol, starSymbol, atSign :: Bool -> LaTeX
+dcolon, arrow, lollipop, darrow, forallSymbol, starSymbol :: Bool -> LaTeX
 dcolon unicode = text (if unicode then "∷" else "::")
 arrow  unicode = text (if unicode then "→" else "->")
 lollipop unicode = text (if unicode then "⊸" else "%1 ->")
 darrow unicode = text (if unicode then "⇒" else "=>")
 forallSymbol unicode = text (if unicode then "∀" else "forall")
 starSymbol unicode = text (if unicode then "★" else "*")
-atSign unicode = text (if unicode then "@" else "@")
+
+atSign :: LaTeX
+atSign = char '@'
 
 multAnnotation :: LaTeX
-multAnnotation = text "%"
+multAnnotation = char '%'
 
 dot :: LaTeX
 dot = char '.'
-
 
 parenList :: [LaTeX] -> LaTeX
 parenList = parens . hsep . punctuate comma

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -1146,8 +1146,7 @@ ppSigType unicode qual emptyCtxts sig_ty = ppr_sig_ty (reparenSigType sig_ty) un
 
 ppLHsTypeArg :: Unicode -> Qualification -> HideEmptyContexts -> LHsTypeArg DocNameI -> Html
 ppLHsTypeArg unicode qual emptyCtxts (HsValArg ty) = ppLParendType unicode qual emptyCtxts ty
-ppLHsTypeArg unicode qual emptyCtxts (HsTypeArg _ ki) = atSign unicode <>
-                                                       ppLParendType unicode qual emptyCtxts ki
+ppLHsTypeArg unicode qual emptyCtxts (HsTypeArg _ ki) = atSign <> ppLParendType unicode qual emptyCtxts ki
 ppLHsTypeArg _ _ _ (HsArgPar _) = toHtml ""
 
 class RenderableBndrFlag flag where
@@ -1279,7 +1278,7 @@ ppr_mono_ty (HsAppTy _ fun_ty arg_ty) unicode qual _
 
 ppr_mono_ty (HsAppKindTy _ fun_ty arg_ki) unicode qual _
   = hsep [ppr_mono_lty fun_ty unicode qual HideEmptyContexts
-         , atSign unicode <> ppr_mono_lty arg_ki unicode qual HideEmptyContexts]
+         , atSign <> ppr_mono_lty arg_ki unicode qual HideEmptyContexts]
 
 ppr_mono_ty (HsOpTy _ prom ty1 op ty2) unicode qual _
   = ppr_mono_lty ty1 unicode qual HideEmptyContexts <+> ppr_op_prom <+> ppr_mono_lty ty2 unicode qual HideEmptyContexts

--- a/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
@@ -188,13 +188,15 @@ ubxparens :: Html -> Html
 ubxparens h = toHtml "(#" <+> h <+> toHtml "#)"
 
 
-dcolon, arrow, lollipop, darrow, forallSymbol, atSign :: Bool -> Html
+dcolon, arrow, lollipop, darrow, forallSymbol :: Bool -> Html
 dcolon unicode = toHtml (if unicode then "∷" else "::")
 arrow  unicode = toHtml (if unicode then "→" else "->")
 lollipop unicode = toHtml (if unicode then "⊸" else "%1 ->")
 darrow unicode = toHtml (if unicode then "⇒" else "=>")
 forallSymbol unicode = if unicode then toHtml "∀" else keyword "forall"
-atSign unicode = toHtml (if unicode then "@" else "@")
+
+atSign :: Html
+atSign = toHtml "@"
 
 multAnnotation :: Html
 multAnnotation = toHtml "%"


### PR DESCRIPTION
Prior to this change, `atSign` was defined as follows:

```haskell
atSign unicode = text (if unicode then "@" else "@")
```

Yes, this is the same symbol `'\64'` and not your font playing tricks on you. Now we define:

```haskell
atSign = char '@'
```

Both the LaTeX and the Xhtml backend are updated accordingly.