### PR TITLE
Allow tree-diff 0.3

### DIFF
--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -117,7 +117,7 @@ test-suite fixtures
     , directory             ^>= 1.3.0.2
     , filepath              ^>= 1.4.1.2
     , optparse-applicative  ^>= 0.15
-    , tree-diff             ^>= 0.2
+    , tree-diff             ^>= 0.2 || ^>= 0.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
Builds fine and all tests pass. The breaking change doesn't seem to affect us.