### PR TITLE
Using `Text`, `Map`, etc for JSON

### DIFF
--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -95,6 +95,8 @@ library
     Haddock.Parser
     Haddock.Utils
     Haddock.Utils.Json
+    Haddock.Utils.Json.Encoding
+    Haddock.Utils.Json.Encoding.Builder
     Haddock.Utils.Json.Types
     Haddock.Utils.Json.Parser
     Haddock.Backends.Xhtml

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -485,9 +485,8 @@ ppJsonIndex logger odir maybe_source_url maybe_wiki_url unicode pkg qual_opt ifa
       Builder.hPutBuilder
         h (encodeToBuilder (encodeIndexes (concat installedIndexes)))
   where
-    encodeIndexes :: [JsonIndexEntry] -> Value
+    encodeIndexes :: [JsonIndexEntry] -> [JsonIndexEntry]
     encodeIndexes installedIndexes =
-      toJSON
         (concatMap fromInterface ifaces
          ++ installedIndexes)
 

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -434,19 +434,19 @@ instance ToJSON JsonIndexEntry where
         , jieModule
         , jieLink } =
       Haddock.Utils.Json.object
-        [ "display_html" .= String jieHtmlFragment
-        , "name"         .= String jieName
-        , "module"       .= String jieModule
-        , "link"         .= String jieLink
+        [ Text.pack "display_html" .= Text.pack jieHtmlFragment
+        , Text.pack "name"         .= Text.pack jieName
+        , Text.pack "module"       .= Text.pack jieModule
+        , Text.pack "link"         .= Text.pack jieLink
         ]
 
 instance FromJSON JsonIndexEntry where
     parseJSON = withObject "JsonIndexEntry" $ \v ->
       JsonIndexEntry
-        <$> v .: "display_html"
-        <*> v .: "name"
-        <*> v .: "module"
-        <*> v .: "link"
+        <$> v .: Text.pack "display_html"
+        <*> v .: Text.pack "name"
+        <*> v .: Text.pack "module"
+        <*> v .: Text.pack "link"
 
 ppJsonIndex
   :: Logger

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -21,6 +21,7 @@ module Haddock.Backends.Xhtml (
 
 import Prelude hiding (div)
 
+import qualified Haddock.Utils.Json.Encoding as EB
 import GHC.Utils.Error
 import Haddock.Backends.Xhtml.Decl
 import Haddock.Backends.Xhtml.DocMarkup
@@ -434,11 +435,22 @@ instance ToJSON JsonIndexEntry where
         , jieModule
         , jieLink } =
       Haddock.Utils.Json.object
-        [ Text.pack "display_html" .= Text.pack jieHtmlFragment
-        , Text.pack "name"         .= Text.pack jieName
-        , Text.pack "module"       .= Text.pack jieModule
-        , Text.pack "link"         .= Text.pack jieLink
+        [ Text.pack "display_html" .= jieHtmlFragment
+        , Text.pack "name"         .= jieName
+        , Text.pack "module"       .= jieModule
+        , Text.pack "link"         .= jieLink
         ]
+    toEncoding JsonIndexEntry
+        { jieHtmlFragment
+        , jieName
+        , jieModule
+        , jieLink } =
+      EB.pairs
+        ( EB.pair (Text.pack "display_html") (toEncoding jieHtmlFragment)
+        <> EB.pair (Text.pack "name") (toEncoding jieName)
+        <> EB.pair (Text.pack "module") (toEncoding jieModule)
+        <> EB.pair (Text.pack "link") (toEncoding jieLink)
+        )
 
 instance FromJSON JsonIndexEntry where
     parseJSON = withObject "JsonIndexEntry" $ \v ->

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -40,6 +40,7 @@ import Text.XHtml hiding ( name, title, p, quote )
 import qualified Text.XHtml as XHtml
 import Haddock.GhcUtils
 
+import qualified Data.Text as Text
 import Control.Monad         ( when, unless )
 import qualified Data.ByteString.Builder as Builder
 import Data.Bifunctor        ( bimap )
@@ -432,20 +433,20 @@ instance ToJSON JsonIndexEntry where
         , jieName
         , jieModule
         , jieLink } =
-      Object
-        [ "display_html" .= String jieHtmlFragment
-        , "name"         .= String jieName
-        , "module"       .= String jieModule
-        , "link"         .= String jieLink
+      Haddock.Utils.Json.object
+        [ Text.pack "display_html" .= Text.pack jieHtmlFragment
+        , Text.pack "name"         .= Text.pack jieName
+        , Text.pack "module"       .= Text.pack jieModule
+        , Text.pack "link"         .= Text.pack jieLink
         ]
 
 instance FromJSON JsonIndexEntry where
     parseJSON = withObject "JsonIndexEntry" $ \v ->
       JsonIndexEntry
-        <$> v .: "display_html"
-        <*> v .: "name"
-        <*> v .: "module"
-        <*> v .: "link"
+        <$> v .: Text.pack "display_html"
+        <*> v .: Text.pack "name"
+        <*> v .: Text.pack "module"
+        <*> v .: Text.pack "link"
 
 ppJsonIndex
   :: Logger

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -499,8 +499,8 @@ ppJsonIndex logger odir maybe_source_url maybe_wiki_url unicode pkg qual_opt ifa
   where
     encodeIndexes :: [JsonIndexEntry] -> [JsonIndexEntry]
     encodeIndexes installedIndexes =
-        (concatMap fromInterface ifaces
-         ++ installedIndexes)
+      concatMap fromInterface ifaces
+        ++ installedIndexes
 
     fromInterface :: Interface -> [JsonIndexEntry]
     fromInterface iface =

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -434,19 +434,19 @@ instance ToJSON JsonIndexEntry where
         , jieModule
         , jieLink } =
       Haddock.Utils.Json.object
-        [ Text.pack "display_html" .= Text.pack jieHtmlFragment
-        , Text.pack "name"         .= Text.pack jieName
-        , Text.pack "module"       .= Text.pack jieModule
-        , Text.pack "link"         .= Text.pack jieLink
+        [ "display_html" .= String jieHtmlFragment
+        , "name"         .= String jieName
+        , "module"       .= String jieModule
+        , "link"         .= String jieLink
         ]
 
 instance FromJSON JsonIndexEntry where
     parseJSON = withObject "JsonIndexEntry" $ \v ->
       JsonIndexEntry
-        <$> v .: Text.pack "display_html"
-        <*> v .: Text.pack "name"
-        <*> v .: Text.pack "module"
-        <*> v .: Text.pack "link"
+        <$> v .: "display_html"
+        <*> v .: "name"
+        <*> v .: "module"
+        <*> v .: "link"
 
 ppJsonIndex
   :: Logger

--- a/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
@@ -21,8 +21,8 @@ writeHaddockMeta odir withQuickjump = do
   let
     meta_json :: Value
     meta_json = object (concat [
-        [ Text.pack "haddock_version"   .= Text.pack projectVersion ]
-      , [ Text.pack "quickjump_version" .= quickjumpVersion | withQuickjump ]
+        [ "haddock_version"   .= String projectVersion ]
+      , [ "quickjump_version" .= quickjumpVersion | withQuickjump ]
       ])
 
   withFile (odir </> "meta.json") WriteMode $ \h ->

--- a/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
@@ -2,6 +2,7 @@ module Haddock.Backends.Xhtml.Meta where
 
 import Haddock.Utils.Json
 import Haddock.Version
+import qualified Data.Text as Text
 
 import Data.ByteString.Builder (hPutBuilder)
 import System.FilePath ((</>))
@@ -20,8 +21,8 @@ writeHaddockMeta odir withQuickjump = do
   let
     meta_json :: Value
     meta_json = object (concat [
-        [ "haddock_version"   .= String projectVersion ]
-      , [ "quickjump_version" .= quickjumpVersion | withQuickjump ]
+        [ Text.pack "haddock_version"   .= Text.pack projectVersion ]
+      , [ Text.pack "quickjump_version" .= quickjumpVersion | withQuickjump ]
       ])
 
   withFile (odir </> "meta.json") WriteMode $ \h ->

--- a/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Meta.hs
@@ -21,8 +21,8 @@ writeHaddockMeta odir withQuickjump = do
   let
     meta_json :: Value
     meta_json = object (concat [
-        [ "haddock_version"   .= String projectVersion ]
-      , [ "quickjump_version" .= quickjumpVersion | withQuickjump ]
+        [ Text.pack "haddock_version"   .= Text.pack projectVersion ]
+      , [ Text.pack "quickjump_version" .= quickjumpVersion | withQuickjump ]
       ])
 
   withFile (odir </> "meta.json") WriteMode $ \h ->

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -163,6 +163,7 @@ instance ToJSON Integer where toJSON = Number . fromInteger
 -- | Serialise value as JSON/UTF8-encoded 'Builder'
 encodeToBuilder :: ToJSON a => a -> Builder
 encodeToBuilder = EB.fromEncoding . toEncoding
+{-# INLINE encodeToBuilder #-}
 
 encodeValueBB :: Value -> Builder
 encodeValueBB jv = case jv of

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -159,10 +159,10 @@ encodeArrayBB (x:jvs) = BB.char8 '[' <> encodeValueBB x <> go jvs <> BB.char8 ']
     go = foldr (\a z -> BB.char8 ',' <> encodeValueBB a <> z) (BB.char8 ']')
 
 encodeObjectBB :: Object -> Builder
-encodeObjectBB m | Map.null m = "{}"
+encodeObjectBB m | null m = "{}"
 encodeObjectBB jvs = BB.char8 '{' <> go jvs <> BB.char8 '}'
   where
-    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair . Map.toList
+    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair
     encPair (l,x) = encodeStringBB l <> BB.char8 ':' <> encodeValueBB x
 
 encodeStringBB :: Text.Text -> Builder
@@ -455,7 +455,7 @@ parse m v = runParser (m v) [] (const Error) Success
 
 explicitParseField :: (Value -> Parser a) -> Object -> Text.Text -> Parser a
 explicitParseField p obj key =
-    case key `Map.lookup` obj of
+    case key `lookup` obj of
       Nothing -> fail $ "key " ++ Text.unpack key ++ " not found"
       Just v  -> p v <?> Key key
 
@@ -464,7 +464,7 @@ explicitParseField p obj key =
 
 explicitParseFieldMaybe :: (Value -> Parser a) -> Object -> Text.Text -> Parser (Maybe a)
 explicitParseFieldMaybe p obj key =
-    case key `Map.lookup` obj of
+    case key `lookup` obj of
       Nothing -> pure Nothing
       Just v  -> Just <$> p v <?> Key key
 

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -137,6 +137,7 @@ instance ToJSON Float where
 
 instance ToJSON Double where
   toJSON = Number
+  toEncoding = EB.double
 
 instance ToJSON Int    where  toJSON = Number . realToFrac
 instance ToJSON Int8   where  toJSON = Number . realToFrac

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -74,6 +74,7 @@ infixr 8 .=
 -- | A key-value pair for encoding a JSON object.
 (.=) :: ToJSON v => Text.Text -> v -> Pair
 k .= v  = (k, toJSON v)
+{-# INLINE (.=) #-}
 
 
 -- | A type that can be converted to JSON.

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -112,6 +112,7 @@ instance ToJSON a => ToJSON [a] where
   {-# SPECIALIZE instance ToJSON [[Value]] #-}
   toJSON = Array . fmap toJSON
   toEncoding = EB.list toEncoding
+  {-# INLINE toEncoding #-}
 
 instance ToJSON Char where
   toJSON = String . Text.singleton

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -70,7 +70,7 @@ import Haddock.Utils.Json.Parser
 infixr 8 .=
 
 -- | A key-value pair for encoding a JSON object.
-(.=) :: ToJSON v => String -> v -> Pair
+(.=) :: ToJSON v => Text.Text -> v -> Pair
 k .= v  = (k, toJSON v)
 
 
@@ -81,6 +81,9 @@ class ToJSON a where
 
 instance ToJSON () where
   toJSON () = Array mempty
+
+instance ToJSON Text.Text where
+    toJSON = String
 
 instance ToJSON Value where
   toJSON = id
@@ -156,13 +159,13 @@ encodeArrayBB (x:jvs) = BB.char8 '[' <> encodeValueBB x <> go jvs <> BB.char8 ']
     go = foldr (\a z -> BB.char8 ',' <> encodeValueBB a <> z) (BB.char8 ']')
 
 encodeObjectBB :: Object -> Builder
-encodeObjectBB [] = "{}"
+encodeObjectBB m | Map.null m = "{}"
 encodeObjectBB jvs = BB.char8 '{' <> go jvs <> BB.char8 '}'
   where
-    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair
+    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair . Map.toList
     encPair (l,x) = encodeStringBB l <> BB.char8 ':' <> encodeValueBB x
 
-encodeStringBB :: String -> Builder
+encodeStringBB :: Text.Text -> Builder
 encodeStringBB str = BB.char8 '"' <> escapeText str <> BB.char8 '"'
 
 ------------------------------------------------------------------------------
@@ -203,24 +206,24 @@ escapeString s
 needsEscape :: Char -> Bool
 needsEscape c = ord c < 0x20 || c == '\\' || c == '"'
 
-escapeText :: String -> Builder
+escapeText :: Text.Text -> Builder
 escapeText txt
-    | any needsEscape txt = BP.primMapListBounded escapeAscii txt
-    | otherwise = BB.stringUtf8 txt
+    | Text.any needsEscape txt = TE.encodeUtf8BuilderEscaped escapeAscii txt
+    | otherwise = TE.encodeUtf8Builder txt
 
 -- Vendored from Aeson
-escapeAscii :: BP.BoundedPrim Char
+escapeAscii :: BP.BoundedPrim Word8
 escapeAscii =
-    BP.condB (== '\\'  ) (ascii2 ('\\','\\')) $
-    BP.condB (== '\"'  ) (ascii2 ('\\','"' )) $
-    BP.condB (>= '\x20') (BP.liftFixedToBounded BP.char8) $
-    BP.condB (== '\n'  ) (ascii2 ('\\','n' )) $
-    BP.condB (== '\r'  ) (ascii2 ('\\','r' )) $
-    BP.condB (== '\t'  ) (ascii2 ('\\','t' )) $
+    BP.condB (== c2w '\\'  ) (ascii2 ('\\','\\')) $
+    BP.condB (== c2w '\"'  ) (ascii2 ('\\','"' )) $
+    BP.condB (>= c2w '\x20') (BP.liftFixedToBounded BP.word8) $
+    BP.condB (== c2w '\n'  ) (ascii2 ('\\','n' )) $
+    BP.condB (== c2w '\r'  ) (ascii2 ('\\','r' )) $
+    BP.condB (== c2w '\t'  ) (ascii2 ('\\','t' )) $
     BP.liftFixedToBounded hexEscape -- fallback for chars < 0x20
   where
-    hexEscape :: BP.FixedPrim Char
-    hexEscape = (\c -> ('\\', ('u', fromIntegral (ord c)))) BP.>$<
+    hexEscape :: BP.FixedPrim Word8
+    hexEscape = (\c -> ('\\', ('u', fromIntegral c))) BP.>$<
         BP.char8 >*< BP.char8 >*< BP.word16HexFixed
 {-# INLINE escapeAscii #-}
 
@@ -234,7 +237,7 @@ ascii2 cs = BP.liftFixedToBounded $ const cs BP.>$< BP.char7 >*< BP.char7
 -- | Elements of a JSON path used to describe the location of an
 -- error.
 data JSONPathElement
-  = Key !String
+  = Key !Text.Text
   -- ^ JSON path element of a key into an object,
   -- \"object.key\".
   | Index !Int
@@ -328,7 +331,7 @@ withArray :: String -> ([Value] -> Parser a) -> Value -> Parser a
 withArray _    f (Array arr) = f arr
 withArray name _ v           = prependContext name (typeMismatch "Array" v)
 
-withString :: String -> (String -> Parser a) -> Value -> Parser a
+withString :: String -> (Text.Text -> Parser a) -> Value -> Parser a
 withString _    f (String txt) = f txt
 withString name _ v            = prependContext name (typeMismatch "String" v)
 
@@ -360,12 +363,16 @@ instance FromJSON () where
 instance FromJSON Char where
     parseJSON = withString "Char" parseChar
 
-    parseJSONList (String s) = pure s
+    parseJSONList (String s) = pure (Text.unpack s)
     parseJSONList v = typeMismatch "String" v
 
-parseChar :: String -> Parser Char
-parseChar [a] = pure a
-parseChar _ = prependContext "Char" $ fail "expected a string of length 1"
+parseChar :: Text.Text -> Parser Char
+parseChar txt = case Text.uncons txt of
+    Nothing -> boom
+    Just (a, "") -> pure a
+    Just (_, _) -> boom
+  where
+    boom = prependContext "Char" $ fail "expected a string of length 1"
 
 parseRealFloat :: RealFloat a => String -> Value -> Parser a
 parseRealFloat _    (Number s) = pure $ realToFrac s
@@ -446,22 +453,22 @@ fromJSON = parse parseJSON
 parse :: (a -> Parser b) -> a -> Result b
 parse m v = runParser (m v) [] (const Error) Success
 
-explicitParseField :: (Value -> Parser a) -> Object -> String -> Parser a
+explicitParseField :: (Value -> Parser a) -> Object -> Text.Text -> Parser a
 explicitParseField p obj key =
-    case key `lookup` obj of
-      Nothing -> fail $ "key " ++ key ++ " not found"
+    case key `Map.lookup` obj of
+      Nothing -> fail $ "key " ++ Text.unpack key ++ " not found"
       Just v  -> p v <?> Key key
 
-(.:) :: FromJSON a => Object -> String -> Parser a
+(.:) :: FromJSON a => Object -> Text.Text -> Parser a
 (.:) = explicitParseField parseJSON
 
-explicitParseFieldMaybe :: (Value -> Parser a) -> Object -> String -> Parser (Maybe a)
+explicitParseFieldMaybe :: (Value -> Parser a) -> Object -> Text.Text -> Parser (Maybe a)
 explicitParseFieldMaybe p obj key =
-    case key `lookup` obj of
+    case key `Map.lookup` obj of
       Nothing -> pure Nothing
       Just v  -> Just <$> p v <?> Key key
 
-(.:?) :: FromJSON a => Object -> String -> Parser (Maybe a)
+(.:?) :: FromJSON a => Object -> Text.Text -> Parser (Maybe a)
 (.:?) = explicitParseFieldMaybe parseJSON
 
 

--- a/haddock-api/src/Haddock/Utils/Json.hs
+++ b/haddock-api/src/Haddock/Utils/Json.hs
@@ -96,6 +96,7 @@ instance ToJSON () where
 
 instance ToJSON Text.Text where
     toJSON = String
+    toEncoding = EB.text
 
 instance ToJSON Value where
   toJSON = id

--- a/haddock-api/src/Haddock/Utils/Json/Encoding.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Encoding.hs
@@ -1,0 +1,347 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Haddock.Utils.Json.Encoding where
+
+import Haddock.Utils.Json.Types (Value, Key)
+import Data.ByteString.Builder (Builder, char7, toLazyByteString)
+import Data.ByteString.Short (ShortByteString)
+import Data.Int (Int8, Int16, Int32, Int64)
+import Data.Text (Text)
+import Data.Typeable (Typeable)
+import Data.Word (Word8, Word16, Word32, Word64)
+import qualified Haddock.Utils.Json.Encoding.Builder as EB
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text.Lazy as LT
+
+-- | An encoding of a JSON value.
+--
+-- @tag@ represents which kind of JSON the Encoding is encoding to,
+-- we reuse 'Text' and 'Value' as tags here.
+newtype Encoding' tag = Encoding {
+      fromEncoding :: Builder
+      -- ^ Acquire the underlying bytestring builder.
+    } deriving (Typeable)
+
+-- | Often used synonym for 'Encoding''.
+type Encoding = Encoding' Value
+
+-- | Make Encoding from Builder.
+--
+-- Use with care! You have to make sure that the passed Builder
+-- is a valid JSON Encoding!
+unsafeToEncoding :: Builder -> Encoding' a
+unsafeToEncoding = Encoding
+
+encodingToLazyByteString :: Encoding' a -> BSL.ByteString
+encodingToLazyByteString = toLazyByteString . fromEncoding
+{-# INLINE encodingToLazyByteString #-}
+
+retagEncoding :: Encoding' a -> Encoding' b
+retagEncoding = Encoding . fromEncoding
+
+-------------------------------------------------------------------------------
+-- Encoding instances
+-------------------------------------------------------------------------------
+
+instance Show (Encoding' a) where
+    show (Encoding e) = show (toLazyByteString e)
+
+instance Eq (Encoding' a) where
+    Encoding a == Encoding b = toLazyByteString a == toLazyByteString b
+
+instance Ord (Encoding' a) where
+    compare (Encoding a) (Encoding b) =
+      compare (toLazyByteString a) (toLazyByteString b)
+
+-- | A series of values that, when encoded, should be separated by
+-- commas. Since 0.11.0.0, the '.=' operator is overloaded to create
+-- either @(Text, Value)@ or 'Series'. You can use Series when
+-- encoding directly to a bytestring builder as in the following
+-- example:
+--
+-- > toEncoding (Person name age) = pairs ("name" .= name <> "age" .= age)
+data Series = Empty
+            | Value (Encoding' Series)
+            deriving (Typeable)
+
+pair :: Key -> Encoding -> Series
+pair name val = pair' (key name) val
+{-# INLINE pair #-}
+
+pairStr :: String -> Encoding -> Series
+pairStr name val = pair' (string name) val
+{-# INLINE pairStr #-}
+
+pair' :: Encoding' Key -> Encoding -> Series
+pair' name val = Value $ retagEncoding $ retagEncoding name >< colon >< val
+
+-- | A variant of a 'pair' where key is already encoded
+-- including the quotes and colon.
+--
+-- @
+-- 'pair' "foo" v = 'unsafePair' "\\"foo\\":" v
+-- @
+--
+-- @since 2.0.3.0
+--
+unsafePairSBS :: ShortByteString -> Encoding -> Series
+unsafePairSBS k v = Value $ retagEncoding $ Encoding (B.shortByteString k) >< v
+{-# INLINE unsafePairSBS #-}
+
+instance Semigroup Series where
+    Empty   <> a = a
+    Value a <> b = Value $ a >< case b of
+        Empty   -> empty
+        Value x -> comma >< x
+
+instance Monoid Series where
+    mempty  = Empty
+    mappend = (<>)
+
+nullEncoding :: Encoding' a -> Bool
+nullEncoding = BSL.null . toLazyByteString . fromEncoding
+
+emptyArray_ :: Encoding
+emptyArray_ = Encoding EB.emptyArray_
+
+emptyObject_ :: Encoding
+emptyObject_ = Encoding EB.emptyObject_
+
+wrapArray :: Encoding' a -> Encoding
+wrapArray e = retagEncoding $ openBracket >< e >< closeBracket
+
+wrapObject :: Encoding' a -> Encoding
+wrapObject e = retagEncoding $ openCurly >< e >< closeCurly
+
+null_ :: Encoding
+null_ = Encoding EB.null_
+
+bool :: Bool -> Encoding
+bool True = Encoding "true"
+bool False = Encoding "false"
+
+-- | Encode a series of key/value pairs, separated by commas.
+pairs :: Series -> Encoding
+pairs (Value v) = openCurly >< retagEncoding v >< closeCurly
+pairs Empty     = emptyObject_
+{-# INLINE pairs #-}
+
+list :: (a -> Encoding) -> [a] -> Encoding
+list _  []     = emptyArray_
+list to' (x:xs) = openBracket >< to' x >< commas xs >< closeBracket
+  where
+    commas = foldr (\v vs -> comma >< to' v >< vs) empty
+{-# INLINE list #-}
+
+-- | Encode as JSON object
+dict
+    :: (k -> Encoding' Key)                           -- ^ key encoding
+    -> (v -> Encoding)                                -- ^ value encoding
+    -> (forall a. (k -> v -> a -> a) -> a -> m -> a)  -- ^ @foldrWithKey@ - indexed fold
+    -> m                                              -- ^ container
+    -> Encoding
+dict encodeKey encodeVal foldrWithKey = pairs . foldrWithKey go mempty
+  where
+    go k v c = Value (encodeKV k v) <> c
+    encodeKV k v = retagEncoding (encodeKey k) >< colon >< retagEncoding (encodeVal v)
+{-# INLINE dict #-}
+
+-- | Type tag for tuples contents, see 'tuple'.
+data InArray
+
+infixr 6 >*<
+-- | See 'tuple'.
+(>*<) :: Encoding' a -> Encoding' b -> Encoding' InArray
+a >*< b = retagEncoding a >< comma >< retagEncoding b
+{-# INLINE (>*<) #-}
+
+empty :: Encoding' a
+empty = Encoding mempty
+
+econcat :: [Encoding' a] -> Encoding' a
+econcat = foldr (><) empty
+
+infixr 6 ><
+(><) :: Encoding' a -> Encoding' a -> Encoding' a
+Encoding a >< Encoding b = Encoding (a <> b)
+{-# INLINE (><) #-}
+
+-- | Encode as a tuple.
+--
+-- @
+-- toEncoding (X a b c) = tuple $
+--     toEncoding a >*<
+--     toEncoding b >*<
+--     toEncoding c
+tuple :: Encoding' InArray -> Encoding
+tuple b = retagEncoding $ openBracket >< b >< closeBracket
+{-# INLINE tuple #-}
+
+key :: Key -> Encoding' a
+key = text
+
+text :: Text -> Encoding' a
+text = Encoding . EB.text
+
+lazyText :: LT.Text -> Encoding' a
+lazyText t = Encoding $
+    B.char7 '"' <>
+    LT.foldrChunks (\x xs -> EB.unquoted x <> xs) (B.char7 '"') t
+
+string :: String -> Encoding' a
+string = Encoding . EB.string
+
+-------------------------------------------------------------------------------
+-- chars
+-------------------------------------------------------------------------------
+
+comma, colon, openBracket, closeBracket, openCurly, closeCurly :: Encoding' a
+comma        = Encoding $ char7 ','
+colon        = Encoding $ char7 ':'
+openBracket  = Encoding $ char7 '['
+closeBracket = Encoding $ char7 ']'
+openCurly    = Encoding $ char7 '{'
+closeCurly   = Encoding $ char7 '}'
+
+-------------------------------------------------------------------------------
+-- Decimal numbers
+-------------------------------------------------------------------------------
+
+int8 :: Int8 -> Encoding
+int8 = Encoding . B.int8Dec
+
+int16 :: Int16 -> Encoding
+int16 = Encoding . B.int16Dec
+
+int32 :: Int32 -> Encoding
+int32 = Encoding . B.int32Dec
+
+int64 :: Int64 -> Encoding
+int64 = Encoding . B.int64Dec
+
+int :: Int -> Encoding
+int = Encoding . B.intDec
+
+word8 :: Word8 -> Encoding
+word8 = Encoding . B.word8Dec
+
+word16 :: Word16 -> Encoding
+word16 = Encoding . B.word16Dec
+
+word32 :: Word32 -> Encoding
+word32 = Encoding . B.word32Dec
+
+word64 :: Word64 -> Encoding
+word64 = Encoding . B.word64Dec
+
+word :: Word -> Encoding
+word = Encoding . B.wordDec
+
+integer :: Integer -> Encoding
+integer = Encoding . B.integerDec
+
+float :: Float -> Encoding
+float = realFloatToEncoding $ Encoding . B.floatDec
+
+-- |
+--
+-- >>> double 42
+-- "42.0"
+--
+-- >>> double (0/0)
+-- "null"
+--
+-- >>> double (1/0)
+-- "\"+inf\""
+--
+-- >>> double (-23/0)
+-- "\"-inf\""
+--
+double :: Double -> Encoding
+double = realFloatToEncoding $ Encoding . B.doubleDec
+
+scientific :: Double -> Encoding
+scientific = Encoding . EB.scientific
+
+realFloatToEncoding :: RealFloat a => (a -> Encoding) -> a -> Encoding
+realFloatToEncoding e d
+    | isNaN d      = null_
+    | isInfinite d = if d > 0 then Encoding "\"+inf\"" else Encoding "\"-inf\""
+    | otherwise    = e d
+{-# INLINE realFloatToEncoding #-}
+
+-------------------------------------------------------------------------------
+-- Decimal numbers as Text
+-------------------------------------------------------------------------------
+
+int8Text :: Int8 -> Encoding' a
+int8Text = Encoding . EB.quote . B.int8Dec
+
+int16Text :: Int16 -> Encoding' a
+int16Text = Encoding . EB.quote . B.int16Dec
+
+int32Text :: Int32 -> Encoding' a
+int32Text = Encoding . EB.quote . B.int32Dec
+
+int64Text :: Int64 -> Encoding' a
+int64Text = Encoding . EB.quote . B.int64Dec
+
+intText :: Int -> Encoding' a
+intText = Encoding . EB.quote . B.intDec
+
+word8Text :: Word8 -> Encoding' a
+word8Text = Encoding . EB.quote . B.word8Dec
+
+word16Text :: Word16 -> Encoding' a
+word16Text = Encoding . EB.quote . B.word16Dec
+
+word32Text :: Word32 -> Encoding' a
+word32Text = Encoding . EB.quote . B.word32Dec
+
+word64Text :: Word64 -> Encoding' a
+word64Text = Encoding . EB.quote . B.word64Dec
+
+wordText :: Word -> Encoding' a
+wordText = Encoding . EB.quote . B.wordDec
+
+integerText :: Integer -> Encoding' a
+integerText = Encoding . EB.quote . B.integerDec
+
+floatText :: Float -> Encoding' a
+floatText d
+    | isInfinite d = if d > 0 then Encoding "\"+inf\"" else Encoding "\"-inf\""
+    | otherwise = Encoding . EB.quote . B.floatDec $ d
+
+-- |
+--
+-- >>> doubleText 42
+-- "\"42.0\""
+--
+-- >>> doubleText (0/0)
+-- "\"NaN\""
+--
+-- >>> doubleText (1/0)
+-- "\"+inf\""
+--
+-- >>> doubleText (-23/0)
+-- "\"-inf\""
+--
+doubleText :: Double -> Encoding' a
+doubleText d
+    | isInfinite d = if d > 0 then Encoding "\"+inf\"" else Encoding "\"-inf\""
+    | otherwise = Encoding . EB.quote . B.doubleDec $ d
+
+scientificText :: Double -> Encoding' a
+scientificText = Encoding . EB.quote . EB.scientific
+
+-------------------------------------------------------------------------------
+-- Value
+-------------------------------------------------------------------------------
+
+value :: Value -> Encoding
+value = Encoding . EB.encodeToBuilder
+

--- a/haddock-api/src/Haddock/Utils/Json/Encoding/Builder.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Encoding/Builder.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TupleSections #-}
+-- |
+-- Module:      Data.Aeson.Encoding.Builder
+-- Copyright:   (c) 2011 MailRank, Inc.
+--              (c) 2013 Simon Meier <iridcode@gmail.com>
+-- License:     BSD3
+-- Maintainer:  Bryan O'Sullivan <bos@serpentine.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- Efficiently serialize a JSON value using the UTF-8 encoding.
+
+module Haddock.Utils.Json.Encoding.Builder
+    (
+      encodeToBuilder
+    , null_
+    , bool
+    , array
+    , emptyArray_
+    , emptyObject_
+    , object
+    , text
+    , string
+    , unquoted
+    , quote
+    , scientific
+    , ascii2
+    , ascii4
+    , ascii5
+    ) where
+
+import Haddock.Utils.Json.Types (Value (..), KeyMap, Key)
+import qualified Data.List as KM
+import qualified Data.Foldable as KM
+import Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Builder as B
+import Data.ByteString.Builder.Prim ((>$<), (>*<))
+import qualified Data.ByteString.Builder.Prim as BP
+import Data.Char (chr, ord)
+import Data.Text.Encoding (encodeUtf8BuilderEscaped)
+import Data.Word (Word8)
+import qualified Data.Text as T
+
+-- | Encode a JSON value to a "Data.ByteString" 'B.Builder'.
+--
+-- Use this function if you are encoding over the wire, or need to
+-- prepend or append further bytes to the encoded JSON value.
+encodeToBuilder :: Value -> Builder
+encodeToBuilder Null       = null_
+encodeToBuilder (Bool b)   = bool b
+encodeToBuilder (Number n) = scientific n
+encodeToBuilder (String s) = text s
+encodeToBuilder (Array v)  = array v
+encodeToBuilder (Object m) = object m
+
+-- | Encode a JSON null.
+null_ :: Builder
+null_ = BP.primBounded (ascii4 ('n',('u',('l','l')))) ()
+
+-- | Encode a JSON boolean.
+bool :: Bool -> Builder
+bool = BP.primBounded (BP.condB id (ascii4 ('t',('r',('u','e'))))
+                                   (ascii5 ('f',('a',('l',('s','e'))))))
+
+-- | Encode a JSON array.
+array :: [] Value -> Builder
+array v
+  | null v  = emptyArray_
+  | otherwise = B.char8 '[' <>
+                encodeToBuilder (head v) <>
+                foldr withComma (B.char8 ']') (tail v)
+  where
+    withComma a z = B.char8 ',' <> encodeToBuilder a <> z
+
+-- Encode a JSON object.
+object :: KeyMap Value -> Builder
+object m = case KM.toList m of
+    (x:xs) -> B.char8 '{' <> one x <> foldr withComma (B.char8 '}') xs
+    _      -> emptyObject_
+  where
+    withComma a z = B.char8 ',' <> one a <> z
+    one (k,v)     = key k <> B.char8 ':' <> encodeToBuilder v
+
+-- | Encode a JSON key.
+key :: Key -> Builder
+key = text
+
+-- | Encode a JSON string.
+text :: T.Text -> Builder
+text t = B.char8 '"' <> unquoted t <> B.char8 '"'
+
+-- | Encode a JSON string, without enclosing quotes.
+unquoted :: T.Text -> Builder
+unquoted = encodeUtf8BuilderEscaped escapeAscii
+
+-- | Add quotes surrounding a builder
+quote :: Builder -> Builder
+quote b = B.char8 '"' <> b <> B.char8 '"'
+
+-- | Encode a JSON string.
+string :: String -> Builder
+string t = B.char8 '"' <> BP.primMapListBounded go t <> B.char8 '"'
+  where go = BP.condB (> '\x7f') BP.charUtf8 (c2w >$< escapeAscii)
+
+escapeAscii :: BP.BoundedPrim Word8
+escapeAscii =
+    BP.condB (== c2w '\\'  ) (ascii2 ('\\','\\')) $
+    BP.condB (== c2w '\"'  ) (ascii2 ('\\','"' )) $
+    BP.condB (>= c2w '\x20') (BP.liftFixedToBounded BP.word8) $
+    BP.condB (== c2w '\n'  ) (ascii2 ('\\','n' )) $
+    BP.condB (== c2w '\r'  ) (ascii2 ('\\','r' )) $
+    BP.condB (== c2w '\t'  ) (ascii2 ('\\','t' )) $
+    BP.liftFixedToBounded hexEscape -- fallback for chars < 0x20
+  where
+    hexEscape :: BP.FixedPrim Word8
+    hexEscape = (\c -> ('\\', ('u', fromIntegral c))) BP.>$<
+        BP.char8 >*< BP.char8 >*< BP.word16HexFixed
+{-# INLINE escapeAscii #-}
+
+c2w :: Char -> Word8
+c2w c = fromIntegral (ord c)
+
+-- | Encode a JSON number.
+scientific :: Double -> Builder
+scientific = B.doubleDec
+
+emptyArray_ :: Builder
+emptyArray_ = BP.primBounded (ascii2 ('[',']')) ()
+
+emptyObject_ :: Builder
+emptyObject_ = BP.primBounded (ascii2 ('{','}')) ()
+
+ascii2 :: (Char, Char) -> BP.BoundedPrim a
+ascii2 cs = BP.liftFixedToBounded $ const cs BP.>$< BP.char7 >*< BP.char7
+{-# INLINE ascii2 #-}
+
+ascii3 :: (Char, (Char, Char)) -> BP.BoundedPrim a
+ascii3 cs = BP.liftFixedToBounded $ const cs >$<
+    BP.char7 >*< BP.char7 >*< BP.char7
+{-# INLINE ascii3 #-}
+
+ascii4 :: (Char, (Char, (Char, Char))) -> BP.BoundedPrim a
+ascii4 cs = BP.liftFixedToBounded $ const cs >$<
+    BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7
+{-# INLINE ascii4 #-}
+
+ascii5 :: (Char, (Char, (Char, (Char, Char)))) -> BP.BoundedPrim a
+ascii5 cs = BP.liftFixedToBounded $ const cs >$<
+    BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7
+{-# INLINE ascii5 #-}
+
+ascii6 :: (Char, (Char, (Char, (Char, (Char, Char))))) -> BP.BoundedPrim a
+ascii6 cs = BP.liftFixedToBounded $ const cs >$<
+    BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7
+{-# INLINE ascii6 #-}
+
+ascii8 :: (Char, (Char, (Char, (Char, (Char, (Char, (Char, Char)))))))
+       -> BP.BoundedPrim a
+ascii8 cs = BP.liftFixedToBounded $ const cs >$<
+    BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7 >*<
+    BP.char7 >*< BP.char7 >*< BP.char7 >*< BP.char7
+{-# INLINE ascii8 #-}
+
+data T = T {-# UNPACK #-} !Char {-# UNPACK #-} !Char
+
+twoDigits :: Int -> T
+twoDigits a     = T (digit hi) (digit lo)
+  where (hi,lo) = a `quotRem` 10
+
+digit :: Int -> Char
+digit x = chr (x + 48)
+

--- a/haddock-api/src/Haddock/Utils/Json/Encoding/Builder.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Encoding/Builder.hs
@@ -65,13 +65,13 @@ bool = BP.primBounded (BP.condB id (ascii4 ('t',('r',('u','e'))))
 
 -- | Encode a JSON array.
 array :: [] Value -> Builder
-array v
-  | null v  = emptyArray_
-  | otherwise = B.char8 '[' <>
-                encodeToBuilder (head v) <>
-                foldr withComma (B.char8 ']') (tail v)
+array [] = emptyArray_
+array (x:xs) = B.char8 '[' <>
+                encodeToBuilder x <>
+                foldr withComma (B.char8 ']') xs
   where
     withComma a z = B.char8 ',' <> encodeToBuilder a <> z
+{-# INLINE array #-}
 
 -- Encode a JSON object.
 object :: KeyMap Value -> Builder

--- a/haddock-api/src/Haddock/Utils/Json/Parser.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Parser.hs
@@ -54,8 +54,8 @@ parseArray =
       (tok (Parsec.char ']'))
       (parseValue `Parsec.sepBy` tok (Parsec.char ','))
 
-parseString :: Parser Text.Text
-parseString = Text.pack <$>
+parseString :: Parser String
+parseString =
     Parsec.between
       (tok (Parsec.char '"'))
       (tok (Parsec.char '"'))
@@ -84,13 +84,13 @@ parseString = Text.pack <$>
                 max_char  = fromEnum (maxBound :: Char)
 
 parseObject :: Parser Object
-parseObject = Map.fromList <$>
+parseObject =
       Parsec.between
         (tok (Parsec.char '{'))
         (tok (Parsec.char '}'))
         (field `Parsec.sepBy` tok (Parsec.char ','))
   where
-    field :: Parser (Text.Text, Value)
+    field :: Parser (String, Value)
     field = (,)
         <$> parseString
         <*  tok (Parsec.char ':')

--- a/haddock-api/src/Haddock/Utils/Json/Parser.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Parser.hs
@@ -84,7 +84,7 @@ parseString = Text.pack <$>
                 max_char  = fromEnum (maxBound :: Char)
 
 parseObject :: Parser Object
-parseObject = Map.fromList <$>
+parseObject =
       Parsec.between
         (tok (Parsec.char '{'))
         (tok (Parsec.char '}'))

--- a/haddock-api/src/Haddock/Utils/Json/Parser.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Parser.hs
@@ -54,8 +54,8 @@ parseArray =
       (tok (Parsec.char ']'))
       (parseValue `Parsec.sepBy` tok (Parsec.char ','))
 
-parseString :: Parser String
-parseString =
+parseString :: Parser Text.Text
+parseString = Text.pack <$>
     Parsec.between
       (tok (Parsec.char '"'))
       (tok (Parsec.char '"'))
@@ -84,13 +84,13 @@ parseString =
                 max_char  = fromEnum (maxBound :: Char)
 
 parseObject :: Parser Object
-parseObject =
+parseObject = Map.fromList <$>
       Parsec.between
         (tok (Parsec.char '{'))
         (tok (Parsec.char '}'))
         (field `Parsec.sepBy` tok (Parsec.char ','))
   where
-    field :: Parser (String, Value)
+    field :: Parser (Text.Text, Value)
     field = (,)
         <$> parseString
         <*  tok (Parsec.char ':')

--- a/haddock-api/src/Haddock/Utils/Json/Parser.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Parser.hs
@@ -7,6 +7,7 @@ module Haddock.Utils.Json.Parser
 
 import Prelude hiding (null)
 
+import qualified Data.Text as Text
 import Control.Applicative (Alternative (..))
 import Control.Monad (MonadPlus (..))
 import Data.Char (isHexDigit)
@@ -16,8 +17,9 @@ import Numeric
 import Text.Parsec.ByteString.Lazy (Parser)
 import Text.ParserCombinators.Parsec ((<?>))
 import qualified Text.ParserCombinators.Parsec as Parsec
+import qualified Data.Map.Strict as Map
 
-import Haddock.Utils.Json.Types hiding (object)
+import Haddock.Utils.Json.Types
 
 parseJSONValue :: Parser Value
 parseJSONValue = Parsec.spaces *> parseValue
@@ -52,8 +54,8 @@ parseArray =
       (tok (Parsec.char ']'))
       (parseValue `Parsec.sepBy` tok (Parsec.char ','))
 
-parseString :: Parser String
-parseString =
+parseString :: Parser Text.Text
+parseString = Text.pack <$>
     Parsec.between
       (tok (Parsec.char '"'))
       (tok (Parsec.char '"'))
@@ -82,13 +84,13 @@ parseString =
                 max_char  = fromEnum (maxBound :: Char)
 
 parseObject :: Parser Object
-parseObject =
+parseObject = Map.fromList <$>
       Parsec.between
         (tok (Parsec.char '{'))
         (tok (Parsec.char '}'))
         (field `Parsec.sepBy` tok (Parsec.char ','))
   where
-    field :: Parser (String, Value)
+    field :: Parser (Text.Text, Value)
     field = (,)
         <$> parseString
         <*  tok (Parsec.char ':')

--- a/haddock-api/src/Haddock/Utils/Json/Types.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Types.hs
@@ -42,7 +42,7 @@ type KeyMap v = [(Key, v)]
 type Key = Text
 
 -- | A JSON \"object\" (key/value map).
-type Object = [Pair]
+type Object = KeyMap Value
 
 -- | Create a 'Value' from a list of name\/value 'Pair's.
 object :: [Pair] -> Value

--- a/haddock-api/src/Haddock/Utils/Json/Types.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Types.hs
@@ -4,20 +4,16 @@ module Haddock.Utils.Json.Types
   , Pair
   , Object
   , object
-  , Map
   ) where
 
 import Data.String
-import Data.Map (Map)
-import qualified Data.Map.Strict as Map
-import Data.Text (Text)
 
 -- TODO: We may want to replace 'String' with 'Text' or 'ByteString'
 
 -- | A JSON value represented as a Haskell value.
 data Value = Object !Object
-           | Array  ![Value]
-           | String  !Text
+           | Array  [Value]
+           | String  String
            | Number !Double
            | Bool   !Bool
            | Null
@@ -33,14 +29,14 @@ typeOf v = case v of
     Null     -> "Null"
 
 -- | A key\/value pair for an 'Object'
-type Pair = (Text, Value)
+type Pair = (String, Value)
 
 -- | A JSON \"object\" (key/value map).
-type Object = Map Text Value
+type Object = [Pair]
 
 -- | Create a 'Value' from a list of name\/value 'Pair's.
 object :: [Pair] -> Value
-object = Object . Map.fromList
+object = Object
 
 instance IsString Value where
-  fromString = String . fromString
+  fromString = String

--- a/haddock-api/src/Haddock/Utils/Json/Types.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Types.hs
@@ -36,11 +36,11 @@ typeOf v = case v of
 type Pair = (Text, Value)
 
 -- | A JSON \"object\" (key/value map).
-type Object = Map Text Value
+type Object = [Pair]
 
 -- | Create a 'Value' from a list of name\/value 'Pair's.
 object :: [Pair] -> Value
-object = Object . Map.fromList
+object = Object
 
 instance IsString Value where
   fromString = String . fromString

--- a/haddock-api/src/Haddock/Utils/Json/Types.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Types.hs
@@ -4,16 +4,20 @@ module Haddock.Utils.Json.Types
   , Pair
   , Object
   , object
+  , Map
   ) where
 
 import Data.String
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 
 -- TODO: We may want to replace 'String' with 'Text' or 'ByteString'
 
 -- | A JSON value represented as a Haskell value.
 data Value = Object !Object
-           | Array  [Value]
-           | String  String
+           | Array  ![Value]
+           | String  !Text
            | Number !Double
            | Bool   !Bool
            | Null
@@ -29,14 +33,14 @@ typeOf v = case v of
     Null     -> "Null"
 
 -- | A key\/value pair for an 'Object'
-type Pair = (String, Value)
+type Pair = (Text, Value)
 
 -- | A JSON \"object\" (key/value map).
-type Object = [Pair]
+type Object = Map Text Value
 
 -- | Create a 'Value' from a list of name\/value 'Pair's.
 object :: [Pair] -> Value
-object = Object
+object = Object . Map.fromList
 
 instance IsString Value where
-  fromString = String
+  fromString = String . fromString

--- a/haddock-api/src/Haddock/Utils/Json/Types.hs
+++ b/haddock-api/src/Haddock/Utils/Json/Types.hs
@@ -3,6 +3,8 @@ module Haddock.Utils.Json.Types
   , typeOf
   , Pair
   , Object
+  , KeyMap
+  , Key
   , object
   , Map
   ) where
@@ -11,13 +13,14 @@ import Data.String
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import Data.ByteString.Builder
 
 -- TODO: We may want to replace 'String' with 'Text' or 'ByteString'
 
 -- | A JSON value represented as a Haskell value.
 data Value = Object !Object
-           | Array  ![Value]
-           | String  !Text
+           | Array  [Value]
+           | String !Text
            | Number !Double
            | Bool   !Bool
            | Null
@@ -34,6 +37,9 @@ typeOf v = case v of
 
 -- | A key\/value pair for an 'Object'
 type Pair = (Text, Value)
+
+type KeyMap v = [(Key, v)]
+type Key = Text
 
 -- | A JSON \"object\" (key/value map).
 type Object = [Pair]


### PR DESCRIPTION
So, `aeson` may be out (#1558), but what if we used `Text` and `Map` instead of `String` and `[]`?

It ain't looking too good.

In fact, it looks downright *weird*!

## Basline

```
time cabal haddock --haddock-options "-v2 --quickjump +RTS -s -RTS --optghc=\"-v2\" --lib=/home/matt/Projects/haddock/haddock-api/resources" persistent --with-haddock=/home/matt/.cabal/bin/haddock-943
```

```
!!! renameAllInterfaces: finished in 112.10 milliseconds, allocated 232.280 megabytes
*** ppJsonIndex:
!!! ppJsonIndex: finished in 1568.96 milliseconds, allocated 7682.663 megabytes
*** ppHtml:
*** ppHtmlContents:
!!! ppHtmlContents: finished in 0.73 milliseconds, allocated 2.298 megabytes
*** ppJsonIndex:
!!! ppJsonIndex: finished in 26.43 milliseconds, allocated 129.281 megabytes

  24,248,235,776 bytes allocated in the heap
   3,644,045,200 bytes copied during GC
     379,247,624 bytes maximum residency (16 sample(s))
       5,837,816 bytes maximum slop
             968 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5794 colls,     0 par    1.573s   1.575s     0.0003s    0.0028s
  Gen  1        16 colls,     0 par    1.255s   1.498s     0.0936s    0.3925s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    5.647s  (  6.241s elapsed)
  GC      time    2.828s  (  3.074s elapsed)
  EXIT    time    0.001s  (  0.005s elapsed)
  Total   time    8.476s  (  9.320s elapsed)

  Alloc rate    4,294,171,488 bytes per MUT second

  Productivity  66.6% of total user, 67.0% of total elapsed
```

Same baseline in #1558 

## Just with encoding improvements

The `encode-to-builder` stuff isn't great - it's inefficiently allocating a bunch of extra lists.
The `foldMap charToBuilder` thing is also wasteful.
Fix that up, using some of the code from `aeson`, and we got:

```
!!! ppJsonIndex: finished in 1711.11 milliseconds, allocated 7466.382 megabytes

  24,001,682,632 bytes allocated in the heap
   3,638,025,448 bytes copied during GC
     378,503,736 bytes maximum residency (16 sample(s))
       5,823,944 bytes maximum slop
             965 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5731 colls,     0 par    1.582s   1.585s     0.0003s    0.0028s
  Gen  1        16 colls,     0 par    1.184s   1.184s     0.0740s    0.2534s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    5.832s  (  6.344s elapsed)
  GC      time    2.766s  (  2.768s elapsed)
  EXIT    time    0.001s  (  0.008s elapsed)
  Total   time    8.599s  (  9.120s elapsed)

  Alloc rate    4,115,707,641 bytes per MUT second

  Productivity  67.8% of total user, 69.6% of total elapsed
```

Saving ~3MB total memory use, 248MB total allocations.
Both JSON index generation and total runtime is slower: index generation is 1711.11ms vs 1568ms. 
JSON allocations are down from 7682 MB to 7466 MB, but total memory use barely moved.

Weird.

## With `Text` instead of `String`

`Text` is more efficient than `String`, right? This should be a lot better.

```
!!! ppJsonIndex: finished in 1633.03 milliseconds, allocated 7908.335 megabytes

  24,466,968,592 bytes allocated in the heap
   3,856,359,552 bytes copied during GC
     321,971,216 bytes maximum residency (17 sample(s))
       5,727,096 bytes maximum slop
             847 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5843 colls,     0 par    1.635s   1.638s     0.0003s    0.0028s
  Gen  1        17 colls,     0 par    1.231s   1.231s     0.0724s    0.1985s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    5.753s  (  6.315s elapsed)
  GC      time    2.867s  (  2.869s elapsed)
  EXIT    time    0.001s  (  0.005s elapsed)
  Total   time    8.620s  (  9.190s elapsed)

  Alloc rate    4,253,272,960 bytes per MUT second

  Productivity  66.7% of total user, 68.7% of total elapsed

```

Nice - saving ~80ms on the JSON index.
But allocationsare up to 7908 MB - 500MB *more* than `String`, and ~220MB more than the encoding.

The overall memory use is *somehow* down to 847 MB from 965 MB, despite allocating more.
Curious.

## List to Map

This replaces the `[(Text, Value)]` with `Map Text Value`.

```
!!! ppJsonIndex: finished in 1699.28 milliseconds, allocated 7925.515 megabytes

  24,485,299,144 bytes allocated in the heap
   3,855,818,800 bytes copied during GC
     320,293,448 bytes maximum residency (17 sample(s))
       5,733,944 bytes maximum slop
             842 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5847 colls,     0 par    1.656s   1.659s     0.0003s    0.0029s
  Gen  1        17 colls,     0 par    1.196s   1.197s     0.0704s    0.1980s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    5.778s  (  6.295s elapsed)
  GC      time    2.852s  (  2.855s elapsed)
  EXIT    time    0.001s  (  0.010s elapsed)
  Total   time    8.632s  (  9.160s elapsed)

  Alloc rate    4,237,462,312 bytes per MUT second

  Productivity  66.9% of total user, 68.7% of total elapsed
```

... Slightly slower still, with worse allocations.

# Further Work

`aeson` improved JSON index generation time by 76% and allocations by 90%. These patches make things *worse*, though also somehow reduce overall memory use by a decent amount. What gives?

The index generation code basically just does `encodeToBuilder . toJSON`, which makes a big `[Object]`, where each `Object` is a map of four `String`s. I suspect that copying more of the `Value -> Builder` code into Haddock should help.