### PR TITLE
Add grey background to inline code

### DIFF
--- a/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
+++ b/haddock-api/resources/html/Linuwial.std-theme/linuwial.css
@@ -385,6 +385,12 @@ summary {
   outline: none;
 }
 
+code {
+  border-radius: 3px;
+  padding: 0 0.125em;
+  background-color: #ececec
+}
+
 pre {
   padding: 0.5rem 1rem;
   margin: 1em 0 0 0;


### PR DESCRIPTION
In line with what other programming languages show, monospaced text will now have a slightly grey background:

![image](https://github.com/haskell/haddock/assets/9791461/9c0f4547-8105-4997-ae5b-0482ccdef987)

as without it, specially non-linked monospaced words were very difficult to spot:

![image](https://github.com/haskell/haddock/assets/9791461/78f7e2be-9e39-4a55-9982-ae5f457a8f4a)

This follows the same style as [Rust does](https://doc.rust-lang.org/std/), which in my opinion looks very readable 

![image](https://github.com/haskell/haddock/assets/9791461/49c1dffb-3c25-4098-a58d-21014a78ef47)

-------------

This is probably a matter of preference and esthetics so I think it would be perfectly understandable if the PR is not accepted.

