### PR TITLE
Add a flag "threaded" for building haddock with the threaded RTS

### DIFF
--- a/haddock.cabal
+++ b/haddock.cabal
@@ -60,11 +60,18 @@ flag in-ghc-tree
   default: False
   manual: True
 
+flag threaded
+  description: Build haddock with the threaded RTS
+  default: True
+  manual: True
+
 executable haddock
   default-language:     Haskell2010
   main-is:              Main.hs
   hs-source-dirs:       driver
-  ghc-options:          -funbox-strict-fields -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -O2 -threaded
+  ghc-options:          -funbox-strict-fields -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -O2
+  if flag(threaded)
+    ghc-options: -threaded
 
   -- haddock typically only supports a single GHC major version
   build-depends:


### PR DESCRIPTION
GHC isn't guaranteed to have a threaded RTS. There should be a way to build it with the vanilla one.