### PR TITLE
raise `optparse-applicative` upper bound

### DIFF
--- a/haddock-library/haddock-library.cabal
+++ b/haddock-library/haddock-library.cabal
@@ -116,7 +116,7 @@ test-suite fixtures
     , base-compat           ^>= 0.12.0
     , directory             ^>= 1.3.0.2
     , filepath              ^>= 1.4.1.2
-    , optparse-applicative  ^>= 0.15
+    , optparse-applicative  >= 0.15
     , tree-diff             ^>= 0.2 || ^>= 0.3
 
 source-repository head


### PR DESCRIPTION
Can we raise the upper bound on `optparse-applicative`?

The test suite produces the same error with `optparse-applicative` 0.15 and 0.17:
```
Error: cabal: Tests failed for test:hypsrc-test from haddock-2.27.0.
```
The other tests pass with both 0.15 and 0.17.

If `optparse-applicative-0.17` is allowed, I think it will be easier to use `haddock-library` with Nix.
`optparse-applicative` is on 0.17 in `nixpkgs-unstable`: https://search.nixos.org/packages?channel=unstable&show=haskellPackages.optparse-applicative&from=0&size=50&sort=relevance&type=packages&query=optparse-applicative Using the alternative `optparse-applicative_0_15_1_0` may have other issues.