### PR TITLE
MathJax 3 support

### DIFF
--- a/doc/invoking.rst
+++ b/doc/invoking.rst
@@ -130,9 +130,15 @@ The following options are available:
 
 .. option:: --mathjax
 
-    Specify a custom URL for a mathjax-compatible JS script. By default,
-    this is set to `MathJax
-    <https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML>`_.
+    Specify a custom URL for a MathJax-compatible JS script. By default, if the MathJax version
+    (see `--mathjax-version`) is 2, `MathJax 2
+    <https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML>`_
+    is used. For version 3, `MathJax 3
+    <https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js>`_ is used.
+
+.. option:: --mathjax-version=<version>
+
+    Specify the version of MathJax. Valid versions are 2 and 3. By default, this is set to 2.
 
 .. option:: --latex
 

--- a/haddock-api/src/Haddock.hs
+++ b/haddock-api/src/Haddock.hs
@@ -329,6 +329,7 @@ render log' dflags unit_state flags sinceQual qual ifaces packages extSrcMap = d
     opt_latex_style      = optLaTeXStyle     flags
     opt_source_css       = optSourceCssFile  flags
     opt_mathjax          = optMathjax        flags
+    opt_mathjax_version  = optMathjaxVersion flags
     dflags'
       | unicode          = gopt_set dflags Opt_PrintUnicodeSyntax
       | otherwise        = dflags
@@ -440,7 +441,7 @@ render log' dflags unit_state flags sinceQual qual ifaces packages extSrcMap = d
     withTiming logger "ppHtmlIndex" (const ()) $ do
       _ <- {-# SCC ppHtmlIndex #-}
            ppHtmlIndex odir title pkgStr
-                  themes opt_mathjax opt_contents_url sourceUrls' opt_wiki_urls
+                  themes opt_mathjax opt_mathjax_version opt_contents_url sourceUrls' opt_wiki_urls
                   (concatMap piInstalledInterfaces allVisiblePackages) pretty
       return ()
 
@@ -450,7 +451,7 @@ render log' dflags unit_state flags sinceQual qual ifaces packages extSrcMap = d
   when (Flag_GenContents `elem` flags) $ do
     _ <- {-# SCC ppHtmlContents #-}
          ppHtmlContents logger unit_state odir title pkgStr
-                   themes opt_mathjax opt_index_url sourceUrls' opt_wiki_urls
+                   themes opt_mathjax opt_mathjax_version opt_index_url sourceUrls' opt_wiki_urls
                    allVisiblePackages True prologue pretty
                    sincePkg (makeContentsQual qual)
     return ()
@@ -469,7 +470,7 @@ render log' dflags unit_state flags sinceQual qual ifaces packages extSrcMap = d
     _ <- {-# SCC ppHtml #-}
          ppHtml logger unit_state title pkgStr visibleIfaces reexportedIfaces odir
                 prologue
-                themes opt_mathjax sourceUrls' opt_wiki_urls opt_base_url
+                themes opt_mathjax opt_mathjax_version sourceUrls' opt_wiki_urls opt_base_url
                 opt_contents_url opt_index_url unicode sincePkg packageInfo
                 qual pretty withQuickjump
     return ()

--- a/haddock-api/src/Haddock/Options.hs
+++ b/haddock-api/src/Haddock/Options.hs
@@ -31,6 +31,7 @@ module Haddock.Options (
   optShowInterfaceFile,
   optLaTeXStyle,
   optMathjax,
+  optMathjaxVersion,
   qualification,
   sinceQualification,
   verbosity,
@@ -83,6 +84,7 @@ data Flag
   | Flag_HyperlinkedSource
   | Flag_SourceCss String
   | Flag_Mathjax String
+  | Flag_MathjaxVersion Int
   | Flag_Help
   | Flag_Verbosity String
   | Flag_Version
@@ -139,7 +141,8 @@ options backwardsCompat =
       "output in HTML (XHTML 1.0)",
     Option []  ["latex"]  (NoArg Flag_LaTeX) "use experimental LaTeX rendering",
     Option []  ["latex-style"]  (ReqArg Flag_LaTeXStyle "FILE") "provide your own LaTeX style in FILE",
-    Option []  ["mathjax"]  (ReqArg Flag_Mathjax "URL") "URL FOR mathjax",
+    Option []  ["mathjax"]  (ReqArg Flag_Mathjax "URL") "URL for MathJax",
+    Option []  ["mathjax-version"] (ReqArg (Flag_MathjaxVersion . read) "VERSION") "MathJax VERSION",
     Option ['U'] ["use-unicode"] (NoArg Flag_UseUnicode) "use Unicode in HTML output",
     Option []  ["hoogle"]     (NoArg Flag_Hoogle)
       "output for Hoogle; you may want --package-name and --package-version too",
@@ -320,6 +323,9 @@ optLaTeXStyle flags = optLast [ str | Flag_LaTeXStyle str <- flags ]
 
 optMathjax :: [Flag] -> Maybe String
 optMathjax flags = optLast [ str | Flag_Mathjax str <- flags ]
+
+optMathjaxVersion :: [Flag] -> Maybe Int
+optMathjaxVersion flags = optLast [ ver | Flag_MathjaxVersion ver <- flags ]
 
 optParCount :: [Flag] -> Maybe (Maybe Int)
 optParCount flags = optLast [ n | Flag_ParCount n <- flags ]


### PR DESCRIPTION
Addressed issue #1602.

A new option, `--mathjax-version=VERSION` was added. This allows the user to specify what major MathJax version they want to use. This information can be used to choose the correct file (from the Cloudflare defaults), and to initialize the library correctly (2 and 3 have different configuration methods), even if the user provides their own files.

This is my first PR in this project, so please tell me if my code may break anything and how it can be improved. The HTML tests don't pass, but I tested that that was already the case in the commit before mine.