### PR TITLE
Using `lucid` for HTML generation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,6 @@ packages: ./
           ./haddock-library
           ./haddock-test
 
-with-compiler: ghc-9.4
-
 allow-newer:
   ghc-paths:Cabal,
   *:base,

--- a/haddock-api/haddock-api.cabal
+++ b/haddock-api/haddock-api.cabal
@@ -41,15 +41,17 @@ data-files:
 
 library
   default-language: Haskell2010
+  default-extensions: 
+    FlexibleContexts
 
   -- this package typically supports only single major versions
   build-depends: base            ^>= 4.16.0
                , ghc             ^>= 9.4
                , ghc-paths       ^>= 0.1.0.9
                , haddock-library ^>= 1.11
-               , xhtml           ^>= 3000.2.2
                , parsec          ^>= 3.1.13.0
                , text            ^>= 2.0
+               , lucid
 
   -- Versions for the dependencies below are transitively pinned by
   -- the non-reinstallable `ghc` package and hence need no version

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -439,7 +439,7 @@ render log' dflags unit_state flags sinceQual qual ifaces packages extSrcMap = d
   when (Flag_GenIndex `elem` flags) $ do
     withTiming logger "ppHtmlIndex" (const ()) $ do
       _ <- {-# SCC ppHtmlIndex #-}
-           ppHtmlIndex odir title pkgStr
+           ppHtmlIndex logger odir title pkgStr
                   themes opt_mathjax opt_contents_url sourceUrls' opt_wiki_urls
                   (concatMap piInstalledInterfaces allVisiblePackages) pretty
       return ()

--- a/haddock-api/src/Haddock/Backends/Hyperlinker.hs
+++ b/haddock-api/src/Haddock/Backends/Hyperlinker.hs
@@ -16,6 +16,7 @@ import Haddock.Backends.Hyperlinker.Types
 import Haddock.Backends.Hyperlinker.Utils
 import Haddock.Backends.Xhtml.Utils ( renderToString )
 
+import Lucid
 import Data.Maybe
 import System.Directory
 import System.FilePath
@@ -95,7 +96,7 @@ ppHyperlinkedModuleSource logger verbosity srcdir pretty srcs iface =
         let tokens = fmap (\tk -> tk {tkSpan = (tkSpan tk){srcSpanFile = srcSpanFile $ nodeSpan fullAst}}) tokens'
 
         -- Produce and write out the hyperlinked sources
-        writeUtf8File path . renderToString pretty . render' fullAst $ tokens
+        renderToFile path . render' fullAst $ tokens
     Nothing -> return ()
   where
     df = ifaceDynFlags iface

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -62,7 +62,6 @@ import GHC.Types.Name
 import GHC.Unit.State
 
 import qualified Lucid
-import Lucid.Base (makeAttribute)
 
 --------------------------------------------------------------------------------
 -- * Generating HTML documentation
@@ -346,7 +345,7 @@ ppHtmlContents logger state odir doctitle _maybe_package
             ppModuleTrees pkg qual trees
 
   createDirectoryIfMissing True odir
-  writeUtf8File (joinPath [odir, contentsHtmlFile]) (renderToString debug html)
+  renderToFile (joinPath [odir, contentsHtmlFile]) html
   where
     -- Extract a module's short description.
     toInstalledDescription :: InstalledInterface -> Maybe (MDoc Name)
@@ -578,9 +577,9 @@ ppHtmlIndex odir doctitle _maybe_package themes
     mapM_ (do_sub_index index) initialChars
     -- Let's add a single large index as well for those who don't know exactly what they're looking for:
     let mergedhtml = indexPage False Nothing index
-    writeUtf8File (joinPath [odir, subIndexHtmlFile merged_name]) (renderToString debug mergedhtml)
+    renderToFile (joinPath [odir, subIndexHtmlFile merged_name]) mergedhtml
 
-  writeUtf8File (joinPath [odir, indexHtmlFile]) (renderToString debug html)
+  renderToFile (joinPath [odir, indexHtmlFile]) html
 
   where
     timed = withTiming logger (fromString "ppHtmlIndex") (const ())

--- a/haddock-api/src/Haddock/Backends/Xhtml.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml.hs
@@ -219,7 +219,7 @@ bodyHtml doctitle iface
            pageContent =
   body_ $ do
     divPackageHeader $ do
-      nonEmptySectionName $ toHtml doctitle
+      nonEmptySectionName doctitle
       unordList (catMaybes [
         srcButton maybe_source_url iface,
         wikiButton maybe_wiki_url (ifaceMod <$> iface),
@@ -754,11 +754,15 @@ ifaceToHtml maybe_source_url maybe_wiki_url iface unicode pkg qual
 
     no_doc_at_all = not (any has_doc exports)
 
-    description | isNoHtml doc = doc
-                | otherwise    = divDescription $ do
-                    sectionName "Description"
-                    doc
-                where doc = docSection Nothing pkg qual (ifaceRnDoc iface)
+    description =
+      case mdoc of
+        Nothing -> mempty
+        Just doc ->
+          divDescription $ do
+            sectionName "Description"
+            doc
+      where
+        mdoc = docSection Nothing pkg qual (ifaceRnDoc iface)
 
         -- omit the synopsis if there are no documentation annotations at all
     synopsis

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -127,10 +127,10 @@ ppTypeOrFunSig :: Bool -> LinksInfo -> SrcSpan -> [DocName] -> HsSigType DocName
 ppTypeOrFunSig summary links loc docnames typ (doc, argDocs) (pref1, pref2, sep)
                splice unicode pkg qual emptyCtxts
   | summary = pref1
-  | Map.null argDocs = topDeclElem links loc splice docnames pref1 +++ docSection curname pkg qual doc
+  | Map.null argDocs = topDeclElem links loc splice docnames pref1 +++ sequence_ (docSection curname pkg qual doc)
   | otherwise = topDeclElem links loc splice docnames pref2
                   +++ subArguments pkg qual (ppSubSigLike unicode qual typ argDocs [] sep emptyCtxts)
-                  +++ docSection curname pkg qual doc
+                  +++ sequence_ (docSection curname pkg qual doc)
   where
     curname = getName <$> listToMaybe docnames
 
@@ -293,7 +293,7 @@ ppFamDecl :: Bool                     -- ^ is a summary
           -> Splice -> Unicode -> Maybe Package -> Qualification -> Html
 ppFamDecl summary associated links instances fixities loc doc decl splice unicode pkg qual
   | summary   = ppFamHeader True associated decl unicode qual
-  | otherwise = header_ +++ docSection curname pkg qual doc +++ instancesBit
+  | otherwise = header_ +++ sequence_ (docSection curname pkg qual doc) +++ instancesBit
 
   where
     docname = unLoc $ fdLName decl
@@ -539,7 +539,7 @@ ppClassDecl summary links instances fixities loc d subdocs
                         , tcdFDs = lfds, tcdSigs = lsigs, tcdATs = ats, tcdATDefs = atsDefs })
             splice unicode pkg qual
   | summary = ppShortClassDecl summary links decl loc subdocs splice unicode pkg qual
-  | otherwise = classheader +++ docSection curname pkg qual d
+  | otherwise = classheader +++ sequence_ (docSection curname pkg qual d)
                   +++ minimalBit +++ atBit +++ methodBit +++ instancesBit
   where
     curname = Just $ getName nm
@@ -810,7 +810,7 @@ ppDataDecl summary links instances fixities subdocs loc doc dataDecl pats
            splice unicode pkg qual
 
   | summary   = ppShortDataDecl summary False dataDecl pats unicode qual
-  | otherwise = header_ +++ docSection curname pkg qual doc +++ constrBit +++ patternBit +++ instancesBit
+  | otherwise = header_ +++ sequence_ (docSection curname pkg qual doc) +++ constrBit +++ patternBit +++ instancesBit
 
   where
     docname   = tcdNameI dataDecl

--- a/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Decl.hs
@@ -33,7 +33,6 @@ import           Data.List             ( intersperse, sort )
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Void             ( absurd )
-import           Text.XHtml hiding     ( name, title, p, quote )
 
 import GHC.Core.Type ( Specificity(..) )
 import GHC.Types.Basic (PromotionFlag(..), isPromoted)
@@ -202,7 +201,7 @@ ppFixities :: [(DocName, Fixity)] -> Qualification -> Html
 ppFixities [] _ = noHtml
 ppFixities fs qual = foldr1 (+++) (map ppFix uniq_fs) +++ rightEdge
   where
-    ppFix (ns, p, d) = thespan ! [theclass "fixity"] <<
+    ppFix (ns, p, d) = span_ [class_ "fixity"] $
                          (toHtml d <+> toHtml (show p) <+> ppNames ns)
 
     ppDir InfixR = "infixr"
@@ -211,13 +210,13 @@ ppFixities fs qual = foldr1 (+++) (map ppFix uniq_fs) +++ rightEdge
 
     ppNames = case fs of
       _:[] -> const noHtml -- Don't display names for fixities on single names
-      _    -> concatHtml . intersperse (stringToHtml ", ") . map (ppDocName qual Infix False)
+      _    -> concatHtml . intersperse (", ") . map (ppDocName qual Infix False)
 
     uniq_fs = [ (n, the p, the d') | (n, Fixity _ p d) <- fs
                                    , let d' = ppDir d
                                    , then group by Down (p,d') using groupWith ]
 
-    rightEdge = thespan ! [theclass "rightedge"] << noHtml
+    rightEdge = span_ [class_ "rightedge"] noHtml
 
 
 -- | Pretty-print type variables.
@@ -261,7 +260,7 @@ ppTypeSig :: Bool -> [OccName] -> Html -> Unicode -> Html
 ppTypeSig summary nms pp_ty unicode =
   concatHtml htmlNames <+> dcolon unicode <+> pp_ty
   where
-    htmlNames = intersperse (stringToHtml ", ") $ map (ppBinder summary) nms
+    htmlNames = intersperse (", ") $ map (ppBinder summary) nms
 
 ppSimpleSig :: LinksInfo -> Splice -> Unicode -> Qualification -> HideEmptyContexts -> SrcSpan
             -> [DocName] -> HsSigType DocNameI
@@ -628,8 +627,9 @@ ppClassDecl summary links instances fixities loc d subdocs
       _ -> noHtml
 
     ppMinimal _ (Var (L _ n)) = ppDocName qual Prefix True n
-    ppMinimal _ (And fs) = foldr1 (\a b -> a+++", "+++b) $ map (ppMinimal True . unLoc) fs
-    ppMinimal p (Or fs) = wrap $ foldr1 (\a b -> a+++" | "+++b) $ map (ppMinimal False . unLoc) fs
+    ppMinimal _ (And fs) =
+      foldr1 (\a b -> a +++ ", " +++b) $ map (ppMinimal True . unLoc) fs
+    ppMinimal p (Or fs) = wrap $ foldr1 (\a b -> a +++ " | " +++ b) $ map (ppMinimal False . unLoc) fs
       where wrap | p = parens | otherwise = id
     ppMinimal p (Parens x) = ppMinimal p (unLoc x)
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/DocMarkup.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/DocMarkup.hs
@@ -251,16 +251,17 @@ rdrDocToHtml pkg qual = markupHacked fmt pkg Nothing . cleanup
 
 docElement :: (Html -> Html) -> Html -> Html
 docElement el content =
-  if isNoHtml content
-    then el spaceHtml `with` [class_ "doc empty"]
-    else el content `with` [class_ "doc"]
+--   if isNoHtml content
+--     then el spaceHtml `with` [class_ "doc empty"]
+--     else
+    el content `with` [class_ "doc"]
 
 
 docSection :: Maybe Name -- ^ Name of the thing this doc is for
            -> Maybe Package -- ^ Current package
-           -> Qualification -> Documentation DocName -> Html
+           -> Qualification -> Documentation DocName -> Maybe Html
 docSection n pkg qual =
-  maybe noHtml (docSection_ n pkg qual) . combineDocumentation
+  fmap (docSection_ n pkg qual) . combineDocumentation
 
 
 docSection_ :: Maybe Name    -- ^ Name of the thing this doc is for

--- a/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Layout.hs
@@ -78,10 +78,10 @@ sectionName = p_ [class_ "caption"]
 
 -- | Make an element that always has at least something (a non-breaking space).
 -- If it would have otherwise been empty, then give it the class ".empty".
-nonEmptySectionName :: Html -> Html
+nonEmptySectionName :: String -> Html
 nonEmptySectionName c
-  | isNoHtml c = span_ [class_ "caption empty"] $ spaceHtml
-  | otherwise  = span_ [class_ "caption"]       $ c
+  | null c = span_ [class_ "caption empty"] $ spaceHtml
+  | otherwise  = span_ [class_ "caption"]       $ toHtml c
 
 
 divPackageHeader, divContent, divModuleHeader, divFooter,

--- a/haddock-api/src/Haddock/Backends/Xhtml/Themes.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Themes.hs
@@ -1,3 +1,4 @@
+{-# language OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Haddock.Backends.Html.Themes
@@ -18,7 +19,8 @@ module Haddock.Backends.Xhtml.Themes (
 
 import Haddock.Options
 import Haddock.Utils (ordNub)
-import Haddock.Backends.Xhtml.Types ( BaseURL, withBaseURL )
+import Haddock.Backends.Xhtml.Types
+import qualified Data.Text as Text
 
 import Control.Monad (liftM)
 import Data.Char (toLower)
@@ -27,8 +29,6 @@ import Data.Maybe (isJust, listToMaybe)
 
 import System.Directory
 import System.FilePath
-import Text.XHtml hiding ( name, title, p, quote, (</>) )
-import qualified Text.XHtml as XHtml
 
 
 --------------------------------------------------------------------------------
@@ -178,15 +178,16 @@ cssFiles ts = ordNub $ concatMap themeFiles ts
 
 
 styleSheet :: BaseURL -> Themes -> Html
-styleSheet base_url ts = toHtml $ zipWith mkLink rels ts
+styleSheet base_url ts = sequence_ $ zipWith mkLink rels ts
   where
     rels = "stylesheet" : repeat "alternate stylesheet"
     mkLink aRel t =
-      thelink
-        ! [ href (withBaseURL base_url (themeHref t)),  rel aRel, thetype "text/css",
-            XHtml.title (themeName t)
-          ]
-        << noHtml
+      link_
+        [ href_ (Text.pack $ withBaseURL base_url (themeHref t))
+        , rel_ aRel
+        , type_ "text/css"
+        , title_ (Text.pack $ themeName t)
+        ]
 
 --------------------------------------------------------------------------------
 -- * Either Utilities

--- a/haddock-api/src/Haddock/Backends/Xhtml/Types.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Types.hs
@@ -17,13 +17,61 @@ module Haddock.Backends.Xhtml.Types (
   LinksInfo,
   Splice,
   Unicode,
+  -- * Lucid Shims
+  Html,
+  makeAttribute,
+  isNoHtml,
+  noHtml,
+  spaceHtml,
+  traverse_,
+  (+++),
+  defList,
+  concatHtml,
+  module Lucid,
+  unordList,
+  for_
 ) where
 
 
+import Data.Foldable (traverse_, for_)
 import Data.Map
 import GHC
 import qualified System.FilePath as FilePath
 
+import Lucid as Lucid hiding (Html, for_)
+import qualified Lucid as L
+import Lucid.Base (makeAttribute)
+import qualified Data.Text.Lazy as LText
+
+type Html = L.Html ()
+
+unordList :: [Html] -> Html
+unordList = ul_ . traverse_ li_
+
+isNoHtml :: Html -> Bool
+isNoHtml html =
+    LText.null (renderText html)
+
+noHtml :: Html
+noHtml = mempty
+
+concatHtml :: ToHtml a => [a] -> Html
+concatHtml = foldMap toHtml
+
+defList :: (ToHtml a, ToHtml b) => [(a, b)] -> Html
+defList items =
+  dl_ $ do
+    for_ items $ \(dt, dd) -> do
+      dt_ $ toHtml dt
+      dd_ $ toHtml dd
+
+
+-- | A @&nbsp@
+spaceHtml :: Html
+spaceHtml = toHtmlRaw "&nbsp"
+
+(+++) :: Html -> Html -> Html
+(+++) = (<>)
 
 -- the base, module and entity URLs for the source code and wiki links.
 type SourceURLs = (Maybe FilePath, Maybe FilePath, Map Unit FilePath, Map Unit FilePath)

--- a/haddock-api/src/Haddock/Backends/Xhtml/Types.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Types.hs
@@ -20,7 +20,6 @@ module Haddock.Backends.Xhtml.Types (
   -- * Lucid Shims
   Html,
   makeAttribute,
-  isNoHtml,
   noHtml,
   spaceHtml,
   traverse_,
@@ -47,10 +46,6 @@ type Html = L.Html ()
 
 unordList :: [Html] -> Html
 unordList = ul_ . traverse_ li_
-
-isNoHtml :: Html -> Bool
-isNoHtml html =
-    LText.null (renderText html)
 
 noHtml :: Html
 noHtml = mempty

--- a/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
@@ -129,17 +129,13 @@ vcat htmls = foldr1 (\a b -> a+++ br_ [] +++b) htmls
 
 infixr 8 <+>
 (<+>) :: Html -> Html -> Html
-a <+> b = a +++ sep +++ b
-  where
-    sep = if isNoHtml a || isNoHtml b then noHtml else " "
+a <+> b = a +++ " " +++ b
 
 -- | Join two 'Html' values together with a linebreak in between.
 --   Has 'noHtml' as left identity.
 infixr 8 <=>
 (<=>) :: Html -> Html -> Html
-a <=> b = a +++ sep +++ b
-  where
-    sep = if isNoHtml a then noHtml else br_ []
+a <=> b = a +++ br_ [] +++ b
 
 
 

--- a/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
+++ b/haddock-api/src/Haddock/Backends/Xhtml/Utils.hs
@@ -40,6 +40,8 @@ import Haddock.GhcUtils
 
 import Data.Functor.Identity
 import Data.Maybe
+import Data.Text (Text)
+import Data.ByteString.Builder
 
 import Haddock.Backends.Xhtml.Types
 
@@ -129,7 +131,7 @@ infixr 8 <+>
 (<+>) :: Html -> Html -> Html
 a <+> b = a +++ sep +++ b
   where
-    sep = if isNoHtml a || isNoHtml b then noHtml else toHtml " "
+    sep = if isNoHtml a || isNoHtml b then noHtml else " "
 
 -- | Join two 'Html' values together with a linebreak in between.
 --   Has 'noHtml' as left identity.
@@ -166,7 +168,7 @@ promoQuote h = char '\'' +++ h
 parens, brackets, pabrackets, braces :: Html -> Html
 parens h        = char '(' +++ h +++ char ')'
 brackets h      = char '[' +++ h +++ char ']'
-pabrackets h    = toHtml "[:" +++ h +++ toHtml ":]"
+pabrackets h    = "[:" +++ h +++ ":]"
 braces h        = char '{' +++ h +++ char '}'
 
 
@@ -187,26 +189,26 @@ ubxParenList = ubxparens . hsep . punctuate comma
 
 
 ubxSumList :: [Html]  -> Html
-ubxSumList = ubxparens . hsep . punctuate (toHtml " | ")
+ubxSumList = ubxparens . hsep . punctuate (" | ")
 
 
 ubxparens :: Html -> Html
-ubxparens h = toHtml "(#" <+> h <+> toHtml "#)"
+ubxparens h = "(#" <+> h <+> "#)"
 
 
 dcolon, arrow, lollipop, darrow, forallSymbol, atSign :: Bool -> Html
-dcolon unicode = toHtml (if unicode then "∷" else "::")
-arrow  unicode = toHtml (if unicode then "→" else "->")
-lollipop unicode = toHtml (if unicode then "⊸" else "%1 ->")
-darrow unicode = toHtml (if unicode then "⇒" else "=>")
-forallSymbol unicode = if unicode then toHtml "∀" else keyword "forall"
-atSign unicode = toHtml (if unicode then "@" else "@")
+dcolon unicode = (if unicode then "∷" else "::")
+arrow  unicode = (if unicode then "→" else "->")
+lollipop unicode = (if unicode then "⊸" else "%1 ->")
+darrow unicode = (if unicode then "⇒" else "=>")
+forallSymbol unicode = if unicode then "∀" else keyword "forall"
+atSign unicode = if unicode then "@" else "@"
 
 multAnnotation :: Html
-multAnnotation = toHtml "%"
+multAnnotation = "%"
 
 dot :: Html
-dot = toHtml "."
+dot = "."
 
 
 -- | Generate a named a_

--- a/haddock-api/src/Haddock/GhcUtils.hs
+++ b/haddock-api/src/Haddock/GhcUtils.hs
@@ -29,6 +29,7 @@ import Data.Maybe ( mapMaybe, fromMaybe )
 
 import Haddock.Types( DocName, DocNameI, XRecCond )
 
+import GHC.Data.FastString
 import GHC.Utils.FV as FV
 import GHC.Utils.Outputable ( Outputable )
 import GHC.Utils.Panic ( panic )
@@ -53,11 +54,21 @@ import qualified GHC.Data.StringBuffer             as S
 import           Data.ByteString ( ByteString )
 import qualified Data.ByteString          as BS
 import qualified Data.ByteString.Internal as BS
+import Data.Text (Text)
+import qualified Data.ByteString.Short as SBS
+import qualified Data.Text.Array as A
+import qualified Data.Text.Internal as Text.Internal
 
 import GHC.HsToCore.Docs
 
 moduleString :: Module -> String
 moduleString = moduleNameString . moduleName
+
+moduleText :: Module -> Text
+moduleText = moduleNameText . moduleName
+
+moduleNameText :: ModuleName -> Text
+moduleNameText = fastStringToText . moduleNameFS
 
 isNameSym :: Name -> Bool
 isNameSym = isSymOcc . nameOccName
@@ -754,3 +765,9 @@ defaultRuntimeRepVars = go emptyVarEnv
 
 fromMaybeContext :: Maybe (LHsContext DocNameI) -> HsContext DocNameI
 fromMaybeContext mctxt = unLoc $ fromMaybe (noLocA []) mctxt
+
+fastStringToText :: FastString -> Text
+fastStringToText fs =
+  let !sbs@(SBS.SBS arr) = fastStringToShortByteString fs
+   in Text.Internal.Text (A.ByteArray arr) 0 (SBS.length sbs)
+

--- a/haddock-api/src/Haddock/Utils.hs
+++ b/haddock-api/src/Haddock/Utils.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-record-updates #-}
 -----------------------------------------------------------------------------
@@ -53,6 +54,7 @@ module Haddock.Utils (
 
 
 import qualified Data.Set as Set
+import Data.String
 import Documentation.Haddock.Doc (emptyMetaDoc)
 import Haddock.Types
 
@@ -148,7 +150,7 @@ moduleHtmlFile' mdl =
     Just fp0 -> HtmlPath.joinPath [fp0, baseName mdl ++ ".html"]
 
 
-contentsHtmlFile, indexHtmlFile, indexJsonFile :: String
+contentsHtmlFile, indexHtmlFile, indexJsonFile :: IsString s => s
 contentsHtmlFile = "index.html"
 indexHtmlFile = "doc-index.html"
 indexJsonFile = "doc-index.json"
@@ -264,7 +266,7 @@ escapeURIString = concatMap . escapeURIChar
 
 
 isUnreserved :: Char -> Bool
-isUnreserved c = isAlphaNumChar c || (c `elem` "-_.~")
+isUnreserved c = isAlphaNumChar c || (c `elem` ("-_.~" :: String))
 
 
 isAlphaChar, isDigitChar, isAlphaNumChar :: Char -> Bool


### PR DESCRIPTION
This PR uses `lucid` for HTML generation, mostly as a test.

# Baseline

The baseline is the `ghc-9.4` branch , not my `xhtml` builder patch.

```
!!! ppHtml: finished in 229.42 milliseconds, allocated 1087.125 megabytes

  16,064,701,512 bytes allocated in the heap
   2,265,714,656 bytes copied during GC
     191,524,344 bytes maximum residency (14 sample(s))
       5,218,824 bytes maximum slop
             493 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      3820 colls,     0 par    1.220s   1.222s     0.0003s    0.0035s
  Gen  1        14 colls,     0 par    0.703s   0.704s     0.0503s    0.1284s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    4.838s  (  5.365s elapsed)
  GC      time    1.923s  (  1.925s elapsed)
  EXIT    time    0.001s  (  0.009s elapsed)
  Total   time    6.762s  (  7.300s elapsed)

  Alloc rate    3,320,501,272 bytes per MUT second

  Productivity  71.5% of total user, 73.5% of total elapsed
```

# Lucid

```
!!! ppHtml: finished in 445.94 milliseconds, allocated 2262.033 megabytes

  17,296,688,776 bytes allocated in the heap
   2,251,719,184 bytes copied during GC
     191,537,256 bytes maximum residency (14 sample(s))
       5,267,352 bytes maximum slop
             493 MiB total memory in use (0 MB lost due to fragmentation)
                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      3969 colls,     0 par    1.232s   1.234s     0.0003s    0.0034s
  Gen  1        14 colls,     0 par    0.711s   0.711s     0.0508s    0.1275s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    5.068s  (  5.588s elapsed)
  GC      time    1.943s  (  1.945s elapsed)
  EXIT    time    0.001s  (  0.007s elapsed)
  Total   time    7.012s  (  7.540s elapsed)

  Alloc rate    3,412,872,044 bytes per MUT second

  Productivity  72.3% of total user, 74.1% of total elapsed
```

# Comparison

| | Baseline | Patched | Difference | Improvement |
|-|----------|---------|------------|-------------|
 | HTML Time | 229.42 | 445.94 | -216.52 | -94% | 
 | HTML Allocations | 1087.125 | 2262.033 | -1174.908 | -108% | 
 | Total Allocations | 16064.0 | 17296.0 | -1232.0 | -7% | 
 | Max Residency | 191.0 | 191.0 | 0.0 | 0.0% | 
 | Total Memory | 493.0 | 493.0 | 0.0 | 0.0% | 
 | Total Time | 6.762 | 7.012 | -0.25 | -3.7% | 

Very surprising! `lucid` is twice as slow.

Now, I suspect that the `isNoHtml` thing is part of that. With the Lucid representation, we're actually having to run the whole `Seq Attribute -> Builder`, then converting that `Builder` to a bytestring, and finally checking if it is `null`. This is very fast with `xhtml` - the `isNoHtml` check is a `null` on a list.

# Banning `isNoHtml`

Without `isNoHtml` to ruin the party, we get this run:

```
!!! ppHtml: finished in 170.42 milliseconds, allocated 592.030 megabytes

  15,545,553,496 bytes allocated in the heap
   2,222,885,336 bytes copied during GC
     191,520,720 bytes maximum residency (14 sample(s))
       5,242,928 bytes maximum slop
             493 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      3694 colls,     0 par    1.198s   1.199s     0.0003s    0.0034s
  Gen  1        14 colls,     0 par    0.715s   0.715s     0.0510s    0.1266s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time    4.819s  (  5.332s elapsed)
  GC      time    1.912s  (  1.914s elapsed)
  EXIT    time    0.001s  (  0.004s elapsed)
  Total   time    6.733s  (  7.250s elapsed)

  Alloc rate    3,225,735,117 bytes per MUT second

  Productivity  71.6% of total user, 73.5% of total elapsed
```

| | Baseline | Patched | Difference | Improvement |
|-|----------|---------|------------|-------------|
 | HTML Time | 229.42 | 170.42 | 59.0 | 26% | 
 | HTML Allocations | 1087.125 | 592.03 | 495.095 | 46% | 
 | Total Allocations | 16064.0 | 15545.0 | 519.0 | 3% | 
 | Max Residency | 191.0 | 191.0 | 0.0 | 0.0% | 
 | Total Memory | 493.0 | 493.0 | 0.0 | 0.0% | 
 | Total Time | 6.762 | 6.733 | 2.8999e-2 | 0.429% | 

That's a pretty great improvement!

I'm surprised to see that total allocations, max residency, and total memory are unchaged from baseline, despite 46% fewer allocations. I guess the streaming `[Char]` representation has some advantages.