### PR TITLE
Using `aeson` for JSON

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -50,6 +50,7 @@ library
                , xhtml           ^>= 3000.2.2
                , parsec          ^>= 3.1.13.0
                , text            ^>= 2.0
+               , aeson
 
   -- Versions for the dependencies below are transitively pinned by
   -- the non-reinstallable `ghc` package and hence need no version

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -21,6 +21,7 @@ module Haddock.Backends.Xhtml (
 
 import Prelude hiding (div)
 
+import Data.String
 import GHC.Utils.Error
 import Haddock.Backends.Xhtml.Decl
 import Haddock.Backends.Xhtml.DocMarkup
@@ -432,20 +433,20 @@ instance ToJSON JsonIndexEntry where
         , jieName
         , jieModule
         , jieLink } =
-      Object
-        [ "display_html" .= String jieHtmlFragment
-        , "name"         .= String jieName
-        , "module"       .= String jieModule
-        , "link"         .= String jieLink
+      Haddock.Utils.Json.object
+        [ fromString "display_html" .= jieHtmlFragment
+        , fromString "name"         .= jieName
+        , fromString "module"       .= jieModule
+        , fromString "link"         .= jieLink
         ]
 
 instance FromJSON JsonIndexEntry where
     parseJSON = withObject "JsonIndexEntry" $ \v ->
       JsonIndexEntry
-        <$> v .: "display_html"
-        <*> v .: "name"
-        <*> v .: "module"
-        <*> v .: "link"
+        <$> v .: fromString "display_html"
+        <*> v .: fromString "name"
+        <*> v .: fromString "module"
+        <*> v .: fromString "link"
 
 ppJsonIndex
   :: Logger

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -21,6 +21,7 @@ module Haddock.Backends.Xhtml (
 
 import Prelude hiding (div)
 
+import Data.Aeson
 import Data.String
 import GHC.Utils.Error
 import Haddock.Backends.Xhtml.Decl
@@ -440,6 +441,18 @@ instance ToJSON JsonIndexEntry where
         , fromString "link"         .= jieLink
         ]
 
+    toEncoding JsonIndexEntry
+        { jieHtmlFragment
+        , jieName
+        , jieModule
+        , jieLink } =
+      pairs
+        ( fromString "display_html" .= jieHtmlFragment
+        <> fromString "name"         .= jieName
+        <> fromString "module"       .= jieModule
+        <> fromString "link"         .= jieLink
+        )
+
 instance FromJSON JsonIndexEntry where
     parseJSON = withObject "JsonIndexEntry" $ \v ->
       JsonIndexEntry
@@ -485,11 +498,10 @@ ppJsonIndex logger odir maybe_source_url maybe_wiki_url unicode pkg qual_opt ifa
       Builder.hPutBuilder
         h (encodeToBuilder (encodeIndexes (concat installedIndexes)))
   where
-    encodeIndexes :: [JsonIndexEntry] -> Value
+    encodeIndexes :: [JsonIndexEntry] -> [JsonIndexEntry]
     encodeIndexes installedIndexes =
-      toJSON
-        (concatMap fromInterface ifaces
-         ++ installedIndexes)
+        concatMap fromInterface ifaces
+            ++ installedIndexes
 
     fromInterface :: Interface -> [JsonIndexEntry]
     fromInterface iface =

--- a/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
@@ -1,3 +1,5 @@
+{-# language OverloadedStrings #-}
+
 module Haddock.Backends.Xhtml.Meta where
 
 import Haddock.Utils.Json
@@ -20,7 +22,7 @@ writeHaddockMeta odir withQuickjump = do
   let
     meta_json :: Value
     meta_json = object (concat [
-        [ "haddock_version"   .= String projectVersion ]
+        [ "haddock_version"   .= projectVersion ]
       , [ "quickjump_version" .= quickjumpVersion | withQuickjump ]
       ])
 

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -11,11 +11,11 @@ module Haddock.Utils.Json
     ( Value(..)
     , Object, object, (.=)
     , encodeToBuilder
-    , ToJSON(toJSON)
+    , ToJSON(..)
 
     , Parser(..)
     , Result(..)
-    , FromJSON(parseJSON)
+    , FromJSON(..)
     , withObject
     , withArray
     , withBool

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -9,8 +9,7 @@
 --
 module Haddock.Utils.Json
     ( Value(..)
-    , Object, object, Pair, (.=)
-    , encodeToString
+    , Object, object, (.=)
     , encodeToBuilder
     , ToJSON(toJSON)
 
@@ -19,8 +18,6 @@ module Haddock.Utils.Json
     , FromJSON(parseJSON)
     , withObject
     , withArray
-    , withString
-    , withDouble
     , withBool
     , fromJSON
     , parse
@@ -28,14 +25,13 @@ module Haddock.Utils.Json
     , (.:)
     , (.:?)
     , decode
-    , decodeWith
     , eitherDecode
-    , eitherDecodeWith
-    , decodeFile
     , eitherDecodeFile
     )
     where
 
+import Data.Aeson
+import Data.Aeson.Types
 import Control.Applicative (Alternative (..))
 import Control.Monad (MonadPlus (..), zipWithM, (>=>))
 import qualified Control.Monad as Monad
@@ -60,499 +56,507 @@ import qualified Text.ParserCombinators.Parsec as Parsec
 import Haddock.Utils.Json.Types
 import Haddock.Utils.Json.Parser
 
-
-infixr 8 .=
-
--- | A key-value pair for encoding a JSON object.
-(.=) :: ToJSON v => String -> v -> Pair
-k .= v  = (k, toJSON v)
-
-
--- | A type that can be converted to JSON.
-class ToJSON a where
-  -- | Convert a Haskell value to a JSON-friendly intermediate type.
-  toJSON :: a -> Value
-
-instance ToJSON () where
-  toJSON () = Array []
-
-instance ToJSON Value where
-  toJSON = id
-
-instance ToJSON Bool where
-  toJSON = Bool
-
-instance ToJSON a => ToJSON [a] where
-  toJSON = Array . map toJSON
-
-instance ToJSON a => ToJSON (Maybe a) where
-  toJSON Nothing  = Null
-  toJSON (Just a) = toJSON a
-
-instance (ToJSON a,ToJSON b) => ToJSON (a,b) where
-  toJSON (a,b) = Array [toJSON a, toJSON b]
-
-instance (ToJSON a,ToJSON b,ToJSON c) => ToJSON (a,b,c) where
-  toJSON (a,b,c) = Array [toJSON a, toJSON b, toJSON c]
-
-instance (ToJSON a,ToJSON b,ToJSON c, ToJSON d) => ToJSON (a,b,c,d) where
-  toJSON (a,b,c,d) = Array [toJSON a, toJSON b, toJSON c, toJSON d]
-
-instance ToJSON Float where
-  toJSON = Number . realToFrac
-
-instance ToJSON Double where
-  toJSON = Number
-
-instance ToJSON Int    where  toJSON = Number . realToFrac
-instance ToJSON Int8   where  toJSON = Number . realToFrac
-instance ToJSON Int16  where  toJSON = Number . realToFrac
-instance ToJSON Int32  where  toJSON = Number . realToFrac
-
-instance ToJSON Word   where  toJSON = Number . realToFrac
-instance ToJSON Word8  where  toJSON = Number . realToFrac
-instance ToJSON Word16 where  toJSON = Number . realToFrac
-instance ToJSON Word32 where  toJSON = Number . realToFrac
-
--- | Possibly lossy due to conversion to 'Double'
-instance ToJSON Int64  where  toJSON = Number . realToFrac
-
--- | Possibly lossy due to conversion to 'Double'
-instance ToJSON Word64 where  toJSON = Number . realToFrac
-
--- | Possibly lossy due to conversion to 'Double'
-instance ToJSON Integer where toJSON = Number . fromInteger
-
-------------------------------------------------------------------------------
--- 'BB.Builder'-based encoding
-
--- | Serialise value as JSON/UTF8-encoded 'Builder'
 encodeToBuilder :: ToJSON a => a -> Builder
-encodeToBuilder = encodeValueBB . toJSON
-
-encodeValueBB :: Value -> Builder
-encodeValueBB jv = case jv of
-  Bool True  -> "true"
-  Bool False -> "false"
-  Null       -> "null"
-  Number n
-    | isNaN n || isInfinite n   -> encodeValueBB Null
-    | Just i <- doubleToInt64 n -> BB.int64Dec i
-    | otherwise                 -> BB.doubleDec n
-  Array a  -> encodeArrayBB a
-  String s -> encodeStringBB s
-  Object o -> encodeObjectBB o
-
-encodeArrayBB :: [Value] -> Builder
-encodeArrayBB [] = "[]"
-encodeArrayBB jvs = BB.char8 '[' <> go jvs <> BB.char8 ']'
-  where
-    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encodeValueBB
-
-encodeObjectBB :: Object -> Builder
-encodeObjectBB [] = "{}"
-encodeObjectBB jvs = BB.char8 '{' <> go jvs <> BB.char8 '}'
-  where
-    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair
-    encPair (l,x) = encodeStringBB l <> BB.char8 ':' <> encodeValueBB x
-
-encodeStringBB :: String -> Builder
-encodeStringBB str = BB.char8 '"' <> go str <> BB.char8 '"'
-  where
-    go = BB.stringUtf8 . escapeString
-
-------------------------------------------------------------------------------
--- 'String'-based encoding
-
--- | Serialise value as JSON-encoded Unicode 'String'
-encodeToString :: ToJSON a => a -> String
-encodeToString jv = encodeValue (toJSON jv) []
-
-encodeValue :: Value -> ShowS
-encodeValue jv = case jv of
-  Bool b   -> showString (if b then "true" else "false")
-  Null     -> showString "null"
-  Number n
-    | isNaN n || isInfinite n    -> encodeValue Null
-    | Just i <- doubleToInt64 n -> shows i
-    | otherwise                 -> shows n
-  Array a -> encodeArray a
-  String s -> encodeString s
-  Object o -> encodeObject o
-
-encodeArray :: [Value] -> ShowS
-encodeArray [] = showString "[]"
-encodeArray jvs = ('[':) . go jvs . (']':)
-  where
-    go []     = id
-    go [x]    = encodeValue x
-    go (x:xs) = encodeValue x . (',':) . go xs
-
-encodeObject :: Object -> ShowS
-encodeObject [] = showString "{}"
-encodeObject jvs = ('{':) . go jvs . ('}':)
-  where
-    go []          = id
-    go [(l,x)]     = encodeString l . (':':) . encodeValue x
-    go ((l,x):lxs) = encodeString l . (':':) . encodeValue x . (',':) . go lxs
-
-encodeString :: String -> ShowS
-encodeString str = ('"':) . showString (escapeString str) . ('"':)
-
-------------------------------------------------------------------------------
--- helpers
-
--- | Try to convert 'Double' into 'Int64', return 'Nothing' if not
--- representable loss-free as integral 'Int64' value.
-doubleToInt64 :: Double -> Maybe Int64
-doubleToInt64 x
-  | fromInteger x' == x
-  , x' <= toInteger (maxBound :: Int64)
-  , x' >= toInteger (minBound :: Int64)
-    = Just (fromIntegral x')
-  | otherwise = Nothing
-  where
-    x' = round x
-
--- | Minimally escape a 'String' in accordance with RFC 7159, "7. Strings"
-escapeString :: String -> String
-escapeString s
-  | not (any needsEscape s) = s
-  | otherwise               = escape s
-  where
-    escape [] = []
-    escape (x:xs) = case x of
-      '\\' -> '\\':'\\':escape xs
-      '"'  -> '\\':'"':escape xs
-      '\b' -> '\\':'b':escape xs
-      '\f' -> '\\':'f':escape xs
-      '\n' -> '\\':'n':escape xs
-      '\r' -> '\\':'r':escape xs
-      '\t' -> '\\':'t':escape xs
-      c | ord c < 0x10 -> '\\':'u':'0':'0':'0':intToDigit (ord c):escape xs
-        | ord c < 0x20 -> '\\':'u':'0':'0':'1':intToDigit (ord c - 0x10):escape xs
-        | otherwise    -> c : escape xs
-
-    -- unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
-    needsEscape c = ord c < 0x20 || c `elem` ['\\','"']
-
-------------------------------------------------------------------------------
--- FromJSON
-
--- | Elements of a JSON path used to describe the location of an
--- error.
-data JSONPathElement
-  = Key String
-  -- ^ JSON path element of a key into an object,
-  -- \"object.key\".
-  | Index !Int
-  -- ^ JSON path element of an index into an
-  -- array, \"array[index]\".
-  deriving (Eq, Show, Ord)
-
-type JSONPath = [JSONPathElement]
-
--- | Failure continuation.
-type Failure f r   = JSONPath -> String -> f r
-
--- | Success continuation.
-type Success a f r = a -> f r
-
-newtype Parser a = Parser {
-      runParser :: forall f r.
-                   JSONPath
-                -> Failure f r
-                -> Success a f r
-                -> f r
-    }
-
-modifyFailure :: (String -> String) -> Parser a -> Parser a
-modifyFailure f (Parser p) = Parser $ \path kf ks ->
-    p path (\p' m -> kf p' (f m)) ks
-
-prependFailure :: String -> Parser a -> Parser a
-prependFailure = modifyFailure . (++)
-
-prependContext :: String -> Parser a -> Parser a
-prependContext name = prependFailure ("parsing " ++ name ++ " failed, ")
-
-typeMismatch :: String -> Value -> Parser a
-typeMismatch expected actual =
-    fail $ "expected " ++ expected ++ ", but encountered " ++ typeOf actual
-
-instance Monad.Monad Parser where
-    m >>= g = Parser $ \path kf ks ->
-      runParser m path kf
-                       (\a -> runParser (g a) path kf ks)
-    return = pure
-
-instance Fail.MonadFail Parser where
-    fail msg = Parser $ \path kf _ks -> kf (reverse path) msg
-
-instance Functor Parser where
-    fmap f m = Parser $ \path kf ks ->
-      let ks' a = ks (f a)
-      in runParser m path kf ks'
-
-instance Applicative Parser where
-    pure a = Parser $ \_path _kf ks -> ks a
-    (<*>) = apP
-
-instance Alternative Parser where
-    empty = fail "empty"
-    (<|>) = mplus
-
-instance MonadPlus Parser where
-    mzero = fail "mzero"
-    mplus a b = Parser $ \path kf ks ->
-      runParser a path (\_ _ -> runParser b path kf ks) ks
-
-instance Semigroup (Parser a) where
-    (<>) = mplus
-
-instance Monoid (Parser a) where
-    mempty  = fail "mempty"
-    mappend = (<>)
-
-apP :: Parser (a -> b) -> Parser a -> Parser b
-apP d e = do
-  b <- d
-  b <$> e
-
-(<?>) :: Parser a -> JSONPathElement -> Parser a
-p <?> pathElem = Parser $ \path kf ks -> runParser p (pathElem:path) kf ks
-
-parseIndexedJSON :: (Value -> Parser a) -> Int -> Value -> Parser a
-parseIndexedJSON p idx value = p value <?> Index idx
-
-unexpected :: Value -> Parser a
-unexpected actual = fail $ "unexpected " ++ typeOf actual
-
-withObject :: String -> (Object -> Parser a) -> Value -> Parser a
-withObject _    f (Object obj) = f obj
-withObject name _ v            = prependContext name (typeMismatch "Object" v)
-
-withArray :: String -> ([Value] -> Parser a) -> Value -> Parser a
-withArray _    f (Array arr) = f arr
-withArray name _ v           = prependContext name (typeMismatch "Array" v)
-
-withString :: String -> (String -> Parser a) -> Value -> Parser a
-withString _    f (String txt) = f txt
-withString name _ v            = prependContext name (typeMismatch "String" v)
-
-withDouble :: String -> (Double -> Parser a) -> Value -> Parser a
-withDouble _    f (Number duble) = f duble
-withDouble name _ v              = prependContext name (typeMismatch "Number" v)
-
-withBool :: String -> (Bool -> Parser a) -> Value -> Parser a
-withBool _    f (Bool arr) = f arr
-withBool name _ v          = prependContext name (typeMismatch "Boolean" v)
-
-class FromJSON a where
-    parseJSON     :: Value -> Parser a
-
-    parseJSONList :: Value -> Parser [a]
-    parseJSONList = withArray "[]" (zipWithM (parseIndexedJSON parseJSON) [0..])
-
-instance FromJSON Bool where
-    parseJSON (Bool b)  = pure b
-    parseJSON v = typeMismatch "Bool" v
-
-instance FromJSON () where
-    parseJSON =
-      withArray "()" $ \v ->
-        if null v
-          then pure ()
-          else prependContext "()" $ fail "expected an empty array"
-
-instance FromJSON Char where
-    parseJSON = withString "Char" parseChar
-
-    parseJSONList (String s) = pure s
-    parseJSONList v = typeMismatch "String" v
-
-parseChar :: String -> Parser Char
-parseChar t =
-    if length t == 1
-      then pure $ head t
-      else prependContext "Char" $ fail "expected a string of length 1"
-
-parseRealFloat :: RealFloat a => String -> Value -> Parser a
-parseRealFloat _    (Number s) = pure $ realToFrac s
-parseRealFloat _    Null       = pure (0/0)
-parseRealFloat name v          = prependContext name (unexpected v)
-
-instance FromJSON Double where
-    parseJSON = parseRealFloat "Double"
-
-instance FromJSON Float where
-    parseJSON = parseRealFloat "Float"
-
-parseNatural :: Integer -> Parser Natural
-parseNatural integer =
-    if integer < 0 then
-        fail $ "parsing Natural failed, unexpected negative number " <> show integer
-    else
-        pure $ fromIntegral integer
-
-parseIntegralFromDouble :: Integral a => Double -> Parser a
-parseIntegralFromDouble d =
-    let r = toRational d
-        x = truncate r
-    in if toRational x == r
-         then pure x
-         else fail $ "unexpected floating number " <> show d
-
-parseIntegral :: Integral a => String -> Value -> Parser a
-parseIntegral name = withDouble name parseIntegralFromDouble
-
-instance FromJSON Integer where
-    parseJSON = parseIntegral "Integer"
-
-instance FromJSON Natural where
-    parseJSON = withDouble "Natural"
-                  (parseIntegralFromDouble >=> parseNatural)
-
-instance FromJSON Int where
-    parseJSON = parseIntegral "Int"
-
-instance FromJSON Int8 where
-    parseJSON = parseIntegral "Int8"
-
-instance FromJSON Int16 where
-    parseJSON = parseIntegral "Int16"
-
-instance FromJSON Int32 where
-    parseJSON = parseIntegral "Int32"
-
-instance FromJSON Int64 where
-    parseJSON = parseIntegral "Int64"
-
-instance FromJSON Word where
-    parseJSON = parseIntegral "Word"
-
-instance FromJSON Word8 where
-    parseJSON = parseIntegral "Word8"
-
-instance FromJSON Word16 where
-    parseJSON = parseIntegral "Word16"
-
-instance FromJSON Word32 where
-    parseJSON = parseIntegral "Word32"
-
-instance FromJSON Word64 where
-    parseJSON = parseIntegral "Word64"
-
-instance FromJSON a => FromJSON [a] where
-    parseJSON = parseJSONList
-
-data Result a = Error String
-              | Success a
-                deriving (Eq, Show)
-
-fromJSON :: FromJSON a => Value -> Result a
-fromJSON = parse parseJSON
-
-parse :: (a -> Parser b) -> a -> Result b
-parse m v = runParser (m v) [] (const Error) Success
-
-parseEither :: (a -> Parser b) -> a -> Either String b
-parseEither m v = runParser (m v) [] onError Right
-  where onError path msg = Left (formatError path msg)
-
-formatError :: JSONPath -> String -> String
-formatError path msg = "Error in " ++ formatPath path ++ ": " ++ msg
-
-formatPath :: JSONPath -> String
-formatPath path = "$" ++ formatRelativePath path
-
-formatRelativePath :: JSONPath -> String
-formatRelativePath path = format "" path
-  where
-    format :: String -> JSONPath -> String
-    format pfx []                = pfx
-    format pfx (Index idx:parts) = format (pfx ++ "[" ++ show idx ++ "]") parts
-    format pfx (Key key:parts)   = format (pfx ++ formatKey key) parts
-
-    formatKey :: String -> String
-    formatKey key
-       | isIdentifierKey key = "." ++ key
-       | otherwise           = "['" ++ escapeKey key ++ "']"
-
-    isIdentifierKey :: String -> Bool
-    isIdentifierKey []     = False
-    isIdentifierKey (x:xs) = isAlpha x && all isAlphaNum xs
-
-    escapeKey :: String -> String
-    escapeKey = concatMap escapeChar
-
-    escapeChar :: Char -> String
-    escapeChar '\'' = "\\'"
-    escapeChar '\\' = "\\\\"
-    escapeChar c    = [c]
-
-explicitParseField :: (Value -> Parser a) -> Object -> String -> Parser a
-explicitParseField p obj key =
-    case key `lookup` obj of
-      Nothing -> fail $ "key " ++ key ++ " not found"
-      Just v  -> p v <?> Key key
-
-(.:) :: FromJSON a => Object -> String -> Parser a
-(.:) = explicitParseField parseJSON
-
-explicitParseFieldMaybe :: (Value -> Parser a) -> Object -> String -> Parser (Maybe a)
-explicitParseFieldMaybe p obj key =
-    case key `lookup` obj of
-      Nothing -> pure Nothing
-      Just v  -> Just <$> p v <?> Key key
-
-(.:?) :: FromJSON a => Object -> String -> Parser (Maybe a)
-(.:?) = explicitParseFieldMaybe parseJSON
-
-
-decodeWith :: (Value -> Result a) -> BSL.ByteString -> Maybe a
-decodeWith decoder bsl =
-   case Parsec.parse parseJSONValue "<input>" bsl of
-     Left  _    -> Nothing
-     Right json ->
-       case decoder json of
-         Success a -> Just a
-         Error _   -> Nothing
-
-decode :: FromJSON a => BSL.ByteString -> Maybe a
-decode = decodeWith fromJSON
-
-eitherDecodeWith :: (Value -> Result a) -> BSL.ByteString -> Either String a
-eitherDecodeWith decoder bsl =
-    case Parsec.parse parseJSONValue "<input>" bsl of
-      Left parsecError -> Left (show parsecError)
-      Right json ->
-        case decoder json of
-          Success a -> Right a
-          Error err -> Left  err
-
-eitherDecode :: FromJSON a => BSL.ByteString -> Either String a
-eitherDecode = eitherDecodeWith fromJSON
-
-
-decodeFile :: FromJSON a => FilePath -> IO (Maybe a)
-decodeFile filePath = do
-    parsecResult <- Parsec.Lazy.parseFromFile parseJSONValue filePath
-    case parsecResult of
-      Right r ->
-        case fromJSON r of
-          Success a -> return (Just a)
-          Error   _ -> return Nothing
-      Left _ -> return Nothing
-
+encodeToBuilder = fromEncoding . toEncoding
 
 eitherDecodeFile :: FromJSON a => FilePath -> IO (Either String a)
 eitherDecodeFile filePath = do
-    parsecResult <- Parsec.Lazy.parseFromFile parseJSONValue filePath
-    case parsecResult of
-      Right r ->
-        case fromJSON r of
-          Success a -> return (Right a)
-          Error err -> return (Left err)
-      Left err -> return $ Left (show err)
+    bytes <- BSL.readFile filePath
+    pure $ eitherDecode bytes
 
+
+-- infixr 8 .=
+--
+-- -- | A key-value pair for encoding a JSON object.
+-- (.=) :: ToJSON v => String -> v -> Pair
+-- k .= v  = (k, toJSON v)
+--
+--
+-- -- | A type that can be converted to JSON.
+-- class ToJSON a where
+--   -- | Convert a Haskell value to a JSON-friendly intermediate type.
+--   toJSON :: a -> Value
+--
+-- instance ToJSON () where
+--   toJSON () = Array []
+--
+-- instance ToJSON Value where
+--   toJSON = id
+--
+-- instance ToJSON Bool where
+--   toJSON = Bool
+--
+-- instance ToJSON a => ToJSON [a] where
+--   toJSON = Array . map toJSON
+--
+-- instance ToJSON a => ToJSON (Maybe a) where
+--   toJSON Nothing  = Null
+--   toJSON (Just a) = toJSON a
+--
+-- instance (ToJSON a,ToJSON b) => ToJSON (a,b) where
+--   toJSON (a,b) = Array [toJSON a, toJSON b]
+--
+-- instance (ToJSON a,ToJSON b,ToJSON c) => ToJSON (a,b,c) where
+--   toJSON (a,b,c) = Array [toJSON a, toJSON b, toJSON c]
+--
+-- instance (ToJSON a,ToJSON b,ToJSON c, ToJSON d) => ToJSON (a,b,c,d) where
+--   toJSON (a,b,c,d) = Array [toJSON a, toJSON b, toJSON c, toJSON d]
+--
+-- instance ToJSON Float where
+--   toJSON = Number . realToFrac
+--
+-- instance ToJSON Double where
+--   toJSON = Number
+--
+-- instance ToJSON Int    where  toJSON = Number . realToFrac
+-- instance ToJSON Int8   where  toJSON = Number . realToFrac
+-- instance ToJSON Int16  where  toJSON = Number . realToFrac
+-- instance ToJSON Int32  where  toJSON = Number . realToFrac
+--
+-- instance ToJSON Word   where  toJSON = Number . realToFrac
+-- instance ToJSON Word8  where  toJSON = Number . realToFrac
+-- instance ToJSON Word16 where  toJSON = Number . realToFrac
+-- instance ToJSON Word32 where  toJSON = Number . realToFrac
+--
+-- -- | Possibly lossy due to conversion to 'Double'
+-- instance ToJSON Int64  where  toJSON = Number . realToFrac
+--
+-- -- | Possibly lossy due to conversion to 'Double'
+-- instance ToJSON Word64 where  toJSON = Number . realToFrac
+--
+-- -- | Possibly lossy due to conversion to 'Double'
+-- instance ToJSON Integer where toJSON = Number . fromInteger
+--
+-- ------------------------------------------------------------------------------
+-- -- 'BB.Builder'-based encoding
+--
+-- -- | Serialise value as JSON/UTF8-encoded 'Builder'
+-- encodeToBuilder :: ToJSON a => a -> Builder
+-- encodeToBuilder = encodeValueBB . toJSON
+--
+-- encodeValueBB :: Value -> Builder
+-- encodeValueBB jv = case jv of
+--   Bool True  -> "true"
+--   Bool False -> "false"
+--   Null       -> "null"
+--   Number n
+--     | isNaN n || isInfinite n   -> encodeValueBB Null
+--     | Just i <- doubleToInt64 n -> BB.int64Dec i
+--     | otherwise                 -> BB.doubleDec n
+--   Array a  -> encodeArrayBB a
+--   String s -> encodeStringBB s
+--   Object o -> encodeObjectBB o
+--
+-- encodeArrayBB :: [Value] -> Builder
+-- encodeArrayBB [] = "[]"
+-- encodeArrayBB jvs = BB.char8 '[' <> go jvs <> BB.char8 ']'
+--   where
+--     go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encodeValueBB
+--
+-- encodeObjectBB :: Object -> Builder
+-- encodeObjectBB [] = "{}"
+-- encodeObjectBB jvs = BB.char8 '{' <> go jvs <> BB.char8 '}'
+--   where
+--     go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair
+--     encPair (l,x) = encodeStringBB l <> BB.char8 ':' <> encodeValueBB x
+--
+-- encodeStringBB :: String -> Builder
+-- encodeStringBB str = BB.char8 '"' <> go str <> BB.char8 '"'
+--   where
+--     go = BB.stringUtf8 . escapeString
+--
+-- ------------------------------------------------------------------------------
+-- -- 'String'-based encoding
+--
+-- -- | Serialise value as JSON-encoded Unicode 'String'
+-- encodeToString :: ToJSON a => a -> String
+-- encodeToString jv = encodeValue (toJSON jv) []
+--
+-- encodeValue :: Value -> ShowS
+-- encodeValue jv = case jv of
+--   Bool b   -> showString (if b then "true" else "false")
+--   Null     -> showString "null"
+--   Number n
+--     | isNaN n || isInfinite n    -> encodeValue Null
+--     | Just i <- doubleToInt64 n -> shows i
+--     | otherwise                 -> shows n
+--   Array a -> encodeArray a
+--   String s -> encodeString s
+--   Object o -> encodeObject o
+--
+-- encodeArray :: [Value] -> ShowS
+-- encodeArray [] = showString "[]"
+-- encodeArray jvs = ('[':) . go jvs . (']':)
+--   where
+--     go []     = id
+--     go [x]    = encodeValue x
+--     go (x:xs) = encodeValue x . (',':) . go xs
+--
+-- encodeObject :: Object -> ShowS
+-- encodeObject [] = showString "{}"
+-- encodeObject jvs = ('{':) . go jvs . ('}':)
+--   where
+--     go []          = id
+--     go [(l,x)]     = encodeString l . (':':) . encodeValue x
+--     go ((l,x):lxs) = encodeString l . (':':) . encodeValue x . (',':) . go lxs
+--
+-- encodeString :: String -> ShowS
+-- encodeString str = ('"':) . showString (escapeString str) . ('"':)
+--
+-- ------------------------------------------------------------------------------
+-- -- helpers
+--
+-- -- | Try to convert 'Double' into 'Int64', return 'Nothing' if not
+-- -- representable loss-free as integral 'Int64' value.
+-- doubleToInt64 :: Double -> Maybe Int64
+-- doubleToInt64 x
+--   | fromInteger x' == x
+--   , x' <= toInteger (maxBound :: Int64)
+--   , x' >= toInteger (minBound :: Int64)
+--     = Just (fromIntegral x')
+--   | otherwise = Nothing
+--   where
+--     x' = round x
+--
+-- -- | Minimally escape a 'String' in accordance with RFC 7159, "7. Strings"
+-- escapeString :: String -> String
+-- escapeString s
+--   | not (any needsEscape s) = s
+--   | otherwise               = escape s
+--   where
+--     escape [] = []
+--     escape (x:xs) = case x of
+--       '\\' -> '\\':'\\':escape xs
+--       '"'  -> '\\':'"':escape xs
+--       '\b' -> '\\':'b':escape xs
+--       '\f' -> '\\':'f':escape xs
+--       '\n' -> '\\':'n':escape xs
+--       '\r' -> '\\':'r':escape xs
+--       '\t' -> '\\':'t':escape xs
+--       c | ord c < 0x10 -> '\\':'u':'0':'0':'0':intToDigit (ord c):escape xs
+--         | ord c < 0x20 -> '\\':'u':'0':'0':'1':intToDigit (ord c - 0x10):escape xs
+--         | otherwise    -> c : escape xs
+--
+--     -- unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+--     needsEscape c = ord c < 0x20 || c `elem` ['\\','"']
+--
+-- ------------------------------------------------------------------------------
+-- -- FromJSON
+--
+-- -- | Elements of a JSON path used to describe the location of an
+-- -- error.
+-- data JSONPathElement
+--   = Key String
+--   -- ^ JSON path element of a key into an object,
+--   -- \"object.key\".
+--   | Index !Int
+--   -- ^ JSON path element of an index into an
+--   -- array, \"array[index]\".
+--   deriving (Eq, Show, Ord)
+--
+-- type JSONPath = [JSONPathElement]
+--
+-- -- | Failure continuation.
+-- type Failure f r   = JSONPath -> String -> f r
+--
+-- -- | Success continuation.
+-- type Success a f r = a -> f r
+--
+-- newtype Parser a = Parser {
+--       runParser :: forall f r.
+--                    JSONPath
+--                 -> Failure f r
+--                 -> Success a f r
+--                 -> f r
+--     }
+--
+-- modifyFailure :: (String -> String) -> Parser a -> Parser a
+-- modifyFailure f (Parser p) = Parser $ \path kf ks ->
+--     p path (\p' m -> kf p' (f m)) ks
+--
+-- prependFailure :: String -> Parser a -> Parser a
+-- prependFailure = modifyFailure . (++)
+--
+-- prependContext :: String -> Parser a -> Parser a
+-- prependContext name = prependFailure ("parsing " ++ name ++ " failed, ")
+--
+-- typeMismatch :: String -> Value -> Parser a
+-- typeMismatch expected actual =
+--     fail $ "expected " ++ expected ++ ", but encountered " ++ typeOf actual
+--
+-- instance Monad.Monad Parser where
+--     m >>= g = Parser $ \path kf ks ->
+--       runParser m path kf
+--                        (\a -> runParser (g a) path kf ks)
+--     return = pure
+--
+-- instance Fail.MonadFail Parser where
+--     fail msg = Parser $ \path kf _ks -> kf (reverse path) msg
+--
+-- instance Functor Parser where
+--     fmap f m = Parser $ \path kf ks ->
+--       let ks' a = ks (f a)
+--       in runParser m path kf ks'
+--
+-- instance Applicative Parser where
+--     pure a = Parser $ \_path _kf ks -> ks a
+--     (<*>) = apP
+--
+-- instance Alternative Parser where
+--     empty = fail "empty"
+--     (<|>) = mplus
+--
+-- instance MonadPlus Parser where
+--     mzero = fail "mzero"
+--     mplus a b = Parser $ \path kf ks ->
+--       runParser a path (\_ _ -> runParser b path kf ks) ks
+--
+-- instance Semigroup (Parser a) where
+--     (<>) = mplus
+--
+-- instance Monoid (Parser a) where
+--     mempty  = fail "mempty"
+--     mappend = (<>)
+--
+-- apP :: Parser (a -> b) -> Parser a -> Parser b
+-- apP d e = do
+--   b <- d
+--   b <$> e
+--
+-- (<?>) :: Parser a -> JSONPathElement -> Parser a
+-- p <?> pathElem = Parser $ \path kf ks -> runParser p (pathElem:path) kf ks
+--
+-- parseIndexedJSON :: (Value -> Parser a) -> Int -> Value -> Parser a
+-- parseIndexedJSON p idx value = p value <?> Index idx
+--
+-- unexpected :: Value -> Parser a
+-- unexpected actual = fail $ "unexpected " ++ typeOf actual
+--
+-- withObject :: String -> (Object -> Parser a) -> Value -> Parser a
+-- withObject _    f (Object obj) = f obj
+-- withObject name _ v            = prependContext name (typeMismatch "Object" v)
+--
+-- withArray :: String -> ([Value] -> Parser a) -> Value -> Parser a
+-- withArray _    f (Array arr) = f arr
+-- withArray name _ v           = prependContext name (typeMismatch "Array" v)
+--
+-- withString :: String -> (String -> Parser a) -> Value -> Parser a
+-- withString _    f (String txt) = f txt
+-- withString name _ v            = prependContext name (typeMismatch "String" v)
+--
+-- withDouble :: String -> (Double -> Parser a) -> Value -> Parser a
+-- withDouble _    f (Number duble) = f duble
+-- withDouble name _ v              = prependContext name (typeMismatch "Number" v)
+--
+-- withBool :: String -> (Bool -> Parser a) -> Value -> Parser a
+-- withBool _    f (Bool arr) = f arr
+-- withBool name _ v          = prependContext name (typeMismatch "Boolean" v)
+--
+-- class FromJSON a where
+--     parseJSON     :: Value -> Parser a
+--
+--     parseJSONList :: Value -> Parser [a]
+--     parseJSONList = withArray "[]" (zipWithM (parseIndexedJSON parseJSON) [0..])
+--
+-- instance FromJSON Bool where
+--     parseJSON (Bool b)  = pure b
+--     parseJSON v = typeMismatch "Bool" v
+--
+-- instance FromJSON () where
+--     parseJSON =
+--       withArray "()" $ \v ->
+--         if null v
+--           then pure ()
+--           else prependContext "()" $ fail "expected an empty array"
+--
+-- instance FromJSON Char where
+--     parseJSON = withString "Char" parseChar
+--
+--     parseJSONList (String s) = pure s
+--     parseJSONList v = typeMismatch "String" v
+--
+-- parseChar :: String -> Parser Char
+-- parseChar t =
+--     if length t == 1
+--       then pure $ head t
+--       else prependContext "Char" $ fail "expected a string of length 1"
+--
+-- parseRealFloat :: RealFloat a => String -> Value -> Parser a
+-- parseRealFloat _    (Number s) = pure $ realToFrac s
+-- parseRealFloat _    Null       = pure (0/0)
+-- parseRealFloat name v          = prependContext name (unexpected v)
+--
+-- instance FromJSON Double where
+--     parseJSON = parseRealFloat "Double"
+--
+-- instance FromJSON Float where
+--     parseJSON = parseRealFloat "Float"
+--
+-- parseNatural :: Integer -> Parser Natural
+-- parseNatural integer =
+--     if integer < 0 then
+--         fail $ "parsing Natural failed, unexpected negative number " <> show integer
+--     else
+--         pure $ fromIntegral integer
+--
+-- parseIntegralFromDouble :: Integral a => Double -> Parser a
+-- parseIntegralFromDouble d =
+--     let r = toRational d
+--         x = truncate r
+--     in if toRational x == r
+--          then pure x
+--          else fail $ "unexpected floating number " <> show d
+--
+-- parseIntegral :: Integral a => String -> Value -> Parser a
+-- parseIntegral name = withDouble name parseIntegralFromDouble
+--
+-- instance FromJSON Integer where
+--     parseJSON = parseIntegral "Integer"
+--
+-- instance FromJSON Natural where
+--     parseJSON = withDouble "Natural"
+--                   (parseIntegralFromDouble >=> parseNatural)
+--
+-- instance FromJSON Int where
+--     parseJSON = parseIntegral "Int"
+--
+-- instance FromJSON Int8 where
+--     parseJSON = parseIntegral "Int8"
+--
+-- instance FromJSON Int16 where
+--     parseJSON = parseIntegral "Int16"
+--
+-- instance FromJSON Int32 where
+--     parseJSON = parseIntegral "Int32"
+--
+-- instance FromJSON Int64 where
+--     parseJSON = parseIntegral "Int64"
+--
+-- instance FromJSON Word where
+--     parseJSON = parseIntegral "Word"
+--
+-- instance FromJSON Word8 where
+--     parseJSON = parseIntegral "Word8"
+--
+-- instance FromJSON Word16 where
+--     parseJSON = parseIntegral "Word16"
+--
+-- instance FromJSON Word32 where
+--     parseJSON = parseIntegral "Word32"
+--
+-- instance FromJSON Word64 where
+--     parseJSON = parseIntegral "Word64"
+--
+-- instance FromJSON a => FromJSON [a] where
+--     parseJSON = parseJSONList
+--
+-- data Result a = Error String
+--               | Success a
+--                 deriving (Eq, Show)
+--
+-- fromJSON :: FromJSON a => Value -> Result a
+-- fromJSON = parse parseJSON
+--
+-- parse :: (a -> Parser b) -> a -> Result b
+-- parse m v = runParser (m v) [] (const Error) Success
+--
+-- parseEither :: (a -> Parser b) -> a -> Either String b
+-- parseEither m v = runParser (m v) [] onError Right
+--   where onError path msg = Left (formatError path msg)
+--
+-- formatError :: JSONPath -> String -> String
+-- formatError path msg = "Error in " ++ formatPath path ++ ": " ++ msg
+--
+-- formatPath :: JSONPath -> String
+-- formatPath path = "$" ++ formatRelativePath path
+--
+-- formatRelativePath :: JSONPath -> String
+-- formatRelativePath path = format "" path
+--   where
+--     format :: String -> JSONPath -> String
+--     format pfx []                = pfx
+--     format pfx (Index idx:parts) = format (pfx ++ "[" ++ show idx ++ "]") parts
+--     format pfx (Key key:parts)   = format (pfx ++ formatKey key) parts
+--
+--     formatKey :: String -> String
+--     formatKey key
+--        | isIdentifierKey key = "." ++ key
+--        | otherwise           = "['" ++ escapeKey key ++ "']"
+--
+--     isIdentifierKey :: String -> Bool
+--     isIdentifierKey []     = False
+--     isIdentifierKey (x:xs) = isAlpha x && all isAlphaNum xs
+--
+--     escapeKey :: String -> String
+--     escapeKey = concatMap escapeChar
+--
+--     escapeChar :: Char -> String
+--     escapeChar '\'' = "\\'"
+--     escapeChar '\\' = "\\\\"
+--     escapeChar c    = [c]
+--
+-- explicitParseField :: (Value -> Parser a) -> Object -> String -> Parser a
+-- explicitParseField p obj key =
+--     case key `lookup` obj of
+--       Nothing -> fail $ "key " ++ key ++ " not found"
+--       Just v  -> p v <?> Key key
+--
+-- (.:) :: FromJSON a => Object -> String -> Parser a
+-- (.:) = explicitParseField parseJSON
+--
+-- explicitParseFieldMaybe :: (Value -> Parser a) -> Object -> String -> Parser (Maybe a)
+-- explicitParseFieldMaybe p obj key =
+--     case key `lookup` obj of
+--       Nothing -> pure Nothing
+--       Just v  -> Just <$> p v <?> Key key
+--
+-- (.:?) :: FromJSON a => Object -> String -> Parser (Maybe a)
+-- (.:?) = explicitParseFieldMaybe parseJSON
+--
+--
+-- decodeWith :: (Value -> Result a) -> BSL.ByteString -> Maybe a
+-- decodeWith decoder bsl =
+--    case Parsec.parse parseJSONValue "<input>" bsl of
+--      Left  _    -> Nothing
+--      Right json ->
+--        case decoder json of
+--          Success a -> Just a
+--          Error _   -> Nothing
+--
+-- decode :: FromJSON a => BSL.ByteString -> Maybe a
+-- decode = decodeWith fromJSON
+--
+-- eitherDecodeWith :: (Value -> Result a) -> BSL.ByteString -> Either String a
+-- eitherDecodeWith decoder bsl =
+--     case Parsec.parse parseJSONValue "<input>" bsl of
+--       Left parsecError -> Left (show parsecError)
+--       Right json ->
+--         case decoder json of
+--           Success a -> Right a
+--           Error err -> Left  err
+--
+-- eitherDecode :: FromJSON a => BSL.ByteString -> Either String a
+-- eitherDecode = eitherDecodeWith fromJSON
+--
+--
+-- decodeFile :: FromJSON a => FilePath -> IO (Maybe a)
+-- decodeFile filePath = do
+--     parsecResult <- Parsec.Lazy.parseFromFile parseJSONValue filePath
+--     case parsecResult of
+--       Right r ->
+--         case fromJSON r of
+--           Success a -> return (Just a)
+--           Error   _ -> return Nothing
+--       Left _ -> return Nothing
+--
+--
+-- eitherDecodeFile :: FromJSON a => FilePath -> IO (Either String a)
+-- eitherDecodeFile filePath = do
+--     parsecResult <- Parsec.Lazy.parseFromFile parseJSONValue filePath
+--     case parsecResult of
+--       Right r ->
+--         case fromJSON r of
+--           Success a -> return (Right a)
+--           Error err -> return (Left err)
+--       Left err -> return $ Left (show err)
+--

--- a/haddock-api/src/Haddock/Utils/Json/Parser.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Parser.hs
@@ -1,3 +1,5 @@
+{-# language PartialTypeSignatures #-}
+
 -- | Json "Parsec" parser, based on
 -- [json](https://hackage.haskell.org/package/json) package.
 --
@@ -7,96 +9,9 @@ module Haddock.Utils.Json.Parser
 
 import Prelude hiding (null)
 
-import Control.Applicative (Alternative (..))
-import Control.Monad (MonadPlus (..))
-import Data.Char (isHexDigit)
-import Data.Functor (($>))
-import qualified Data.ByteString.Lazy.Char8 as BSCL
-import Numeric
-import Text.Parsec.ByteString.Lazy (Parser)
-import Text.ParserCombinators.Parsec ((<?>))
-import qualified Text.ParserCombinators.Parsec as Parsec
+import Data.Aeson
+import Data.Aeson.Types
+import Data.Aeson.Parser
 
-import Haddock.Utils.Json.Types hiding (object)
-
-parseJSONValue :: Parser Value
-parseJSONValue = Parsec.spaces *> parseValue
-
-tok :: Parser a -> Parser a
-tok p = p <* Parsec.spaces
-
-parseValue :: Parser Value
-parseValue =
-         parseNull
-     <|> Bool   <$> parseBoolean
-     <|> Array  <$> parseArray
-     <|> String <$> parseString
-     <|> Object <$> parseObject
-     <|> Number <$> parseNumber
-     <?> "JSON value"
-
-parseNull :: Parser Value
-parseNull = tok
-     $  Parsec.string "null"
-     $> Null
-
-parseBoolean :: Parser Bool
-parseBoolean = tok
-     $  Parsec.string "true"  $> True
-    <|> Parsec.string "false" $> False
-
-parseArray :: Parser [Value]
-parseArray =
-    Parsec.between
-      (tok (Parsec.char '['))
-      (tok (Parsec.char ']'))
-      (parseValue `Parsec.sepBy` tok (Parsec.char ','))
-
-parseString :: Parser String
-parseString =
-    Parsec.between
-      (tok (Parsec.char '"'))
-      (tok (Parsec.char '"'))
-      (many char)
-  where
-    char = (Parsec.char '\\' >> escapedChar)
-       <|> Parsec.satisfy (\x -> x /= '"' && x /= '\\')
-
-    escapedChar =
-          Parsec.char '"'  $> '"'
-      <|> Parsec.char '\\' $> '\\'
-      <|> Parsec.char '/'  $> '/'
-      <|> Parsec.char 'b'  $> '\b'
-      <|> Parsec.char 'f'  $> '\f'
-      <|> Parsec.char 'n'  $> '\n'
-      <|> Parsec.char 'r'  $> '\r'
-      <|> Parsec.char 't'  $> '\t'
-      <|> Parsec.char 'u'  *> uni
-      <?> "escape character"
-
-    uni = check =<< Parsec.count 4 (Parsec.satisfy isHexDigit)
-      where
-        check x | code <= max_char = return (toEnum code)
-                | otherwise        = mzero
-          where code      = fst $ head $ readHex x
-                max_char  = fromEnum (maxBound :: Char)
-
-parseObject :: Parser Object
-parseObject =
-      Parsec.between
-        (tok (Parsec.char '{'))
-        (tok (Parsec.char '}'))
-        (field `Parsec.sepBy` tok (Parsec.char ','))
-  where
-    field :: Parser (String, Value)
-    field = (,)
-        <$> parseString
-        <*  tok (Parsec.char ':')
-        <*> parseValue
-
-parseNumber :: Parser Double
-parseNumber = tok $ do
-  s <- BSCL.unpack <$> Parsec.getInput
-  case readSigned readFloat s of
-    [(n,s')] -> Parsec.setInput (BSCL.pack s') $> n
-    _        -> mzero
+parseJSONValue :: _ Value
+parseJSONValue = json

--- a/haddock-api/src/Haddock/Utils/Json/Types.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Types.hs
@@ -1,23 +1,13 @@
 module Haddock.Utils.Json.Types
   ( Value(..)
   , typeOf
-  , Pair
   , Object
   , object
   ) where
 
-import Data.String
+import Data.Aeson
 
 -- TODO: We may want to replace 'String' with 'Text' or 'ByteString'
-
--- | A JSON value represented as a Haskell value.
-data Value = Object !Object
-           | Array  [Value]
-           | String  String
-           | Number !Double
-           | Bool   !Bool
-           | Null
-           deriving (Eq, Read, Show)
 
 typeOf :: Value -> String
 typeOf v = case v of
@@ -27,16 +17,3 @@ typeOf v = case v of
     Number _ -> "Number"
     Bool _   -> "Boolean"
     Null     -> "Null"
-
--- | A key\/value pair for an 'Object'
-type Pair = (String, Value)
-
--- | A JSON \"object\" (key/value map).
-type Object = [Pair]
-
--- | Create a 'Value' from a list of name\/value 'Pair's.
-object :: [Pair] -> Value
-object = Object
-
-instance IsString Value where
-  fromString = String


### PR DESCRIPTION
# Fast JSON

As usual, testing on `persistent`.

## With `--quickjump`:

`--quickjump` is what actually uses the JSON stuff, so let's try running with that.

### Baseline

```
time cabal haddock --haddock-options "-v2 --quickjump +RTS -s -RTS --optghc=\"-v2\" --lib=/home/matt/Projects/haddock/haddock-api/resources" persistent --with-haddock=/home/matt/.cabal/bin/haddock-943
```

```
!!! renameAllInterfaces: finished in 112.10 milliseconds, allocated 232.280 megabytes
*** ppJsonIndex:
!!! ppJsonIndex: finished in 1568.96 milliseconds, allocated 7682.663 megabytes
*** ppHtml:
*** ppHtmlContents:
!!! ppHtmlContents: finished in 0.73 milliseconds, allocated 2.298 megabytes
*** ppJsonIndex:
!!! ppJsonIndex: finished in 26.43 milliseconds, allocated 129.281 megabytes

  24,248,235,776 bytes allocated in the heap
   3,644,045,200 bytes copied during GC
     379,247,624 bytes maximum residency (16 sample(s))
       5,837,816 bytes maximum slop
             968 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5794 colls,     0 par    1.573s   1.575s     0.0003s    0.0028s
  Gen  1        16 colls,     0 par    1.255s   1.498s     0.0936s    0.3925s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    5.647s  (  6.241s elapsed)
  GC      time    2.828s  (  3.074s elapsed)
  EXIT    time    0.001s  (  0.005s elapsed)
  Total   time    8.476s  (  9.320s elapsed)

  Alloc rate    4,294,171,488 bytes per MUT second

  Productivity  66.6% of total user, 67.0% of total elapsed
```

We generate the JSON index twice - which seems weird? The two calls are very different. Feels like it should be folded in to a single thing.

- JSON Index Time:      1568.96ms 
- JSON Index Alloc:     7682.663 MB
- Total Memory:          968 MB
- Total Allocations:    24,248 MB
- Total Time:            8.476 s

### With `aeson` and `toEncoding`

```
!!! renameAllInterfaces: finished in 108.26 milliseconds, allocated 232.280 megabytes
*** ppJsonIndex:
!!! ppJsonIndex: finished in 365.63 milliseconds, allocated 811.310 megabytes
*** ppHtml:
*** ppHtmlContents:
!!! ppHtmlContents: finished in 1.07 milliseconds, allocated 2.298 megabytes
*** ppJsonIndex:
!!! ppJsonIndex: finished in 21.48 milliseconds, allocated 109.262 megabytes

  17,022,183,480 bytes allocated in the heap
   2,663,379,568 bytes copied during GC
     248,824,560 bytes maximum residency (15 sample(s))
       5,737,744 bytes maximum slop
             586 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      4043 colls,     0 par    1.313s   1.319s     0.0003s    0.0028s
  Gen  1        15 colls,     0 par    0.877s   0.880s     0.0587s    0.1663s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    5.090s  (  5.627s elapsed)
  GC      time    2.190s  (  2.199s elapsed)
  EXIT    time    0.001s  (  0.003s elapsed)
  Total   time    7.282s  (  7.830s elapsed)

  Alloc rate    3,343,944,691 bytes per MUT second

  Productivity  69.9% of total user, 71.9% of total elapsed
```

- JSON Index Time: 365.63ms
- JSON Index Allocations: 811.310 MB
- Total Memory: 586 MB
- Total Allocations: 17,022 MB
- Total Time: 7.282s

# Comparison

| | Baseline | Patched | Difference | Improvement |
|-|----------|---------|------------|-------------|
 | JSON Index Time | 1568.96 | 365.63 | 1203.33 | 76.7% | 
 | JSON Index Allocations | 7682.663 | 811.31 | 6871.352999999999 | 89.4% | 
 | Total Allocations | 24248.0 | 17022.0 | 7226.0 | 29.8% | 
 | Max Residency | 379.0 | 248.0 | 131.0 | 34.6% | 
 | Total Memory | 968.0 | 586.0 | 382.0 | 39.5% | 
 | Total Time | 8.467 | 7.282 | 1.185 | 14% | 

Overall a pretty large improvement.

Unfortunately, using `aeson` directly is likely out of the question - there are far too many dependencies. Even if we were to core out the important bits, that would require `unordered-containers`, `vector`, and `attoparsec`, none of which are boot packages.

Still, I think this PR demonstrates that a faster JSON representation is worth pursuing.