### PR TITLE
 Expand HsDo before typechecking using HsExpansion

### DIFF
--- a/hypsrc-test/ref/src/Classes.html
+++ b/hypsrc-test/ref/src/Classes.html
@@ -195,7 +195,7 @@
 	  >bar :: Int -&gt; Int
 </span
 	  ><a href="Classes.html#bar"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >bar</span
 	    ></a
 	  ></span
@@ -227,7 +227,7 @@ forall a. a -&gt; a
 	  >baz :: Int -&gt; (Int, Int)
 </span
 	  ><a href="Classes.html#baz"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >baz</span
 	    ></a
 	  ></span
@@ -328,7 +328,7 @@ forall a. a -&gt; a
 	  >bar :: [a] -&gt; Int
 </span
 	  ><a href="Classes.html#bar"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >bar</span
 	    ></a
 	  ></span
@@ -361,7 +361,7 @@ forall (t :: * -&gt; *) a. Foldable t =&gt; t a -&gt; Int
 	  >baz :: Int -&gt; ([a], [a])
 </span
 	  ><a href="Classes.html#baz"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >baz</span
 	    ></a
 	  ></span
@@ -801,7 +801,7 @@ forall a. Foo a =&gt; a -&gt; Int
 	  >norf :: [Int] -&gt; Int
 </span
 	  ><a href="Classes.html#norf"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >norf</span
 	    ></a
 	  ></span
@@ -874,7 +874,7 @@ forall (t :: * -&gt; *) a. (Foldable t, Num a) =&gt; t a -&gt; a
 	  >quux :: ([a], [a]) -&gt; [a]
 </span
 	  ><a href="Classes.html#quux"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >quux</span
 	    ></a
 	  ></span
@@ -1122,7 +1122,7 @@ forall a. [a] -&gt; [a] -&gt; [a]
 	  >plugh :: forall a b. Either a a -&gt; Either b b -&gt; Either (a -&gt; b) (b -&gt; a)
 </span
 	  ><a href="Classes.html#plugh"
-	  ><span class="hs-identifier hs-var hs-var hs-var hs-var"
+	  ><span class="hs-identifier hs-var hs-var hs-var"
 	    >plugh</span
 	    ></a
 	  ></span


### PR DESCRIPTION
Part of fixing #18324. https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10140
