### PR TITLE
testsuite: Print haddock stdout/stderr on failure

### DIFF
--- a/haddock-test/src/Test/Haddock.hs
+++ b/haddock-test/src/Test/Haddock.hs
@@ -94,7 +94,9 @@ runHaddock cfg@(Config { .. }) = do
                     , pcStdErr = Just haddockStdOut
                     }
 
-        let msg = "Failed to run Haddock on test package '" ++ tpkgName tpkg ++ "'"
+        let msg = do
+              err <- readFile cfgHaddockStdOut
+              return $ unlines [err, "Failed to run Haddock on test package '" ++ tpkgName tpkg ++ "'"]
         succeeded <- waitForSuccess msg stdout =<< runProcess' cfgHaddockPath pc
         unless succeeded $ removeDirectoryRecursive (outDir cfgDirConfig tpkg)
 

--- a/haddock-test/src/Test/Haddock/Config.hs
+++ b/haddock-test/src/Test/Haddock/Config.hs
@@ -236,13 +236,13 @@ printVersions env haddockPath = do
         { pcEnv = Just env
         , pcArgs = ["--version"]
         }
-    void $ waitForSuccess "Failed to run `haddock --version`" stderr handleHaddock
+    void $ waitForSuccess (return "Failed to run `haddock --version`") stderr handleHaddock
 
     handleGhc <- runProcess' haddockPath $ processConfig
         { pcEnv = Just env
         , pcArgs = ["--ghc-version"]
         }
-    void $ waitForSuccess "Failed to run `haddock --ghc-version`" stderr handleGhc
+    void $ waitForSuccess (return "Failed to run `haddock --ghc-version`") stderr handleGhc
 
 
 baseDependencies :: FilePath -> IO [String]

--- a/haddock-test/src/Test/Haddock/Process.hs
+++ b/haddock-test/src/Test/Haddock/Process.hs
@@ -42,8 +42,8 @@ runProcess' path (ProcessConfig { .. }) = runProcess
 
 -- | Wait for a process to finish running. If it ends up failing, print out the
 -- error message.
-waitForSuccess :: String -> Handle -> ProcessHandle -> IO Bool
+waitForSuccess :: IO String -> Handle -> ProcessHandle -> IO Bool
 waitForSuccess msg out handle = do
     succeeded <- fmap (== ExitSuccess) $ waitForProcess handle
-    unless succeeded $ hPutStrLn out msg
+    unless succeeded $ msg >>= hPutStrLn out
     pure succeeded


### PR DESCRIPTION
This greatly helps when there are problems running haddock tests on GHC's CI because otherwise we get the very unhelpful error message:

```
Failed to run Haddock on test package ''
```

Now instead we also get the actual problem in the log:

```
haddock: internal error: /private/var/lib/gitlab-runner/builds/7KQsmDei/0/ghc/ghc/_build/install/lib/ghc-9.7.20230404/lib/../../../share/doc/ghc-9.7.20230404/html/libraries/array-0.5.5.0-inplace/array-0.5.5.0-inplace.conf.haddock: withBinaryFile: does not exist (No such file or directory)
```